### PR TITLE
fix: add blank line before Template Updates heading and add markdown validator to linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ htmlcov/
 # bv (beads viewer) local config and caches
 .bv/
 AI_PR_REVIEW_AGENT_FEEDBACK.md
+project/windsurf-issues.code-workspace

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -23,7 +23,7 @@ With [`uv`](https://docs.astral.sh/uv/):
 ```bash
 uv tool install {{ python_package_distribution_name }}
 ```
-{%- endif -%}
+{%- endif %}
 
 ## Template Updates
 

--- a/scripts/lint_templates.py
+++ b/scripts/lint_templates.py
@@ -157,10 +157,36 @@ def validate_yaml(content: str, _path: str) -> str | None:
     return None
 
 
+def validate_markdown(content: str, _path: str) -> str | None:
+    """Return error message if rendered Markdown has structural issues, else None.
+
+    Only checks issues caused by Jinja whitespace control (MD022).
+    Full markdownlint integration is tracked in #91.
+    """
+    issues = []
+    lines = content.splitlines()
+    in_code_block = False
+    for i, line in enumerate(lines):
+        # Track fenced code blocks (including inside blockquotes)
+        stripped = re.sub(r"^(?:>\s*)+", "", line)
+        if re.match(r"^```", stripped):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        # MD022: Headings must be surrounded by blank lines
+        if re.match(r"^#{1,6}\s", line) and i > 0 and lines[i - 1].strip():
+            issues.append(f"line {i + 1}: heading without preceding blank line (MD022)")
+    if issues:
+        return "; ".join(issues)
+    return None
+
+
 VALIDATORS = {
     ".toml": validate_toml,
     ".yml": validate_yaml,
     ".yaml": validate_yaml,
+    ".md": validate_markdown,
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fix missing blank line between code fence and heading in generated README.md, and add a markdown structural validator to the template linter.

## Problem
The `{%- endif -%}` on line 26 of `README.md.jinja` stripped the trailing newline, causing the `## Template Updates` heading to render directly after the code fence with no blank line. This breaks rendering on GitHub and PyPI.

## Solution
- Changed `{%- endif -%}` to `{%- endif %}` to preserve the blank line after the code fence
- Added `validate_markdown()` to `lint_templates.py` that checks MD022 (headings must be surrounded by blank lines) — catches Jinja whitespace control bugs
- Full markdownlint integration deferred to #91

## Changes
- `project/README.md.jinja` — fix whitespace control
- `scripts/lint_templates.py` — add `.md` validator

Closes #83
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
