### PR TITLE
fix: use local hook for ty since no official pre-commit hook exists yet

### DIFF
--- a/project/.pre-commit-config.yaml.jinja
+++ b/project/.pre-commit-config.yaml.jinja
@@ -23,10 +23,14 @@ repos:
     hooks:
       - id: uv-lock
 
-  - repo: https://github.com/astral-sh/ty
-    rev: ""  # prek autoupdate will fill this
+  - repo: local
     hooks:
       - id: ty
+        name: ty type checker
+        entry: uv run ty check
+        language: system
+        types: [python]
+        pass_filenames: false
 
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: ""  # prek autoupdate will fill this


### PR DESCRIPTION
## TL;DR

Use a local hook for ty type checker since there's no official pre-commit hook yet.

## What changed?

- Replaced `https://github.com/astral-sh/ty` repo hook with a local hook
- The local hook runs `uv run ty check` which uses ty from the project's dependencies

## Why?

The ty project doesn't have a `.pre-commit-hooks.yaml` file yet (see [astral-sh/ty#269](https://github.com/astral-sh/ty/issues/269)). Using the repo directly causes prek/pre-commit to fail with "failed to read manifest".

The local hook approach works because:
1. ty is already a dependency in the generated project
2. `uv run ty check` runs ty from the project's venv
3. No external repo needed