### PR TITLE
feat: auto-cleanup deprecated files during copier update

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -143,4 +143,5 @@ publish_to_pypi:
 _tasks:
   - "uv sync"
   - "test -d .git && uv run prek install || true"
+  - "test -f .copier-answers.yml && rm -f duties.py Makefile scripts/make scripts/make.py || true"
   - "echo '🎉 Project scaffolded successfully! Run: prek autoupdate'"

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -229,10 +229,8 @@ At this point, Copier will generate the project in the specified directory:
 ```
     create  pyproject.toml
     create  mkdocs.yml
-    create  duties.py
     create  .copier-answers.yml
     create  README.md
-    create  Makefile
     create  LICENSE
     create  CREDITS.md
     create  CONTRIBUTING.md

--- a/docs/update.md
+++ b/docs/update.md
@@ -12,6 +12,10 @@ apply a change to all your projects.
 Example: the template fixed a bug in the Makefile.
 You don't want to apply it manually to your projects.
 
+Note: When updating from older versions of this template,
+deprecated files like `duties.py`, `Makefile`, and `scripts/make`
+will be automatically removed during the update process.
+
 To update your project, go into its directory,
 and run `copier update`. Your repository must be clean
 (no modified files) when running this command.


### PR DESCRIPTION
Add automatic cleanup of deprecated files during copier updates.

**Changes:**
- Added post-generation task to remove duties.py, Makefile, and scripts/make
- Cleanup only runs on updates (when .copier-answers.yml exists)
- Updated docs/update.md to explain the cleanup behavior
- Fixed docs/generate.md to show current file structure (no deprecated files)

This ensures that projects updating from older versions of the template
automatically have deprecated files removed, keeping the project clean.