### PR TITLE
feat: add .editorconfig for universal editor settings

### DIFF
--- a/project/.editorconfig
+++ b/project/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
Add `.editorconfig` to generated projects for baseline formatting consistency across all editors.

## Why
- Works in every major editor (VS Code, JetBrains, Vim, Emacs, Sublime) without plugins
- Prevents formatting fights from contributors who haven't run `uv sync` yet
- Reinforces the `mixed-line-ending --fix=lf` pre-commit hook at editor level
- Standard in virtually every serious OSS project

## Settings
- 4-space indent, UTF-8, LF line endings, trim trailing whitespace
- 2-space indent for YAML
- No trailing whitespace trim for Markdown (preserves line breaks)
- Tab indent for Makefiles

Closes #86
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
