### PR TITLE
fix: create htmlcov placeholder before docs-build in CI

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -57,7 +57,10 @@ jobs:
       run: uv run poe setup
 
     - name: Check if the documentation builds correctly
-      run: uv run poe docs-build
+      run: |
+        mkdir -p htmlcov
+        echo '<html><body>No coverage report yet</body></html>' > htmlcov/index.html
+        uv run poe docs-build
 
     - name: Check the code quality
       run: uv run poe lint


### PR DESCRIPTION
## Summary
Fix CI workflow template: create htmlcov placeholder before docs-build.

## Problem
The `mkdocs-coverage` plugin needs `htmlcov/index.html` to exist. In the CI quality job, tests haven't run yet so there's no coverage report, causing a warning that fails strict mode.

## Solution
Create a minimal `htmlcov/index.html` placeholder before running `poe docs-build` in CI.

## Verified
Tested locally - docs-build now succeeds with the placeholder.