### PR TITLE
fix: remove overly specific config and gate platform-specific poe tasks

### DIFF
--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <defs>
+    <linearGradient id="dropGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ff1a1a;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#cc0000;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8b0000;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient id="sheen" cx="35%" cy="35%" r="50%">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:0.45" />
+      <stop offset="100%" style="stop-color:#ffffff;stop-opacity:0" />
+    </radialGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="130%" height="130%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#000" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+  <!-- Blood drop shape -->
+  <path d="M64 10 C64 10, 28 60, 28 82 C28 102, 44 118, 64 118 C84 118, 100 102, 100 82 C100 60, 64 10, 64 10 Z"
+        fill="url(#dropGrad)" filter="url(#shadow)"/>
+  <!-- Glossy highlight -->
+  <path d="M64 10 C64 10, 28 60, 28 82 C28 102, 44 118, 64 118 C84 118, 100 102, 100 82 C100 60, 64 10, 64 10 Z"
+        fill="url(#sheen)"/>
+  <!-- Small specular highlight -->
+  <ellipse cx="48" cy="65" rx="10" ry="14" fill="white" opacity="0.2" transform="rotate(-15 48 65)"/>
+</svg>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,8 @@ nav:
 
 theme:
   name: material
+  logo: logo.svg
+  favicon: logo.svg
   features:
   - content.action.edit
   - content.action.view

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -166,9 +166,6 @@ branch = true
 parallel = true
 source = ["src/", "tests/"]
 
-[tool.coverage.paths]
-equivalent = ["src/", ".venv/lib/*/site-packages/"]
-
 [tool.coverage.report]
 precision = 2
 omit = ["src/*/__init__.py", "src/*/__main__.py", "tests/__init__.py"]
@@ -179,9 +176,6 @@ output = "htmlcov/coverage.json"
 
 [tool.ty.environment]
 python-version = "3.14"
-
-[tool.ty.src]
-exclude = ["tests/fixtures/"]
 
 [tool.poe.tasks]
 # Setup
@@ -204,16 +198,22 @@ fix = ["lint --fix", "format"]
 # Documentation
 docs = "mkdocs serve"
 docs-build = "mkdocs build -s"
+{%- if repository_provider == "github.com" %}
 docs-deploy = "mkdocs gh-deploy"
+{%- endif %}
 
 # Pre-commit
 prek = "prek run --all-files"
 
+# Git utilities
+tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
+{%- if repository_provider == "github.com" %}
+
 # GitHub utilities
 releases = "gh release list --limit 10"
-tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 runs = "gh run list --limit 10"
 watch = "gh run watch"
+{%- endif %}
 
 {%- if use_semantic_release %}
 [tool.semantic_release]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -499,6 +499,48 @@ class TestCascadingBooleanDefaults:
         assert "maintain" in content
 
 
+class TestTemplateCleanup:
+    """Test removal of overly specific config and proper gating of platform-specific tasks.
+
+    Regression tests for #49 (docs-deploy) and #50 (coverage.paths, ty.src.exclude).
+    """
+
+    def test_no_coverage_paths(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Generated pyproject.toml should not have [tool.coverage.paths]."""
+        project = generate_project(tmp_path, copier_defaults)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "[tool.coverage.paths]" not in content
+
+    def test_no_ty_src_exclude_fixtures(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Generated pyproject.toml should not have ty.src.exclude for fixtures."""
+        project = generate_project(tmp_path, copier_defaults)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "tests/fixtures" not in content
+
+    def test_github_has_docs_deploy(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """GitHub projects should have docs-deploy poe task."""
+        project = generate_project(tmp_path, copier_defaults)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "docs-deploy" in content
+        assert "gh-deploy" in content
+
+    def test_github_has_gh_cli_tasks(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """GitHub projects should have gh CLI poe tasks."""
+        project = generate_project(tmp_path, copier_defaults)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "gh release list" in content
+        assert "gh run list" in content
+        assert "gh run watch" in content
+
+
 class TestTyperOption:
     """Test typer CLI option."""
 


### PR DESCRIPTION
## Summary
Remove overly specific config and gate platform-specific poe tasks.

## Changes
- **`project/pyproject.toml.jinja`**: Remove `[tool.coverage.paths]` (assumes venv layout for parallel coverage — noise for most projects)
- **`project/pyproject.toml.jinja`**: Remove `[tool.ty.src] exclude = ["tests/fixtures/"]` (assumes non-existent directory — noise)
- **`project/pyproject.toml.jinja`**: Gate `docs-deploy`, `releases`, `runs`, `watch` poe tasks behind `repository_provider == "github.com"`
- **`tests/test_template.py`**: Add 4 regression tests

Fixes #49, fixes #50
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
