### PR TITLE
fix: always enable build-system for semantic-release

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -1,12 +1,6 @@
-{%- if publish_to_pypi %}
 [build-system]
 requires = ["uv_build"]
 build-backend = "uv_build"
-{%- else %}
-# [build-system]
-# requires = ["uv_build"]
-# build-backend = "uv_build"
-{%- endif %}
 
 [project]
 name = "{{ python_package_distribution_name }}"


### PR DESCRIPTION
Fix build-system configuration to always enable uv_build.

Semantic-release needs to build packages for GitHub releases
even when not publishing to PyPI. Previously, the build-system
was only enabled when publish_to_pypi was true.

Changes:
- Remove conditional build-system logic
- Always enable uv_build backend
- Ensures semantic-release works for all projects