### PR TITLE
fix: prefix poe commands with uv run in CI workflow

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -54,25 +54,25 @@ jobs:
         cache-dependency-glob: pyproject.toml
 
     - name: Install dependencies
-      run: poe setup
+      run: uv run poe setup
 
     - name: Check if the documentation builds correctly
-      run: poe docs-build
+      run: uv run poe docs-build
 
     - name: Check the code quality
-      run: poe lint
+      run: uv run poe lint
 
     - name: Check if the code is correctly typed
-      run: poe typecheck
+      run: uv run poe typecheck
 
     - name: Check for security vulnerabilities
-      run: poe security
+      run: uv run poe security
 
     - name: Check for dead code
-      run: poe deadcode
+      run: uv run poe deadcode
 
     - name: Check for breaking changes in the API
-      run: poe lint
+      run: uv run poe lint
 
     - name: Store objects inventory for tests
       uses: actions/upload-artifact@v4
@@ -129,7 +129,7 @@ jobs:
     - name: Install dependencies
       env:
         UV_RESOLUTION: {% raw %}${{ matrix.resolution }}{% endraw %}
-      run: poe setup
+      run: uv run poe setup
 
     - name: Download objects inventory
       uses: actions/download-artifact@v4
@@ -138,4 +138,4 @@ jobs:
         path: site/
 
     - name: Run the test suite
-      run: poe test
+      run: uv run poe test


### PR DESCRIPTION
## Summary
Fix CI workflow template: prefix all poe commands with `uv run` so they work in GitHub Actions.

## Problem
In CI, the workflow runs `poe setup` before any `uv sync` has happened, so `poe` (poethepoet) isn't installed yet and the command fails with "poe: command not found".

## Solution
Use `uv run poe ...` which automatically syncs dependencies and then executes poe from the installed environment.

## Local usage unchanged
You can still use `poe <command>` directly locally — this fix only affects CI.