### PR TITLE
fix: wrap bare URL in CONTRIBUTING.md to satisfy markdownlint MD034

### DIFF
--- a/project/CONTRIBUTING.md.jinja
+++ b/project/CONTRIBUTING.md.jinja
@@ -55,7 +55,7 @@ As usual:
 1. run `poe test` to run the tests (fix any issues)
 1. if you updated the documentation or the project dependencies:
     1. run `poe docs`
-    1. go to http://localhost:8000 and check that everything looks good
+    1. go to <http://localhost:8000> and check that everything looks good
 1. follow our [commit message convention](#commit-message-convention)
 
 If you are unsure about how to fix or ignore a warning, just let the continuous integration fail, and we will help you during review.


### PR DESCRIPTION
## Summary
Wrap bare `http://localhost:8000` URL in angle brackets in the generated CONTRIBUTING.md.

## Problem
Line 58 of `CONTRIBUTING.md.jinja` contains a bare URL that triggers markdownlint MD034 (no-bare-urls). The template configures markdownlint as a pre-commit hook, so generated projects fail their own lint checks.

## Solution
Changed `http://localhost:8000` to `<http://localhost:8000>`.

## Changes
- `project/CONTRIBUTING.md.jinja` — wrap bare URL

Closes #84
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
