### PR TITLE
feat: add docs-build pre-push hook to catch doc issues before CI

### DIFF
--- a/project/.pre-commit-config.yaml.jinja
+++ b/project/.pre-commit-config.yaml.jinja
@@ -37,6 +37,13 @@ repos:
         types: [python]
         pass_filenames: false
 
+      - id: docs-build
+        name: docs build check
+        entry: bash -c 'mkdir -p htmlcov && echo "<html><body>No coverage report yet</body></html>" > htmlcov/index.html && uv run poe docs-build'
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: ""  # prek autoupdate will fill this
     hooks:

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "copier-uv-bleeding"
-version = "2.6.3"
+version = "2.6.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
Add docs-build pre-push hook to catch documentation issues before CI.

## Problem
Documentation build warnings (like broken links) weren't caught until CI ran, causing unexpected failures.

## Solution
Add a `docs-build` hook that runs on `pre-push` (not every commit) to validate docs locally before pushing.

## Implementation
- Uses `prek` (already a template dependency) — no new packages needed
- Creates htmlcov placeholder to prevent mkdocs-coverage warning
- Only runs on pre-push to avoid slowing down commits

## Tested
Verified with `prek run docs-build --hook-stage pre-push` on a generated project.