### PR TITLE
feat: add Codecov integration and badge

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -172,4 +172,17 @@ jobs:
         path: site/
 
     - name: Run the test suite
-      run: uv run poe test
+      run: uv run poe test-cov
+
+    - name: Upload coverage to Codecov
+{%- if publish_to_pypi %}
+{%- if use_blacksmith_runners %}
+      if: {% raw %}${{ matrix.os == 'blacksmith-4vcpu-ubuntu-2404' && matrix.resolution == 'highest' }}{% endraw %}
+{%- else %}
+      if: {% raw %}${{ matrix.os == 'ubuntu-latest' && matrix.resolution == 'highest' }}{% endraw %}
+{%- endif %}
+{%- endif %}
+      uses: codecov/codecov-action@v5
+      with:
+        token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
+        fail_ci_if_error: false

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -9,6 +9,9 @@
 [![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://{{ repository_namespace }}.{{ repository_provider[:-4] }}.io/{{ repository_name }}/)
 [![pypi version](https://img.shields.io/pypi/v/{{ python_package_distribution_name }}.svg)](https://pypi.org/project/{{ python_package_distribution_name }}/)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
+{%- if repository_provider == "github.com" %}
+[![codecov](https://codecov.io/gh/{{ repository_namespace }}/{{ repository_name }}/branch/main/graph/badge.svg)](https://codecov.io/gh/{{ repository_namespace }}/{{ repository_name }})
+{%- endif %}
 {{ project_description }}
 
 ## Installation


### PR DESCRIPTION
Added code coverage reporting to CI workflow and README

This PR adds code coverage reporting to the CI workflow by:

1. Changing the test command from `uv run poe test` to `uv run poe test-cov` to generate coverage data
2. Adding a step to upload coverage results to Codecov using the codecov-action
3. Configuring the upload to only run on specific environments (Ubuntu with highest dependency resolution)
4. Adding a Codecov badge to the README for GitHub repositories

The Codecov integration will help track code coverage metrics over time, providing visibility into test coverage across the codebase.

Closes #89