### PR TITLE
docs: update template documentation to reference fork instead of upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+---
+
+**Note:** This is a fork of [pawamoy/copier-uv](https://github.com/pawamoy/copier-uv). 
+See the original repository for historical changes before version 2.0.0.
+
+---
+
 <!-- insertion marker -->
 ## [1.11.2](https://github.com/pawamoy/copier-uv/releases/tag/1.11.2) - 2025-11-20
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ uv tool install copier --with copier-templates-extensions
 Then you can clone the repository, enter it and set it up with:
 
 ```bash
-git clone https://github.com/pawamoy/copier-uv
-cd copier-uv
+git clone https://github.com/ichoosetoaccept/copier-uv-bleeding
+cd copier-uv-bleeding
 make setup
 ```
 

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -3,19 +3,19 @@
 To generate a project, run the following command:
 
 ```bash
-copier copy --trust "https://github.com/pawamoy/copier-uv.git" /path/to/your/new/project
+copier copy --trust "https://github.com/ichoosetoaccept/copier-uv-bleeding.git" /path/to/your/new/project
 ```
 
 Or with a shorter command:
 
 ```bash
-copier copy --trust "gh:pawamoy/copier-uv" /path/to/your/new/project
+copier copy --trust "gh:ichoosetoaccept/copier-uv-bleeding" /path/to/your/new/project
 ```
 
 You can even generate a project without installing Copier, using [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uvx --with copier-templates-extensions copier copy --trust "gh:pawamoy/copier-uv" /path/to/your/new/project
+uvx --with copier-templates-extensions copier copy --trust "gh:ichoosetoaccept/copier-uv-bleeding" /path/to/your/new/project
 ```
 
 ## Questions

--- a/docs/update.md
+++ b/docs/update.md
@@ -36,13 +36,13 @@ And the file looks like this:
 ```yaml
 # Changes here will be overwritten by Copier
 _commit: 0.1.10
-_src_path: gh:pawamoy/copier-uv
-author_email: dev@pawamoy.fr
-author_fullname: "Timothée Mazzucotelli"
-author_username: pawamoy
+_src_path: gh:ichoosetoaccept/copier-uv-bleeding
+author_email: ismar@gmail.com
+author_fullname: Ismar Iljazovic
+author_username: ichoosetoaccept
 copyright_date: '2020'
-copyright_holder: "Timothée Mazzucotelli"
-copyright_holder_email: dev@pawamoy.fr
+copyright_holder: Ismar Iljazovic
+copyright_holder_email: ismar@gmail.com
 copyright_license: ISC License
 project_description: Automatic documentation from sources, for MkDocs.
 project_name: mkdocstrings

--- a/docs/work.md
+++ b/docs/work.md
@@ -623,7 +623,7 @@ The template expects that all the API be exposed at the top-level. If you expose
 add a new page for each one of these submodules.
 
 For more information about `mkdocstrings`,
-check [its documentation](https://pawamoy.github.io/mkdocstrings).
+check [its documentation](https://mkdocstrings.github.io).
 
 ### Serving
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
-site_name: "Copier UV"
-site_description: "Copier template for Python projects managed by uv"
-site_url: "https://pawamoy.github.io/copier-uv"
-repo_url: "https://github.com/pawamoy/copier-uv"
-repo_name: "pawamoy/copier-uv"
+site_name: "Copier UV Bleeding"
+site_description: "Copier template for Python projects managed by uv (bleeding edge fork)"
+site_url: "https://ichoosetoaccept.github.io/copier-uv-bleeding"
+repo_url: "https://github.com/ichoosetoaccept/copier-uv-bleeding"
+repo_name: "ichoosetoaccept/copier-uv-bleeding"
 
 validation:
   omitted_files: warn


### PR DESCRIPTION
### TL;DR

Update template documentation to reference fork instead of upstream repository

### What changed?

**Template Configuration:**
- Updated mkdocs.yml site name to "Copier UV Bleeding" 
- Changed site_url, repo_url, and repo_name to point to ichoosetoaccept/copier-uv-bleeding
- Updated site description to indicate it's a bleeding edge fork

**Contributing Guide:**
- Updated clone instructions from pawamoy/copier-uv to ichoosetoaccept/copier-uv-bleeding
- Now directs contributors to the correct fork repository

**Documentation Examples:**
- Updated all copier copy examples in docs/generate.md to use the fork
- Changed both HTTPS and GitHub shorthand (gh:) references
- Updated uvx examples as well

**Author Information:**
- Updated docs/update.md with fork maintainer details
- Changed author email to ismar@gmail.com and username to ichoosetoaccept
- Updated copyright holder information

**Documentation Links:**
- Updated mkdocstrings documentation link to generic mkdocstrings.github.io
- Kept duty link pointing to original repository (still maintained by pawamoy)

**Changelog:**
- Added fork note to distinguish from upstream history
- Clearly indicates this is a fork with reference to original repository

### Why make this change?

This ensures:
- Users generate projects using your fork, not the upstream
- Contributors know where to submit pull requests
- Documentation correctly represents the fork's identity
- Clear attribution to original while establishing independence

### Testing

- All documentation examples now reference the correct fork
- Template generation will direct users to ichoosetoaccept/copier-uv-bleeding
- Contributing instructions point to the right repository
