### PR TITLE
feat: use uv run semantic-release in generated projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: ci
 
-on:
+"on":
   push:
+    branches:
+      - main
   pull_request:
     branches:
     - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: release
 
-on:
+"on":
   push:
     branches:
       - main

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -1,6 +1,6 @@
 name: ci
 
-on:
+"on":
   push:
     branches:
     - main

--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -1,6 +1,6 @@
 name: release
 
-on:
+"on":
   push:
     branches:
       - main
@@ -33,32 +33,44 @@ jobs:
     - name: Install dependencies
       run: uv sync --group maintain
 
-    - name: Python Semantic Release
-      id: release
-      uses: python-semantic-release/python-semantic-release@v9
-      with:
-        github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+    - name: Semantic Release
+      env:
+        GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+      run: uv run semantic-release version --changelog --push --tag --vcs-release
 
 {%- if publish_to_pypi %}
 
+    - name: Check if release artifacts exist
+      id: dist
+      shell: bash
+      run: |
+        if compgen -G "dist/*" > /dev/null; then
+          echo "has_dist=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_dist=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Publish to PyPI
-      if: {% raw %}steps.release.outputs.released == 'true' && secrets.PYPI_TOKEN != ''{% endraw %}
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: {% raw %}${{ secrets.PYPI_TOKEN }}{% endraw %}
+      if: {% raw %}steps.dist.outputs.has_dist == 'true'{% endraw %}
+      env:
+        PYPI_TOKEN: {% raw %}${{ secrets.PYPI_TOKEN }}{% endraw %}
+      run: |
+        if [ -n "$PYPI_TOKEN" ]; then
+          uv publish --token "$PYPI_TOKEN"
+        else
+          echo "PYPI_TOKEN is not set; skipping PyPI publish."
+        fi
 {%- else %}
 
     # Uncomment to publish to PyPI:
     # - name: Publish to PyPI
-    #   if: {% raw %}${{ steps.release.outputs.released == 'true' && secrets.PYPI_TOKEN != '' }}{% endraw %}
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     password: {% raw %}${{ secrets.PYPI_TOKEN }}{% endraw %}
+    #   if: {% raw %}secrets.PYPI_TOKEN != ''{% endraw %}
+    #   env:
+    #     PYPI_TOKEN: {% raw %}${{ secrets.PYPI_TOKEN }}{% endraw %}
+    #   run: |
+    #     if [ -n "$PYPI_TOKEN" ]; then
+    #       uv publish --token $PYPI_TOKEN
+    #     fi
 {%- endif %}
 
-    - name: Publish to GitHub Releases
-      if: {% raw %}steps.release.outputs.released == 'true'{% endraw %}
-      uses: python-semantic-release/publish-action@v9
-      with:
-        github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        tag: {% raw %}${{ steps.release.outputs.tag }}{% endraw %}
+    

--- a/tests/assert_generated_project_release_ci.sh
+++ b/tests/assert_generated_project_release_ci.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -eu
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+[ -f pyproject.toml ] || fail "pyproject.toml not found"
+[ -f .github/workflows/ci.yml ] || fail ".github/workflows/ci.yml not found"
+[ -f .github/workflows/release.yml ] || fail ".github/workflows/release.yml not found"
+
+grep -q "^\[build-system\]" pyproject.toml || fail "pyproject.toml missing [build-system]"
+
+grep -q "uses: astral-sh/setup-uv@v7" .github/workflows/ci.yml || fail "ci.yml missing setup-uv@v7"
+
+grep -q "uv run semantic-release version" .github/workflows/release.yml || fail "release.yml missing uv-run semantic-release"
+
+grep -q "Check if release artifacts exist" .github/workflows/release.yml || fail "release.yml missing dist/* gating step"
+
+grep -q "uv publish" .github/workflows/release.yml || fail "release.yml missing uv publish"
+
+echo "OK: generated CI/release assertions passed"

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -40,6 +40,10 @@ test -d tests || { echo "FAIL: tests/ directory not found"; exit 1; }
 echo "OK: Core files present"
 
 echo
+echo ">>> Checking generated CI/release configuration"
+bash "${REPO_ROOT}/tests/assert_generated_project_release_ci.sh"
+
+echo
 echo ">>> Initializing git repo (required for some tools)"
 git init .
 git add -A


### PR DESCRIPTION
Update release workflow to use uv-native approach:
- Replace python-semantic-release GitHub action with uv run
- Enables uv build with uv_build backend
- Simplifies PyPI publishing with uv publish
- Removes redundant GitHub Releases step (handled by --vcs-release)