### PR TITLE
feat: make polar sponsorship optional with use_polar setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,41 @@ env:
 jobs:
 
   test-filenames:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Test file names
       run: bash tests/test_filenames.sh
 
+  test-funding:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+    - name: Configure Git
+      run: |
+        git config --global init.defaultBranch main
+        git config --global user.email "dev@ichoosetoaccept.com"
+        git config --global user.name "I Choose to Accept"
+    - name: Setup uv and Python
+      uses: astral-sh/setup-uv@v7.1.5
+      with:
+        python-version: "3.13"
+        enable-cache: true
+        cache-dependency-glob: project/pyproject.toml.jinja
+    - name: Install Copier
+      env:
+        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+      run: uv tool install copier --with copier-templates-extensions
+    - name: Test FUNDING.yml generation
+      run: bash tests/test_funding.sh
+
   test-licenses:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -54,7 +80,7 @@ jobs:
         - "3.13"
         - "3.14"
 
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     concurrency: release
     steps:
     - name: Checkout

--- a/copier.yml
+++ b/copier.yml
@@ -148,6 +148,11 @@ publish_to_pypi:
   help: Will you publish this package to PyPI?
   default: true
 
+use_polar:
+  type: bool
+  help: Enable Polar.sh sponsorship? (requires account at polar.sh)
+  default: false
+
 # TASKS --------------------------------
 _tasks:
   - "uv sync"

--- a/project/.github/FUNDING.yml.jinja
+++ b/project/.github/FUNDING.yml.jinja
@@ -1,2 +1,4 @@
 github: {{ author_username }}
+{%- if use_polar %}
 polar: {{ author_username }}
+{%- endif %}

--- a/tests/test_funding.sh
+++ b/tests/test_funding.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -eu
+
+# Test FUNDING.yml generation with and without polar
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+test_without_polar() {
+    local test_dir="/tmp/funding-test-no-polar-$$"
+    trap "rm -rf ${test_dir}" RETURN
+
+    echo ">>> Testing FUNDING.yml without polar (use_polar=false)"
+    copier copy -f --trust -r HEAD "${REPO_ROOT}" "${test_dir}" \
+        -d project_name="Test No Polar" \
+        -d project_description="Testing" \
+        -d author_username="testuser" \
+        -d use_polar=false \
+        >/dev/null 2>&1
+
+    local funding_file="${test_dir}/.github/FUNDING.yml"
+    [ -f "${funding_file}" ] || fail "FUNDING.yml not found"
+
+    grep -q "^github: testuser$" "${funding_file}" || fail "FUNDING.yml missing github sponsor"
+    if grep -q "^polar:" "${funding_file}"; then
+        fail "FUNDING.yml should NOT contain polar when use_polar=false"
+    fi
+
+    echo "OK: FUNDING.yml correct without polar"
+}
+
+test_with_polar() {
+    local test_dir="/tmp/funding-test-with-polar-$$"
+    trap "rm -rf ${test_dir}" RETURN
+
+    echo ">>> Testing FUNDING.yml with polar (use_polar=true)"
+    copier copy -f --trust -r HEAD "${REPO_ROOT}" "${test_dir}" \
+        -d project_name="Test With Polar" \
+        -d project_description="Testing" \
+        -d author_username="testuser" \
+        -d use_polar=true \
+        >/dev/null 2>&1
+
+    local funding_file="${test_dir}/.github/FUNDING.yml"
+    [ -f "${funding_file}" ] || fail "FUNDING.yml not found"
+
+    grep -q "^github: testuser$" "${funding_file}" || fail "FUNDING.yml missing github sponsor"
+    grep -q "^polar: testuser$" "${funding_file}" || fail "FUNDING.yml missing polar when use_polar=true"
+
+    echo "OK: FUNDING.yml correct with polar"
+}
+
+test_without_polar
+test_with_polar
+
+echo
+echo "==========================================="
+echo "      FUNDING.YML TESTS PASSED ✓"
+echo "==========================================="


### PR DESCRIPTION
## Summary

Make Polar.sh sponsorship optional in generated projects. Previously, all projects got a `polar:` entry in `.github/FUNDING.yml` which showed a broken sponsor link unless the user had Polar configured.

## Changes

- **Add `use_polar` copier question** (default: `false`) - Users must explicitly opt-in
- **Make FUNDING.yml.jinja conditional** - Only includes `polar:` line when `use_polar=true`
- **Add `tests/test_funding.sh`** - Verifies FUNDING.yml is generated correctly for both cases
- **Update all CI jobs to Blacksmith runners** - Consistent with other projects in the org

## Testing

- `bash tests/test_funding.sh` passes locally
- Smoke test continues to pass