### PR TITLE
feat: remove hardcoded upstream references and use template variables

### DIFF
--- a/project/.github/ISSUE_TEMPLATE/1-bug.md.jinja
+++ b/project/.github/ISSUE_TEMPLATE/1-bug.md.jinja
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a bug report to help us improve.
 title: "bug: "
 labels: unconfirmed
-assignees: [pawamoy]
+assignees: [{{ author_username }}]
 ---
 
 ### Description of the bug

--- a/project/.github/ISSUE_TEMPLATE/2-feature.md.jinja
+++ b/project/.github/ISSUE_TEMPLATE/2-feature.md.jinja
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project.
 title: "feature: "
 labels: feature
-assignees: pawamoy
+assignees: [{{ author_username }}]
 ---
 
 ### Is your feature request related to a problem? Please describe.

--- a/project/.github/ISSUE_TEMPLATE/3-docs.md.jinja
+++ b/project/.github/ISSUE_TEMPLATE/3-docs.md.jinja
@@ -3,7 +3,7 @@ name: Documentation update
 about: Point at unclear, missing or outdated documentation.
 title: "docs: "
 labels: docs
-assignees: pawamoy
+assignees: [{{ author_username }}]
 ---
 
 ### Is something unclear, missing or outdated in our documentation?

--- a/project/.github/ISSUE_TEMPLATE/4-change.md.jinja
+++ b/project/.github/ISSUE_TEMPLATE/4-change.md.jinja
@@ -2,7 +2,7 @@
 name: Change request
 about: Suggest any other kind of change for this project.
 title: "change: "
-assignees: pawamoy
+assignees: [{{ author_username }}]
 ---
 
 ### Is your change request related to a problem? Please describe.

--- a/project/CONTRIBUTING.md.jinja
+++ b/project/CONTRIBUTING.md.jinja
@@ -37,7 +37,7 @@ Run `make help` to see all the available actions!
 The entry-point to run commands and tasks is the `make` Python script, located in the `scripts` directory. Try running `make` to show the available commands and tasks. The *commands* do not need the Python dependencies to be installed,
 while the *tasks* do. The cross-platform tasks are written in Python, thanks to [duty](https://github.com/pawamoy/duty).
 
-If you work in VSCode, we provide [an action to configure VSCode](https://pawamoy.github.io/copier-uv/work/#vscode-setup) for the project.
+If you work in VSCode, we provide [an action to configure VSCode](https://ichoosetoaccept.github.io/copier-uv-bleeding/work/#vscode-setup) for the project.
 
 ## Development
 

--- a/project/scripts/gen_credits.py.jinja
+++ b/project/scripts/gen_credits.py.jinja
@@ -126,7 +126,7 @@ def _render_credits() -> str:
         "project_name": project_name,
         "prod_dependencies": sorted(prod_dependencies.values(), key=lambda dep: str(dep["name"]).lower()),
         "dev_dependencies": sorted(dev_dependencies.values(), key=lambda dep: str(dep["name"]).lower()),
-        "more_credits": "{% if author_username == "pawamoy" %}http://pawamoy.github.io/credits/{% endif %}",
+        "more_credits": "",
     }
     template_text = dedent(
         """{% raw %}
@@ -136,7 +136,7 @@ def _render_credits() -> str:
 
         [Python](https://www.python.org/) |
         [uv](https://github.com/astral-sh/uv) |
-        [copier-uv](https://github.com/pawamoy/copier-uv)
+        [copier-uv](https://github.com/ichoosetoaccept/copier-uv-bleeding)
 
         {% macro dep_line(dep) -%}
         [{{ dep.name }}](https://pypi.org/project/{{ dep.name }}/) | {{ dep.summary }} | {{ ("`" ~ dep.spec|sort(reverse=True)|join(", ") ~ "`") if dep.spec else "" }} | `{{ dep.version }}` | {{ dep.license }}


### PR DESCRIPTION
### TL;DR

Remove hardcoded upstream references and use template variables for proper fork support

### What changed?

**GitHub Issue Templates:**
- Updated all issue templates (`1-bug.md`, `2-feature.md`, `3-docs.md`, `4-change.md`) to use `{{ author_username }}` instead of hardcoded "pawamoy"
- Now issues will be assigned to the actual project maintainer who scaffolds the project

**Documentation Links:**
- Updated CONTRIBUTING.md VSCode setup link to point to the fork's documentation
- Changed from `pawamoy.github.io/copier-uv` to `ichoosetoaccept.github.io/copier-uv-bleeding`
- Kept duty link pointing to original repository (still maintained by pawamoy)

**Credits Generation:**
- Removed pawamoy-specific "more_credits" conditional in gen_credits.py
- Updated copier-uv reference to point to the fork repository
- Cleaned up hardcoded upstream references

### Why make this change?

This makes the template properly forkable by:
- Allowing users to generate projects with their own GitHub username in issue templates
- Removing hardcoded references that would confuse users of the fork
- Maintaining proper attribution while making the template independent

### Testing

- Verified template generation with `author_username="testuser"` correctly populates issue templates
- All conditional features (like sponsors workflow) remain properly scoped to original author
- No breaking changes to template functionality
