### PR TITLE
fix: update CI to Python 3.13+ and add actionlint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.8
+    rev: v0.14.9
     hooks:
       - id: ruff
         args: [--fix]
@@ -21,6 +21,11 @@ repos:
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.9
+    hooks:
+      - id: actionlint
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.47.0

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -34,15 +34,8 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.10"
+        - "3.13"
         - "3.14"
-        include:
-        - os: ubuntu-latest
-          python-version: "3.11"
-        - os: ubuntu-latest
-          python-version: "3.12"
-        - os: ubuntu-latest
-          python-version: "3.13"
 
     runs-on: {% raw %}${{ matrix.os }}{% endraw %}
 
@@ -99,9 +92,6 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.10"
-        - "3.11"
-        - "3.12"
         - "3.13"
         - "3.14"
         - "3.15"

--- a/project/.pre-commit-config.yaml.jinja
+++ b/project/.pre-commit-config.yaml.jinja
@@ -23,6 +23,11 @@ repos:
     hooks:
       - id: uv-lock
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: ""  # prek autoupdate will fill this
+    hooks:
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: ty


### PR DESCRIPTION
## Summary
Update CI workflow template to Python 3.13+ and add actionlint pre-commit hook for GitHub Actions workflow validation.

## Changes
- **CI workflow template**: Remove Python 3.10-3.12 from matrix, keep only 3.13+ (matching template's minimum Python version)
- **actionlint hook**: Add to both template repo and generated projects to catch workflow syntax errors before commit

## Why
- Template targets Python 3.13+ but generated CI workflows were still testing 3.10-3.12
- IDE false positives on workflow YAML prompted adding proper validation via actionlint