### PR TITLE
feat: improve poe tasks and fix adopt behavior for pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
-# Copier UV (Bleeding Edge Fork)
+<p align="center">
+  <img src="docs/assets/bleeding-edge-header.svg" alt="copier-uv-bleeding" width="800">
+</p>
 
-[![ci](https://github.com/detailobsessed/copier-uv-bleeding/workflows/ci/badge.svg)](https://github.com/detailobsessed/copier-uv-bleeding/actions?query=workflow%3Aci)
-[![release](https://github.com/detailobsessed/copier-uv-bleeding/workflows/release/badge.svg)](https://github.com/detailobsessed/copier-uv-bleeding/actions?query=workflow%3Arelease)
-[![GitHub Release](https://img.shields.io/github/v/release/detailobsessed/copier-uv-bleeding)](https://github.com/detailobsessed/copier-uv-bleeding/releases)
-[![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
+<p align="center">
+  <a href="https://github.com/detailobsessed/copier-uv-bleeding/actions?query=workflow%3Aci"><img src="https://github.com/detailobsessed/copier-uv-bleeding/workflows/ci/badge.svg" alt="CI"></a>
+  <a href="https://github.com/detailobsessed/copier-uv-bleeding/actions?query=workflow%3Arelease"><img src="https://github.com/detailobsessed/copier-uv-bleeding/workflows/release/badge.svg" alt="Release"></a>
+  <a href="https://github.com/detailobsessed/copier-uv-bleeding/releases"><img src="https://img.shields.io/github/v/release/detailobsessed/copier-uv-bleeding" alt="GitHub Release"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.14+-blue.svg" alt="Python 3.14+"></a>
+</p>
 
 > **⚠️ Requires Python 3.14+** — This template targets the latest stable Python release only.
 >
@@ -17,16 +21,30 @@ for Python projects managed by [uv](https://github.com/astral-sh/uv).
 
 - **[ty](https://github.com/astral-sh/ty)** instead of mypy for type checking (fast, modern, from Astral)
 - **[prek](https://github.com/prek-org/prek)** instead of pre-commit (faster, written in Rust)
-- **[poethepoet](https://github.com/nat-n/poethepoet)** task runner
-- **[bandit](https://github.com/PyCQA/bandit)** for security scanning
-- **[vulture](https://github.com/jendrikseipp/vulture)** for dead code detection
-- **Ruff UP rules** for syntax modernization (replaces pyupgrade)
+- **[poethepoet](https://github.com/nat-n/poethepoet)** task runner with pre-configured tasks
+- **Comprehensive ruff rules** - 18 rule categories including security (S), unused args (ARG), and more
+- **No standalone bandit/vulture** - ruff handles security scanning and dead code detection
 - **No version pins** - get the latest versions at scaffold time
-- **Dependabot** configured for uv and GitHub Actions
-- **[commitlint](https://commitlint.js.org/)** for commit message enforcement (Angular/Conventional format)
-- **[python-semantic-release](https://python-semantic-release.readthedocs.io/)** for automated versioning and releases
 - **[uv build backend](https://docs.astral.sh/uv/concepts/build-backend/)** - native uv build system
-- **Optional PyPI publishing** - prompted during scaffold, commented out if not needed
+
+## Scaffold Prompts
+
+When you run `copier copy`, you'll be asked:
+
+| Prompt | Description |
+| ------ | ----------- |
+| **Project name** | Name of your project |
+| **Project description** | One-line description |
+| **Project type** | `app` (script), `lib` (library), or `package` (CLI tool) |
+| **Author info** | Name, email, username (auto-detected from git) |
+| **Repository namespace** | GitHub username or organization |
+| **License** | Choose from 40+ open source licenses |
+| **Enable CI?** | GitHub Actions for testing, linting, type checking |
+| **Enable semantic-release?** | Automated versioning and changelog (requires CI) |
+| **Publish to PyPI?** | Include PyPI publishing in release workflow |
+| **Use Blacksmith runners?** | 2x faster, 75% cheaper CI runners |
+| **Enable Polar.sh?** | Sponsorship integration |
+| **Existing project?** | Skip generating scaffolding files (CLI, tests) for existing codebases |
 
 ### Recommended Reading
 
@@ -36,10 +54,9 @@ for Python projects managed by [uv](https://github.com/astral-sh/uv).
 
 - [uv](https://github.com/astral-sh/uv) setup, with pre-defined `pyproject.toml`
 - Pre-configured tools for code formatting, quality analysis and testing:
-  [ruff](https://github.com/charliermarsh/ruff),
-  [ty](https://github.com/astral-sh/ty),
-  [bandit](https://github.com/PyCQA/bandit),
-  [vulture](https://github.com/jendrikseipp/vulture)
+  [ruff](https://github.com/astral-sh/ruff) (linting, formatting, security, dead code),
+  [ty](https://github.com/astral-sh/ty) (type checking),
+  [pytest](https://github.com/pytest-dev/pytest) (testing)
 - Tests run with [pytest](https://github.com/pytest-dev/pytest) and plugins, with [coverage](https://github.com/nedbat/coveragepy) support
 - Documentation built with [MkDocs](https://github.com/mkdocs/mkdocs)
   ([Material theme](https://github.com/squidfunk/mkdocs-material)
@@ -55,4 +72,24 @@ for Python projects managed by [uv](https://github.com/astral-sh/uv).
 copier copy --trust "gh:detailobsessed/copier-uv-bleeding" /path/to/your/new/project
 ```
 
-The template automatically runs `prek autoupdate` and `uv sync` after scaffolding.
+The template automatically runs `uv sync` and `prek install` after scaffolding.
+
+## Available Tasks
+
+All projects come with pre-configured [poethepoet](https://github.com/nat-n/poethepoet) tasks:
+
+| Task | Description |
+| ---- | ----------- |
+| `poe setup` | Install dependencies with uv |
+| `poe lint` | Check code with ruff |
+| `poe format` | Format code with ruff |
+| `poe typecheck` | Type check with ty |
+| `poe check` | Run lint + typecheck |
+| `poe fix` | Auto-fix lint issues and format |
+| `poe test` | Run fast tests (skip slow) |
+| `poe test-all` | Run all tests |
+| `poe test-cov` | Run tests with coverage |
+| `poe docs` | Serve docs locally |
+| `poe prek` | Run all pre-commit hooks |
+| `poe runs` | List recent CI runs |
+| `poe watch` | Watch current CI run |

--- a/copier.yml
+++ b/copier.yml
@@ -12,10 +12,15 @@ _jinja_extensions:
 - extensions.py:GitExtension
 - extensions.py:SlugifyExtension
 - extensions.py:GitHubIDsforGiscusExtension
+# Files to skip if they already exist in the destination.
+# NOTE: pyproject.toml and .pre-commit-config.yaml are intentionally NOT here.
+# During `copier adopt`, we want these to merge with conflict markers so users
+# get template improvements (poe tasks, ruff config, hooks). During `copier update`,
+# copier performs a 3-way merge that preserves user customizations.
+# Only truly user-owned files (README, CHANGELOG, source code) should be skipped.
 _skip_if_exists:
 - CHANGELOG.md
 - README.md
-- pyproject.toml
 - "src/{{ python_package_import_name }}/__init__.py"
 - "src/{{ python_package_import_name }}/cli.py"
 - "src/{{ python_package_import_name }}/_internal/__init__.py"
@@ -28,7 +33,6 @@ _skip_if_exists:
 - "tests/test_cli.py"
 - "tests/test_api.py"
 - .gitignore
-- .pre-commit-config.yaml
 
 _exclude:
 - "{% if not use_ci %}.github/workflows/ci.yml{% endif %}"

--- a/docs/assets/bleeding-edge-header.svg
+++ b/docs/assets/bleeding-edge-header.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 200">
+  <defs>
+    <linearGradient id="bleedingGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3776ab;stop-opacity:1" />
+      <stop offset="60%" style="stop-color:#3776ab;stop-opacity:1" />
+      <stop offset="80%" style="stop-color:#dc143c;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8b0000;stop-opacity:1" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="2" result="coloredBlur"/>
+      <feMerge>
+        <feMergeNode in="coloredBlur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="200" fill="#0d1117"/>
+
+  <!-- Blade shape -->
+  <path d="M 50 100 L 700 100 L 750 85 L 700 100 L 50 100"
+        fill="none"
+        stroke="url(#bleedingGradient)"
+        stroke-width="4"
+        filter="url(#glow)"/>
+
+  <!-- Blood drops -->
+  <ellipse cx="720" cy="120" rx="8" ry="12" fill="#dc143c" opacity="0.9"/>
+  <ellipse cx="735" cy="140" rx="5" ry="8" fill="#dc143c" opacity="0.7"/>
+  <ellipse cx="745" cy="155" rx="3" ry="5" fill="#dc143c" opacity="0.5"/>
+
+  <!-- Text -->
+  <text x="400" y="90" font-family="system-ui, -apple-system, sans-serif" font-size="42" font-weight="bold" fill="#ffffff" text-anchor="middle">
+    copier-uv-bleeding
+  </text>
+  <text x="400" y="130" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="#8b949e" text-anchor="middle">
+    Python 3.14+ • uv • ruff • ty • prek • poethepoet
+  </text>
+
+  <!-- Decorative edge line -->
+  <line x1="100" y1="160" x2="700" y2="160" stroke="url(#bleedingGradient)" stroke-width="2" opacity="0.5"/>
+</svg>

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -142,6 +142,9 @@ docstring-code-line-length = 100
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --cov"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 filterwarnings = [
     "error",
     "default::EncodingWarning",
@@ -181,7 +184,8 @@ format = "ruff format src tests"
 typecheck = "ty check src tests"
 
 # Testing
-test = "pytest"
+test = "pytest -m 'not slow'"
+test-all = "pytest"
 test-cov = "pytest --cov={{ python_package_import_name }} --cov-report=term-missing --cov-report=html"
 
 # Combined tasks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pyyaml>=6.0.3",
     "reuse",
     "ruff",
+    "ty>=0.0.14",
 ]
 
 [tool.uv]
@@ -113,6 +114,8 @@ setup = "uv sync"
 # Quality
 format = "ruff format ."
 lint = "ruff check ."
+typecheck = "ty check ."
+check = ["lint", "typecheck"]
 fix = ["lint --fix", "format"]
 
 # Testing


### PR DESCRIPTION
## Summary
Improve poe tasks and fix copier adopt behavior for pyproject.toml

## Problem
1. Template project was missing `ty` dependency and `typecheck`/`check` tasks
2. Generated projects had no `test-all` task to run all tests including slow ones
3. `pyproject.toml` and `.pre-commit-config.yaml` were in `_skip_if_exists`, causing `copier adopt` to skip them entirely instead of merging with conflict markers

## Solution
- Add `ty>=0.0.14` to template dev dependencies
- Add `typecheck = "ty check ."` and `check = ["lint", "typecheck"]` tasks to template
- Add `test-all = "pytest"` to generated projects, change `test` to skip slow tests by default
- Remove `pyproject.toml` and `.pre-commit-config.yaml` from `_skip_if_exists` so adopt merges them

## Changes
- `copier.yml` - remove pyproject.toml and .pre-commit-config.yaml from _skip_if_exists
- `project/pyproject.toml.jinja` - add test-all task, make test skip slow
- `pyproject.toml` - add ty dep, typecheck and check tasks