### PR TITLE
fix: add blank line between shellcheck and typos repos in pre-commit config

### DIFF
--- a/project/.pre-commit-config.yaml.jinja
+++ b/project/.pre-commit-config.yaml.jinja
@@ -60,12 +60,14 @@ repos:
         priority: 1
 
 {%- if repository_provider == "github.com" %}
+
   - repo: https://github.com/rhysd/actionlint
     rev: ""  # prek autoupdate will fill this
     hooks:
       - id: actionlint
         priority: 1
-{% endif %}
+{%- endif %}
+
   - repo: https://github.com/crate-ci/typos
     rev: ""  # prek autoupdate will fill this
     hooks:
@@ -100,8 +102,9 @@ repos:
 
       - id: docs-build
         name: docs build check
-        entry: bash -c 'mkdir -p htmlcov && echo "<html><body>No coverage report yet</body></html>" > htmlcov/index.html && uv run poe docs-build'
+        entry: bash -c 'test -f htmlcov/index.html || (mkdir -p htmlcov && touch htmlcov/index.html); uv run poe docs-build'
         language: system
+        files: ^(docs/|mkdocs\.yml|README\.md|CONTRIBUTING\.md|CHANGELOG\.md|src/)
         pass_filenames: false
         stages: [pre-push]
 


### PR DESCRIPTION
## Summary
Fix missing blank line between shellcheck and typos repos, and improve docs-build hook.

## Changes

### Fix #69: Blank line separator
The generated `.pre-commit-config.yaml` was missing a blank line between the shellcheck and typos repo entries when `repository_provider != github.com` (actionlint block absent). Fixed Jinja whitespace control to ensure consistent blank line separators.

### Fix #70: docs-build hook improvements
- Only create `htmlcov/index.html` placeholder if it doesn't already exist (preserves real coverage reports)
- Use `touch` instead of writing fake HTML content
- Add `files:` filter so the hook only runs when docs files actually change

## Files
- **`project/.pre-commit-config.yaml.jinja`**: Both fixes

Fixes #69, fixes #70
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
