### PR TITLE
feat: add prek improvements - builtin hooks, priority for parallel execution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,37 +1,54 @@
+minimum_prek_version: "0.2.23"
+
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+  # prek builtin hooks - no network/env needed, instant execution
+  - repo: builtin
     hooks:
       - id: trailing-whitespace
+        priority: 0
       - id: end-of-file-fixer
+        priority: 0
       - id: check-yaml
         args: [--allow-multiple-documents]
+        priority: 0
       - id: check-toml
+        priority: 0
       - id: check-added-large-files
+        priority: 0
       - id: check-merge-conflict
+        priority: 0
+      - id: check-case-conflict
+        priority: 0
+      - id: detect-private-key
+        priority: 0
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.9
     hooks:
       - id: ruff
         args: [--fix]
+        priority: 1
       - id: ruff-format
+        priority: 1
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1
     hooks:
       - id: shellcheck
+        priority: 1
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.9
     hooks:
       - id: actionlint
+        priority: 1
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.47.0
     hooks:
       - id: markdownlint
         args: [--fix, --disable, MD013, MD024, MD033, MD040, MD041, --]
+        priority: 1
 
   - repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ---
 
-**Note:** This is a fork of [pawamoy/copier-uv](https://github.com/pawamoy/copier-uv). 
+**Note:** This is a fork of [pawamoy/copier-uv](https://github.com/pawamoy/copier-uv).
 See the original repository for historical changes before version 2.0.0.
 
 ---

--- a/docs/work.md
+++ b/docs/work.md
@@ -144,6 +144,7 @@ Available tasks:
 ## Additional Commands
 
 You can run arbitrary commands with uv:
+
 - `uv run command --args`: Run commands in the virtual environment.
   Example: `uv run python` to start Python without activating the venv.
 

--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -72,5 +72,3 @@ jobs:
     #       uv publish --token $PYPI_TOKEN
     #     fi
 {%- endif %}
-
-    

--- a/project/.pre-commit-config.yaml.jinja
+++ b/project/.pre-commit-config.yaml.jinja
@@ -1,32 +1,47 @@
+minimum_prek_version: "0.2.23"
+
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: ""  # prek autoupdate will fill this
+  # prek builtin hooks - no network/env needed, instant execution
+  - repo: builtin
     hooks:
       - id: trailing-whitespace
+        priority: 0
       - id: end-of-file-fixer
+        priority: 0
       - id: check-yaml
+        priority: 0
       - id: check-toml
+        priority: 0
       - id: check-added-large-files
+        priority: 0
       - id: check-merge-conflict
+        priority: 0
+      - id: check-case-conflict
+        priority: 0
       - id: detect-private-key
+        priority: 0
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: ""  # prek autoupdate will fill this
     hooks:
       - id: ruff
         args: [--config, config/ruff.toml, --fix]
+        priority: 1
       - id: ruff-format
         args: [--config, config/ruff.toml]
+        priority: 1
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: ""  # prek autoupdate will fill this
     hooks:
       - id: uv-lock
+        priority: 1
 
   - repo: https://github.com/rhysd/actionlint
     rev: ""  # prek autoupdate will fill this
     hooks:
       - id: actionlint
+        priority: 1
 
   - repo: local
     hooks:
@@ -36,6 +51,7 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+        priority: 1
 
       - id: docs-build
         name: docs build check

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "copier-uv-bleeding"
-version = "2.6.5"
+version = "2.7.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Adds prek (pre-commit alternative) improvements to both the template's own config and the generated project config.

## Changes

### prek Features Added

- **`minimum_prek_version: "0.2.23"`** - Ensures users have a version that supports builtin hooks and priority
- **`repo: builtin`** - Uses prek's native hooks instead of cloning from `pre-commit/pre-commit-hooks`
  - No network required
  - No environment setup
  - Instant startup and execution
- **`priority`** - Enables parallel hook execution
  - `priority: 0` for fast checks (trailing-whitespace, end-of-file-fixer, check-yaml, etc.)
  - `priority: 1` for linters (ruff, actionlint, etc.)
- **New hooks**: `check-case-conflict`, `detect-private-key`

### Files Modified

- `.pre-commit-config.yaml` - Template's own pre-commit config
- `project/.pre-commit-config.yaml.jinja` - Generated project pre-commit config

## Benefits

- Faster hook execution (no network/env setup for builtin hooks)
- Parallel execution of hooks with same priority
- Better security checks (detect-private-key, check-case-conflict)