### PR TITLE
fix: add RUF067 per-file-ignore for tests/__init__.py constants

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -141,6 +141,7 @@ select = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]  # Allow assert in tests
+"tests/__init__.py" = ["RUF067"]  # Allow test constants (TESTS_DIR, FIXTURES_DIR)
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false


### PR DESCRIPTION
## Summary
Add `RUF067` per-file-ignore for `tests/__init__.py` in the generated `pyproject.toml`.

## Problem
With ruff's `preview = true`, the `RUF067` rule (`__init__` module should only contain docstrings and re-exports) flags the test directory constants (`TESTS_DIR`, `TMP_DIR`, `FIXTURES_DIR`) in `tests/__init__.py`. The template's own ruff config flags the template's own generated code.

## Solution
Added per-file-ignore rather than moving constants to `conftest.py`, because:
- `tests/__init__.py` is in `_skip_if_exists` — existing projects importing from it would break
- Constants in `__init__.py` is a common pattern for test suites

## Changes
- `project/pyproject.toml.jinja` — added `"tests/__init__.py" = ["RUF067"]`

Closes #85
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
