### PR TITLE
feat: add delete-branch-on-merge to copier post-generation tasks

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -144,4 +144,5 @@ _tasks:
   - "uv sync"
   - "test -d .git && uv run prek install || true"
   - "test -f .copier-answers.yml && rm -f duties.py Makefile scripts/make scripts/make.py || true"
+  - "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge && echo '✓ Enabled delete-branch-on-merge' || true"
   - "echo '🎉 Project scaffolded successfully! Run: prek autoupdate'"


### PR DESCRIPTION
## Summary

Automatically enables `delete-branch-on-merge` on GitHub repos when running copier post-generation tasks.

## Changes

Added a task to `copier.yml` that:
1. Checks if `gh` CLI is available
2. Checks if the current directory is a GitHub repo
3. If both conditions are met, enables `--delete-branch-on-merge`

This ensures that when PRs are merged, the head branch is automatically deleted on GitHub, keeping the remote clean.

## Why

GitHub doesn't have an organization-level default for this setting, so it needs to be enabled per-repo. This automates that step during project scaffolding.