### PR TITLE
feat: update poe tags command to fetch remote tags

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -127,7 +127,7 @@ vscode = "cp -r config/vscode/.vscode ."
 
 # GitHub utilities
 releases = "gh release list --limit 10"
-tags = "git tag --sort=-version:refname"
+tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 runs = "gh run list --limit 10"
 watch = "gh run watch"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,6 @@ test = "bash tests/test_filenames.sh && bash tests/test_project.sh && .venv/bin/
 release = "test -n \"${version}\" || { echo \"error: usage: poe release version=x.y.z\" >&2; exit 1; } && git add CHANGELOG.md && git commit -m \"chore: Prepare release ${version}\" && git tag -m \"\" -a ${version} && git push && git push --tags"
 # GitHub utilities
 releases = "gh release list --limit 10"
-tags = "git tag --sort=-version:refname"
+tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 runs = "gh run list --limit 10"
 watch = "gh run watch"


### PR DESCRIPTION
- Use shell wrapper to run both git fetch --tags and git tag
- Ensures users always see the latest tags from remote