### PR TITLE
fix: gate semantic_release config and maintain group behind use_semantic_release

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -52,10 +52,12 @@ Funding = "https://{{ repository_provider }}/sponsors/{{ author_username }}"
 {% endif -%}
 
 [dependency-groups]
+{%- if use_semantic_release %}
 maintain = [
     "build>=1.2",
     "python-semantic-release>=10",
 ]
+{%- endif %}
 ci = [
     "ruff>=0.14",
     "pytest>=8",
@@ -83,7 +85,7 @@ docs = [
 ]
 
 [tool.uv]
-default-groups = ["maintain", "ci", "docs", "local"]
+default-groups = [{% if use_semantic_release %}"maintain", {% endif %}"ci", "docs", "local"]
 
 [tool.ruff]
 target-version = "py314"
@@ -213,6 +215,7 @@ tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 runs = "gh run list --limit 10"
 watch = "gh run watch"
 
+{%- if use_semantic_release %}
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
@@ -233,3 +236,4 @@ changelog_file = "CHANGELOG.md"
 allowed_tags = ["build", "chore", "ci", "deps", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
+{%- endif %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -450,6 +450,54 @@ class TestCascadingBooleanDefaults:
         assert "classifiers" not in content
         assert "keywords" not in content
 
+    def test_use_ci_false_no_semantic_release_config(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """When use_ci=false, semantic_release config and maintain group should not appear."""
+        answers = {
+            **copier_defaults,
+            "use_ci": False,
+        }
+        answers.pop("use_semantic_release", None)
+        answers.pop("publish_to_pypi", None)
+        answers.pop("use_blacksmith_runners", None)
+        project = generate_project(tmp_path, answers)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "[tool.semantic_release]" not in content
+        assert "python-semantic-release" not in content
+        assert "maintain" not in content
+
+    def test_use_semantic_release_false_no_semantic_release_config(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """When use_semantic_release=false explicitly, semantic_release config should not appear."""
+        answers = {
+            **copier_defaults,
+            "use_ci": True,
+            "use_semantic_release": False,
+        }
+        answers.pop("publish_to_pypi", None)
+        project = generate_project(tmp_path, answers)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "[tool.semantic_release]" not in content
+        assert "python-semantic-release" not in content
+        assert "maintain" not in content
+
+    def test_use_semantic_release_true_has_config(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """When use_semantic_release=true, semantic_release config and maintain group should appear."""
+        answers = {
+            **copier_defaults,
+            "use_ci": True,
+            "use_semantic_release": True,
+        }
+        project = generate_project(tmp_path, answers)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "[tool.semantic_release]" in content
+        assert "python-semantic-release" in content
+        assert "maintain" in content
+
 
 class TestTyperOption:
     """Test typer CLI option."""


### PR DESCRIPTION
## Summary
Gate `[tool.semantic_release]` config and `maintain` dependency group behind `use_semantic_release`.

## Problem
When `use_semantic_release` is `false`, the generated `pyproject.toml` still includes:
- `maintain = ["build>=1.2", "python-semantic-release>=10"]` dependency group
- `"maintain"` in `default-groups`
- `[tool.semantic_release]` and all sub-tables

This adds unnecessary dependencies and config to projects that don't use semantic-release.

## Solution
Wrap all three sections in `{% if use_semantic_release %}` Jinja conditionals in `pyproject.toml.jinja`.

## Changes
- **project/pyproject.toml.jinja**: Gate `maintain` group, `default-groups` entry, and `[tool.semantic_release]` sections behind `use_semantic_release`
- **tests/test_template.py**: Add 3 regression tests (ci=false, semantic_release=false, semantic_release=true)

Fixes #47
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
