### PR TITLE
chore: remove Python 3.15 from template repo CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,8 @@ jobs:
         python-version:
         - "3.13"
         - "3.14"
-        - "3.15"
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.python-version == '3.15'}}
 
     steps:
     - name: Checkout

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "copier-uv-bleeding"
-version = "2.6.4"
+version = "2.6.5"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Too early - 3.14 just released. Matches the change we made to the
generated project's CI template.