### PR TITLE
fix: add noqa T201 to main.py print statement for T20 rule consistency

### DIFF
--- a/project/{% if project_type == 'app' %}main.py{% endif %}.jinja
+++ b/project/{% if project_type == 'app' %}main.py{% endif %}.jinja
@@ -3,7 +3,7 @@
 
 def main() -> None:
     """Run the application."""
-    print("Hello from {{ project_name }}!")
+    print("Hello from {{ project_name }}!")  # noqa: T201
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add `# noqa: T201` to the `print()` call in the generated `main.py` for app-type projects.

## Problem
The template configures ruff with the `T20` rule (flake8-print) which flags `print()` statements, while the generated `main.py` entry point uses `print()` for the hello world message. This is an inconsistency — the template advocates against `print()` via lint rules while using it in scaffolded code.

## Solution
Added `# noqa: T201` to the print statement. This is appropriate for a hello world scaffold — users will replace it with their own logic.

## Changes
- `project/{% if project_type == 'app' %}main.py{% endif %}.jinja` — added noqa comment

Closes #76
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
