### PR TITLE
fix: correct ty config and gate classifiers behind publish_to_pypi

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -12,6 +12,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 keywords = []
 version = "0.0.0"
+{%- if publish_to_pypi %}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -24,6 +25,7 @@ classifiers = [
     "Topic :: Utilities",
     "Typing :: Typed",
 ]
+{%- endif %}
 dependencies = [
 {%- if project_type == 'package' and use_typer %}
     "typer>=0.21",
@@ -171,8 +173,8 @@ output = "htmlcov/coverage.json"
 [tool.ty.environment]
 python-version = "3.14"
 
-[tool.ty.rules]
-ignore = ["tests/fixtures/"]
+[tool.ty.src]
+exclude = ["tests/fixtures/"]
 
 [tool.poe.tasks]
 # Setup


### PR DESCRIPTION
## Summary

Two fixes for the generated pyproject.toml template:

### 1. Fix ty configuration section
- Changed `[tool.ty.rules] ignore` to `[tool.ty.src] exclude`
- The previous config was invalid - ty uses `[tool.ty.src]` for file exclusions

### 2. Gate classifiers behind `publish_to_pypi`
- PyPI classifiers are only useful when publishing to PyPI
- Projects with `publish_to_pypi: false` no longer get unnecessary classifiers

## Testing

After merging, run `copier update` on a project with `publish_to_pypi: false` to verify:
- Classifiers section is removed from pyproject.toml
- ty config uses correct `[tool.ty.src] exclude` format
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
