### PR TITLE
fix: remove copier invocation from reset-and-adopt script

### DIFF
--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -33,4 +33,4 @@ This project was generated with [copier-uv-bleeding](https://github.com/detailob
 poe reset-and-adopt
 ```
 
-This resets local changes, preserves `.copier-answers.yml`, and re-runs `copier adopt` with conflict markers for easy review.
+This resets local changes and preserves `.copier-answers.yml`. Then run `copier recopy --trust .` or `copier update --trust .` to re-apply the template.

--- a/project/scripts/reset-and-adopt.sh
+++ b/project/scripts/reset-and-adopt.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Reset working tree and re-run copier adopt with the template.
+# Reset working tree to a clean state for re-applying a copier template.
 # Preserves .copier-answers.yml so copier reuses previous answers.
 # Usage: ./scripts/reset-and-adopt.sh [-y]
 #   -y  Skip confirmation prompt
@@ -41,13 +41,10 @@ if [ -f .copier-answers.yml.backup ]; then
     mv .copier-answers.yml.backup .copier-answers.yml
 fi
 
-echo "Running copier adopt..."
-copier adopt \
-    --trust \
-    --conflict inline \
-    --vcs-ref=HEAD \
-    "https://github.com/detailobsessed/copier-uv-bleeding.git" .
-
 echo ""
-echo "Done. Check for conflicts with:"
-echo "  grep -r '<<<<<<< existing' --include='*.toml' --include='*.yaml' --include='*.yml' --include='*.md' --include='*.example' ."
+echo "✓ Working tree reset to HEAD."
+echo ""
+echo "Next steps — run one of:"
+echo "  copier recopy --trust .                    # re-apply template (standard copier)"
+echo "  copier update --trust .                    # update to latest template version"
+echo "  copier adopt --trust --conflict inline .   # adopt template (requires copier fork)"


### PR DESCRIPTION
## Summary
Remove the `copier adopt` invocation from `reset-and-adopt.sh` — the script should only reset the working tree, not run copier.

## Problem
The script called `copier adopt` which:
1. Only exists in a [fork](https://github.com/detailobsessed/copier) — not in upstream copier
2. Couples the script to a specific copier subcommand when users may want `recopy`, `update`, or `adopt`

## Solution
Script now only resets the working tree (preserving `.copier-answers.yml`) and prints next-step instructions showing all three copier options. Users choose which copier command fits their workflow.

## Changes
- `project/scripts/reset-and-adopt.sh` — removed copier invocation, added next-steps output
- `project/README.md.jinja` — updated Template Updates description

Closes #95
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
