### PR TITLE
chore: remove Gitter references (service is deprecated)

### DIFF
--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -5,8 +5,6 @@
 {% endif -%}
 [![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://{{ repository_namespace }}.{{ repository_provider[:-4] }}.io/{{ repository_name }}/)
 [![pypi version](https://img.shields.io/pypi/v/{{ python_package_distribution_name }}.svg)](https://pypi.org/project/{{ python_package_distribution_name }}/)
-[![gitter](https://img.shields.io/badge/matrix-chat-4DB798.svg?style=flat)](https://app.gitter.im/#/room/#{{ repository_name }}:gitter.im)
-
 {{ project_description }}
 
 ## Installation

--- a/project/mkdocs.yml.jinja
+++ b/project/mkdocs.yml.jinja
@@ -143,8 +143,6 @@ extra:
   social:
   - icon: fontawesome/brands/{{ repository_provider.rsplit('.', 1)[0] }}
     link: https://{{ repository_provider }}/{{ author_username }}
-  - icon: fontawesome/brands/gitter
-    link: https://gitter.im/{{ repository_name }}/community
   - icon: fontawesome/brands/python
     link: https://pypi.org/project/{{ python_package_distribution_name }}/
   analytics:

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -35,7 +35,6 @@ Changelog = "https://{{ repository_namespace }}.{{ repository_provider.rsplit('.
 Repository = "https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}"
 Issues = "https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}/issues"
 Discussions = "https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}/discussions"
-Gitter = "https://gitter.im/{% if repository_namespace != author_username %}{{ repository_namespace }}/{{ repository_name }}{% else %}{{ repository_name }}/community{% endif %}"
 {%- if repository_provider == "github.com" %}
 Funding = "https://{{ repository_provider }}/sponsors/{{ author_username }}"
 {%- endif %}


### PR DESCRIPTION
### TL;DR

Removed Gitter references from project templates.

### What changed?

- Removed Gitter badge from README.md.jinja
- Removed Gitter social link from mkdocs.yml.jinja
- Removed Gitter URL from project metadata in pyproject.toml.jinja

### How to test?

1. Generate a new project using these templates
2. Verify that no Gitter references appear in the README, documentation, or package metadata

### Why make this change?

This change removes Gitter integration from the project templates because it's outdated and unnecessary.