### PR TITLE
fix: make CI question text provider-neutral

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -183,12 +183,12 @@ use_typer:
 
 use_ci:
   type: bool
-  help: Enable GitHub Actions CI workflow? (testing, linting, type checking)
+  help: "Enable CI workflow? (testing, linting, type checking)"
   default: true
 
 use_semantic_release:
   type: bool
-  help: Enable semantic-release workflow? (automated versioning, changelog, GitHub releases)
+  help: "Enable semantic-release workflow? (automated versioning, changelog, releases)"
   default: "{{ use_ci }}"
   when: "{{ use_ci }}"
 


### PR DESCRIPTION
## Summary
Make CI-related copier question text provider-neutral.

## Problem
The `use_ci` prompt says "Enable GitHub Actions CI workflow?" and `use_semantic_release` says "GitHub releases" — misleading for GitLab users who may answer "No" thinking it's GitHub-only.

## Solution
Remove provider-specific references from help text:
- `use_ci`: "Enable CI workflow? (testing, linting, type checking)"
- `use_semantic_release`: "Enable semantic-release workflow? (automated versioning, changelog, releases)"

## Changes
- **`copier.yml`**: Update help text for `use_ci` and `use_semantic_release`

Fixes #64
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
