### PR TITLE
fix: YAML indentation bug in pre-commit config for non-GitHub providers

### DIFF
--- a/project/.pre-commit-config.yaml.jinja
+++ b/project/.pre-commit-config.yaml.jinja
@@ -59,14 +59,13 @@ repos:
       - id: shellcheck
         priority: 1
 
-{% if repository_provider == "github.com" -%}
+{%- if repository_provider == "github.com" %}
   - repo: https://github.com/rhysd/actionlint
     rev: ""  # prek autoupdate will fill this
     hooks:
       - id: actionlint
         priority: 1
-
-{% endif -%}
+{% endif %}
   - repo: https://github.com/crate-ci/typos
     rev: ""  # prek autoupdate will fill this
     hooks:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -589,6 +589,18 @@ class TestGitLabSupport:
         content = config.read_text()
         assert "actionlint" not in content
 
+    def test_gitlab_precommit_valid_yaml(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """GitLab pre-commit config should have valid YAML indentation (#56)."""
+        import yaml
+
+        answers = {**copier_defaults, "repository_provider": "gitlab.com"}
+        project = generate_project(tmp_path, answers)
+
+        config = project / ".pre-commit-config.yaml"
+        data = yaml.safe_load(config.read_text())
+        repo_urls = [r["repo"] for r in data["repos"] if isinstance(r, dict)]
+        assert "https://github.com/crate-ci/typos" in repo_urls
+
     def test_gitlab_no_giscus(self, tmp_path: Path, copier_defaults: dict) -> None:
         """GitLab projects should not have Giscus comments."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}


### PR DESCRIPTION
## Summary
Fix YAML indentation bug in generated `.pre-commit-config.yaml` for non-GitHub providers.

## Problem
The Jinja conditional for the `actionlint` hook used `{% endif -%}` which stripped the leading whitespace from the `typos` repo entry when `repository_provider != "github.com"`. This produced invalid YAML:

```yaml
  - repo: https://github.com/shellcheck-py/shellcheck-py
    ...

- repo: https://github.com/crate-ci/typos    # <-- missing 2 leading spaces
```

## Solution
Changed whitespace control from `{% if %} ... {% endif -%}` to `{%- if %} ... {% endif %}` — strip *before* the block, not *after*, preserving the indentation of the next entry.

## Changes
- **`project/.pre-commit-config.yaml.jinja`**: Fix Jinja whitespace control tags
- **`tests/test_template.py`**: Add regression test that parses the generated YAML and verifies the `typos` repo is present

Fixes #56
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
