### PR TITLE
fix: release workflow should only run after CI passes

### DIFF
--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -1,9 +1,10 @@
 name: release
 
 "on":
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -14,6 +15,7 @@ permissions:
 
 jobs:
   release:
+    if: {% raw %}${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}{% endraw %}
 {%- if use_blacksmith_runners %}
     runs-on: blacksmith-4vcpu-ubuntu-2404
 {%- else %}

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ wheels = [
 
 [[package]]
 name = "copier-uv-bleeding"
-version = "2.14.0"
+version = "2.18.0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
Ensure the release workflow only runs after CI passes, preventing broken releases.

## Problem
The release workflow was triggered directly on push to main, which could result in releases being published even when CI tests fail.

## Solution
Changed the release workflow trigger from `push` to `workflow_run`, so it only runs after the CI workflow completes successfully on main.

## Changes
- **`project/.github/workflows/release.yml.jinja`**: 
  - Changed trigger from `push: branches: [main]` to `workflow_run: workflows: [ci]`
  - Added condition to only run if CI succeeded or manually dispatched