### PR TITLE
fix: add 'if __name__' to coverage exclude_lines

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -171,7 +171,7 @@ source = ["src/", "tests/"]
 [tool.coverage.report]
 precision = 2
 omit = ["src/*/__init__.py", "src/*/__main__.py", "tests/__init__.py"]
-exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING", "if __name__ == .__main__.:"]
 
 [tool.coverage.json]
 output = "htmlcov/coverage.json"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -513,6 +513,14 @@ class TestTemplateCleanup:
         content = pyproject.read_text()
         assert "[tool.coverage.paths]" not in content
 
+    def test_coverage_excludes_main_guard(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Coverage exclude_lines should include if __name__ == '__main__' (#57)."""
+        project = generate_project(tmp_path, copier_defaults)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert "if __name__ == .__main__." in content
+
     def test_no_ty_src_exclude_fixtures(self, tmp_path: Path, copier_defaults: dict) -> None:
         """Generated pyproject.toml should not have ty.src.exclude for fixtures."""
         project = generate_project(tmp_path, copier_defaults)


### PR DESCRIPTION
## Summary
Add `if __name__ == "__main__":` to coverage `exclude_lines`.

## Problem
The template's coverage config was missing this standard exclusion pattern. The `__main__` guard is boilerplate that doesn't need test coverage.

## Changes
- **`project/pyproject.toml.jinja`**: Add pattern to `exclude_lines`
- **`tests/test_template.py`**: Add regression test

Fixes #57
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
