### PR TITLE
feat: add SECURITY.md for vulnerability reporting policy

### DIFF
--- a/project/SECURITY.md.jinja
+++ b/project/SECURITY.md.jinja
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do NOT open a public issue.**
+
+Instead, please email [{{ author_email }}](mailto:{{ author_email }}) with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+You should receive a response within 48 hours. We will work with you to understand and address the issue before any public disclosure.
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |


### PR DESCRIPTION
## Summary
Add `SECURITY.md.jinja` to generated projects with a templated vulnerability reporting policy.

## Why
- GitHub shows a prominent "Set up a security policy" banner without one
- Required for responsible disclosure workflows
- Standard for any package published to PyPI
- Builds trust with users and contributors

## Template
- Instructs reporters to email `{{ author_email }}` instead of opening public issues
- Requests description, reproduction steps, and impact assessment
- Commits to 48-hour response time
- Supported versions table

Closes #88
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
