### PR TITLE
fix: add modern lower bounds to dev deps and remove Python 3.15

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -97,7 +97,6 @@ jobs:
         python-version:
         - "3.13"
         - "3.14"
-        - "3.15"
         resolution:
         - highest
         - lowest-direct

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -50,37 +50,37 @@ Funding = "https://{{ repository_provider }}/sponsors/{{ author_username }}"
 
 [dependency-groups]
 maintain = [
-    "build",
-    "yore",
-    "python-semantic-release",
+    "build>=1.2",
+    "yore>=0.4",
+    "python-semantic-release>=10",
 ]
 ci = [
-    "ruff",
-    "pytest",
-    "pytest-cov",
-    "pytest-randomly",
-    "pytest-xdist",
-    "ty",
-    "poethepoet",
-    "bandit",
-    "vulture",
-    "pyupgrade",
+    "ruff>=0.11",
+    "pytest>=8",
+    "pytest-cov>=6",
+    "pytest-randomly>=3.15",
+    "pytest-xdist>=3.5",
+    "ty>=0.0.1a20",
+    "poethepoet>=0.32",
+    "bandit>=1.8",
+    "vulture>=2.13",
+    "pyupgrade>=3.19",
 ]
 local = [
-    "prek",
+    "prek>=0.2.20",
 ]
 docs = [
-    "markdown-callouts",
-    "markdown-exec",
-    "mkdocs",
-    "mkdocs-coverage",
-    "mkdocs-git-revision-date-localized-plugin",
-    "mkdocs-llmstxt",
-    "mkdocs-material",
-    "mkdocs-minify-plugin",
-    "mkdocs-material-extensions",
-    "mkdocs-section-index",
-    "mkdocstrings[python]",
+    "markdown-callouts>=0.4",
+    "markdown-exec>=1.10",
+    "mkdocs>=1.6",
+    "mkdocs-coverage>=1.1",
+    "mkdocs-git-revision-date-localized-plugin>=1.4",
+    "mkdocs-llmstxt>=0.4",
+    "mkdocs-material>=9.6",
+    "mkdocs-minify-plugin>=0.8",
+    "mkdocs-material-extensions>=1.3",
+    "mkdocs-section-index>=0.3.9",
+    "mkdocstrings[python]>=0.27",
     # YORE: EOL 3.10: Remove line.
     "tomli; python_version < '3.11'",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "copier-uv-bleeding"
-version = "2.5.0"
+version = "2.6.2"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
Fix CI workflow template: add modern lower bounds to dev dependencies and remove Python 3.15.

## Problem
With `lowest-direct` resolution, uv was trying to install ancient versions like `pytest==2.0.0` (from 2011) because dev dependencies had no lower bounds.

## Solution
- Add lower bounds to all dev dependencies based on recent versions (e.g., `pytest>=8`, `ruff>=0.11`)
- Remove Python 3.15 from CI matrix — too early, 3.14 just released last month

## Dependencies updated
| Package | Lower bound |
|---------|-------------|
| ruff | >=0.11 |
| pytest | >=8 |
| pytest-cov | >=6 |
| poethepoet | >=0.32 |
| bandit | >=1.8 |
| mkdocs-material | >=9.6 |
| python-semantic-release | >=10 |
| ... and more |