### PR TITLE
feat: include reset-and-adopt script for rapid template iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,5 +124,6 @@ All projects come with pre-configured [poethepoet](https://github.com/nat-n/poet
 | `poe test-cov` | Run tests with coverage |
 | `poe docs` | Serve docs locally |
 | `poe prek` | Run all pre-commit hooks |
+| `poe reset-and-adopt` | Reset and re-adopt template (preserves answers) |
 | `poe runs` | List recent CI runs |
 | `poe watch` | Watch current CI run |

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -24,3 +24,13 @@ With [`uv`](https://docs.astral.sh/uv/):
 uv tool install {{ python_package_distribution_name }}
 ```
 {%- endif -%}
+
+## Template Updates
+
+This project was generated with [copier-uv-bleeding](https://github.com/detailobsessed/copier-uv-bleeding). To re-apply the latest template changes:
+
+```bash
+poe reset-and-adopt
+```
+
+This resets local changes, preserves `.copier-answers.yml`, and re-runs `copier adopt` with conflict markers for easy review.

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -211,6 +211,9 @@ docs-deploy = "mkdocs gh-deploy"
 # Pre-commit
 prek = "prek run --all-files"
 
+# Template
+reset-and-adopt = "bash scripts/reset-and-adopt.sh"
+
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 {%- if repository_provider == "github.com" %}

--- a/project/scripts/reset-and-adopt.sh
+++ b/project/scripts/reset-and-adopt.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Reset working tree and re-run copier adopt with the template.
+# Preserves .copier-answers.yml so copier reuses previous answers.
+# Usage: ./scripts/reset-and-adopt.sh [-y]
+#   -y  Skip confirmation prompt
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+auto_yes=false
+while getopts "y" opt; do
+    case $opt in
+        y) auto_yes=true ;;
+        *) echo "Usage: $0 [-y]" && exit 1 ;;
+    esac
+done
+
+echo "=== Uncommitted changes ==="
+git status --short
+echo ""
+echo "=== Untracked files (will be removed) ==="
+git clean -fdn -e .copier-answers.yml
+echo ""
+
+if [ "$auto_yes" = false ]; then
+    read -rp "This will discard ALL changes and untracked files (except .copier-answers.yml). Are you sure? [y/N] " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+echo "Discarding all changes..."
+if [ -f .copier-answers.yml ]; then
+    cp .copier-answers.yml .copier-answers.yml.backup
+fi
+git reset --hard HEAD
+git clean -fd -e .copier-answers.yml.backup
+if [ -f .copier-answers.yml.backup ]; then
+    mv .copier-answers.yml.backup .copier-answers.yml
+fi
+
+echo "Running copier adopt..."
+copier adopt \
+    --trust \
+    --conflict inline \
+    --vcs-ref=HEAD \
+    "https://github.com/detailobsessed/copier-uv-bleeding.git" .
+
+echo ""
+echo "Done. Check for conflicts with:"
+echo "  grep -r '<<<<<<< existing' --include='*.toml' --include='*.yaml' --include='*.yml' --include='*.md' --include='*.example' ."


### PR DESCRIPTION
## Summary
Add a `scripts/reset-and-adopt.sh` script to generated projects for rapid template iteration during `copier adopt` workflows.

## Problem
When testing the template on projects (especially during `copier adopt` workflows), users repeatedly need to:
1. Discard all uncommitted changes
2. Clean untracked files except `.copier-answers.yml`
3. Re-run `copier adopt` with `--trust --conflict inline --vcs-ref=HEAD`

This was a manual multi-step process with no standardized tooling.

## Solution
- Added `scripts/reset-and-adopt.sh` — a safe, interactive script that:
  - Shows uncommitted changes and untracked files before acting
  - Prompts for confirmation (skippable with `-y` flag)
  - Preserves `.copier-answers.yml` so copier reuses previous answers
  - Runs `copier adopt` with conflict markers for easy review
- Added `poe reset-and-adopt` task in `pyproject.toml.jinja`
- Added "Template Updates" section to generated `README.md.jinja`
- Added task to template project `README.md` Available Tasks table
- Passes shellcheck

## Changes
- `project/scripts/reset-and-adopt.sh` — new script
- `project/pyproject.toml.jinja` — added poe task
- `project/README.md.jinja` — added Template Updates section
- `README.md` — added to Available Tasks table

Closes #78
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
