### PR TITLE
docs: add Python 3.14+ requirement note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Copier UV (Bleeding Edge Fork)
 
+> **⚠️ Requires Python 3.14+** — This template targets the latest stable Python release only.
+
 > **This is a fork of [pawamoy/copier-uv](https://github.com/pawamoy/copier-uv).**
 > Huge thanks to [Timothée Mazzucotelli](https://github.com/pawamoy) for the excellent original template!
 


### PR DESCRIPTION
### TL;DR

Add Python 3.14+ requirement notice to README

### What changed?

Added a warning notice at the top of the README.md file that clearly indicates this template requires Python 3.14 or newer.

### How to test?

View the README.md file and verify the warning notice appears correctly with proper formatting.

### Why make this change?

To clearly communicate version requirements to users upfront, preventing confusion and failed installations when users attempt to use the template with older Python versions.