### PR TITLE
fix: gate pytest-xdist and filterwarning behind use_ci

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -65,7 +65,9 @@ ci = [
     "pytest>=8",
     "pytest-cov>=6",
     "pytest-randomly>=3.15",
+{%- if use_ci %}
     "pytest-xdist>=3.5",
+{%- endif %}
     "ty>=0.0.14",
     "poethepoet>=0.32",
 ]
@@ -160,7 +162,9 @@ markers = [
 filterwarnings = [
     "error",
     "error::EncodingWarning",
+{%- if use_ci %}
     "ignore:.*rsyncdir:DeprecationWarning:xdist",
+{%- endif %}
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
Gate `pytest-xdist` dependency and its filterwarning behind `use_ci`.

## Problem
`pytest-xdist` and its `rsyncdir` deprecation filterwarning were unconditionally included in the generated `pyproject.toml`, even when CI was disabled. Users with `use_ci: false` got an unnecessary dependency and a filterwarning for a package they didn't need.

## Solution
Wrap both behind `{%- if use_ci %}` conditionals. xdist is a CI optimization for parallel test execution — users who want it without CI can add it manually.

## Changes
- **`project/pyproject.toml.jinja`**: Gate `pytest-xdist>=3.5` dep and `ignore:.*rsyncdir` filterwarning behind `use_ci`

Fixes #58
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
