### PR TITLE
fix: replace make setup with uv sync and fix run command per project type in CONTRIBUTING.md

### DIFF
--- a/project/CONTRIBUTING.md.jinja
+++ b/project/CONTRIBUTING.md.jinja
@@ -10,7 +10,7 @@ Fork and clone the repository, then:
 
 ```bash
 cd {{ repository_name }}
-make setup
+uv sync
 ```
 
 > NOTE: If it fails for some reason, you'll need to install [uv](https://github.com/astral-sh/uv) manually.
@@ -21,12 +21,15 @@ make setup
 > curl -LsSf https://astral.sh/uv/install.sh | sh
 > ```
 >
-> Now you can try running `poe setup` again, or simply `uv sync`.
+> Now you can try running `uv sync` again.
 
 You now have the dependencies installed.
 
-{% if python_package_command_line_name -%}
+{% if project_type == 'package' -%}
 You can run the application with `uv run {{ python_package_command_line_name }} [ARGS...]`.
+
+{% elif project_type == 'app' -%}
+You can run the application with `uv run python main.py`.
 
 {% endif -%}
 


### PR DESCRIPTION
## Summary
Fix incorrect setup command and project-type-specific run instructions in the generated CONTRIBUTING.md.

## Problem
1. CONTRIBUTING.md instructed contributors to run `make setup` but no Makefile exists in the template (#74)
2. The run command section always showed `uv run <cli-name>` regardless of project type, but `app` type has no `[project.scripts]` entry — making the command fail (#77)

## Solution
- Changed `make setup` → `uv sync`
- Made the run command conditional on `project_type`:
  - **package**: `uv run <cli-name> [ARGS...]` (uses `[project.scripts]` entrypoint)
  - **app**: `uv run python main.py`
  - **lib**: section omitted (libraries aren't run directly)

## Changes
- `project/CONTRIBUTING.md.jinja` — fixed setup command and run instructions

Closes #74
Closes #77
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
