### PR TITLE
feat: update GitHub Actions to follow Astral's recommendations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
         git config --global init.defaultBranch main
         git config --global user.email "dev@ichoosetoaccept.com"
         git config --global user.name "I Choose to Accept"
-    - name: Setup Python
-      uses: actions/setup-python@v6
+    - name: Setup uv and Python
+      uses: astral-sh/setup-uv@v7.1.5
       with:
         python-version: "3.13"
-    - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+        enable-cache: true
+        cache-dependency-glob: project/pyproject.toml.jinja
     - name: Test licenses
       run: uv run --with jinja2 --with pyyaml --with reuse python tests/test_licenses.py
 
@@ -69,15 +69,10 @@ jobs:
         git config --global user.email "dev@ichoosetoaccept.com"
         git config --global user.name "I Choose to Accept"
 
-    - name: Setup Python
-      uses: actions/setup-python@v6
+    - name: Setup uv and Python
+      uses: astral-sh/setup-uv@v7.1.5
       with:
         python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-
-    - name: Setup uv
-      uses: astral-sh/setup-uv@v5
-      with:
         enable-cache: true
         cache-dependency-glob: project/pyproject.toml.jinja
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,11 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
-    - name: Setup Python
-      uses: actions/setup-python@v5
+    - name: Setup uv and Python
+      uses: astral-sh/setup-uv@v7.1.5
       with:
         python-version: "3.13"
-    - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+        enable-cache: true
     - name: Install dependencies
       run: uv sync
     - name: Semantic Release

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -53,14 +53,10 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Setup Python
-      uses: actions/setup-python@v6
+    - name: Setup uv and Python
+      uses: astral-sh/setup-uv@v7.1.5
       with:
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
-
-    - name: Setup uv
-      uses: astral-sh/setup-uv@v5
-      with:
         enable-cache: true
         cache-dependency-glob: pyproject.toml
 

--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -24,13 +24,11 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
-    - name: Setup Python
-      uses: actions/setup-python@v6
+    - name: Setup uv and Python
+      uses: astral-sh/setup-uv@v7.1.5
       with:
         python-version: "3.13"
-
-    - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+        enable-cache: true
 
     - name: Install dependencies
       run: uv sync --group maintain

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "copier-uv-bleeding"
-version = "2.3.0"
+version = "2.5.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Update GitHub Actions workflows to use Astral's latest recommendations:

- Upgrade from setup-uv@v5 to setup-uv@v7.1.5 (latest)
- Consolidate Python setup into setup-uv action
- Remove redundant setup-python steps
- Enable caching in release workflow
- Update both template and generated project workflows