### PR TITLE
feat: add verify-scaffold script gated behind copier question

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -41,6 +41,7 @@ _exclude:
 - "{% if not use_ci %}.gitlab-ci.yml{% endif %}"
 - "{% if not use_semantic_release %}.github/workflows/release.yml{% endif %}"
 # Exclude scaffolding files when adopting an existing project
+- "{% if not include_template_dev_scripts %}scripts/verify-scaffold.sh{% endif %}"
 - "{% if is_existing_project %}src/{{ python_package_import_name }}/_internal{% endif %}"
 - "{% if is_existing_project %}src/{{ python_package_import_name }}/__main__.py{% endif %}"
 - "{% if is_existing_project %}src/{{ python_package_import_name }}/py.typed{% endif %}"
@@ -207,6 +208,11 @@ use_blacksmith_runners:
 use_polar:
   type: bool
   help: Enable Polar.sh sponsorship? (requires account at polar.sh)
+  default: false
+
+include_template_dev_scripts:
+  type: bool
+  help: Include helper scripts for template development? (verify-scaffold)
   default: false
 
 is_existing_project:

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -142,6 +142,9 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101"]  # Allow assert in tests
 "tests/__init__.py" = ["RUF067"]  # Allow test constants (TESTS_DIR, FIXTURES_DIR)
+{%- if project_type == "package" %}
+"src/{{ python_package_import_name }}/_internal/debug.py" = ["T201"]  # Debug output uses print()
+{%- endif %}
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
@@ -211,6 +214,12 @@ docs-deploy = "mkdocs gh-deploy"
 
 # Pre-commit
 prek = "prek run --all-files"
+
+{%- if include_template_dev_scripts %}
+
+# Template dev
+verify-scaffold = "bash scripts/verify-scaffold.sh"
+{%- endif %}
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/project/scripts/verify-scaffold.sh
+++ b/project/scripts/verify-scaffold.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+# Verify that a copier-uv-bleeding scaffold meets all quality expectations.
+# Run from the project root: bash scripts/verify-scaffold.sh
+# Exit code 0 = all checks pass, non-zero = failures found.
+
+set -euo pipefail
+
+passed=0
+failed=0
+warnings=0
+
+pass() { printf "  ✅ %s\n" "$1"; passed=$((passed + 1)); }
+fail() { printf "  ❌ %s\n" "$1"; failed=$((failed + 1)); }
+warn() { printf "  ⚠️  %s\n" "$1"; warnings=$((warnings + 1)); }
+
+section() { printf "\n━━━ %s ━━━\n" "$1"; }
+
+# ---------------------------------------------------------------------------
+section "Project Structure"
+# ---------------------------------------------------------------------------
+
+# Core files
+for f in pyproject.toml README.md LICENSE CHANGELOG.md CONTRIBUTING.md \
+         CODE_OF_CONDUCT.md SECURITY.md .gitignore .envrc .env.example \
+         .copier-answers.yml .pre-commit-config.yaml .editorconfig \
+         mkdocs.yml; do
+    if [[ -f "$f" ]]; then pass "$f exists"; else fail "$f missing"; fi
+done
+
+# Read copier answers for conditional checks
+project_type=$(grep 'project_type' .copier-answers.yml 2>/dev/null | sed 's/.*: *//' || echo "unknown")
+repo_provider=$(grep 'repository_provider' .copier-answers.yml 2>/dev/null | sed 's/.*: *//' || echo "github.com")
+
+# App entry point (only for app project type)
+if [[ "$project_type" == "app" ]]; then
+    if [[ -f "main.py" ]]; then pass "main.py exists (app entry point)"; else fail "main.py missing"; fi
+fi
+
+# Source package
+pkg_name=$(grep '^name' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/' | tr '-' '_')
+if [[ -d "src/$pkg_name" ]]; then pass "src/$pkg_name/ package dir exists"; else fail "src/$pkg_name/ missing"; fi
+if [[ -f "src/$pkg_name/__init__.py" ]]; then pass "__init__.py exists"; else fail "__init__.py missing"; fi
+if [[ -f "src/$pkg_name/py.typed" ]]; then pass "py.typed marker exists"; else fail "py.typed missing"; fi
+
+# Tests
+if [[ -f "tests/__init__.py" ]]; then pass "tests/__init__.py exists"; else fail "tests/__init__.py missing"; fi
+if [[ -f "tests/conftest.py" ]]; then pass "tests/conftest.py exists"; else fail "tests/conftest.py missing"; fi
+
+# Docs
+for f in docs/index.md docs/changelog.md docs/contributing.md docs/license.md \
+         docs/code_of_conduct.md docs/reference/api.md; do
+    if [[ -f "$f" ]]; then pass "$f exists"; else fail "$f missing"; fi
+done
+
+# Provider-specific files
+if [[ "$repo_provider" == "github.com" ]]; then
+    for f in .github/workflows/ci.yml .github/workflows/release.yml \
+             .github/workflows/copier-update.yml .github/dependabot.yml \
+             .github/FUNDING.yml .github/actionlint.yaml; do
+        if [[ -f "$f" ]]; then pass "$f exists"; else fail "$f missing"; fi
+    done
+    if [[ -d ".github/ISSUE_TEMPLATE" ]]; then pass "Issue templates dir exists"; else fail "Issue templates missing"; fi
+    if [[ -f ".github/pull_request_template.md" ]]; then pass "PR template exists"; else fail "PR template missing"; fi
+elif [[ "$repo_provider" == "gitlab.com" ]]; then
+    if [[ -f ".gitlab-ci.yml" ]]; then pass ".gitlab-ci.yml exists"; else fail ".gitlab-ci.yml missing"; fi
+fi
+
+# ---------------------------------------------------------------------------
+section "Security"
+# ---------------------------------------------------------------------------
+
+if grep -q '^\.env$' .gitignore; then
+    pass ".env is gitignored"
+else
+    fail ".env is NOT in .gitignore — secrets at risk"
+fi
+
+if grep -q '!\.env\.example' .gitignore; then
+    pass ".env.example is excluded from gitignore"
+else
+    fail ".env.example not excluded — it should be tracked"
+fi
+
+if grep -q 'detect-private-key' .pre-commit-config.yaml; then
+    pass "detect-private-key hook present"
+else
+    fail "detect-private-key hook missing"
+fi
+
+if grep -q 'gitleaks' .pre-commit-config.yaml; then
+    pass "gitleaks hook present"
+else
+    fail "gitleaks hook missing"
+fi
+
+if [[ -f "SECURITY.md" ]]; then
+    pass "SECURITY.md exists"
+else
+    fail "SECURITY.md missing — no vulnerability reporting policy"
+fi
+
+# ---------------------------------------------------------------------------
+section "Python / uv Configuration"
+# ---------------------------------------------------------------------------
+
+if grep -q 'requires-python.*3\.14' pyproject.toml; then
+    pass "requires-python >= 3.14"
+else
+    warn "requires-python is not 3.14+"
+fi
+
+if grep -q 'uv_build' pyproject.toml; then
+    pass "uv_build backend configured"
+else
+    fail "build backend is not uv_build"
+fi
+
+if grep -q 'default-groups' pyproject.toml; then
+    pass "dependency groups configured"
+else
+    fail "No dependency groups found"
+fi
+
+if [[ -f "uv.lock" ]]; then pass "uv.lock exists"; else warn "uv.lock missing — run uv sync"; fi
+if [[ -d ".venv" ]]; then pass ".venv exists"; else warn ".venv missing — run uv sync"; fi
+
+# ---------------------------------------------------------------------------
+section "Ruff Linting"
+# ---------------------------------------------------------------------------
+
+for rule in '"E"' '"F"' '"UP"' '"I"' '"B"' '"SIM"' '"S"' '"T20"' '"PT"' '"PERF"'; do
+    if grep -q "$rule" pyproject.toml; then
+        pass "Ruff rule $rule enabled"
+    else
+        fail "Ruff rule $rule not found"
+    fi
+done
+
+if grep -q 'per-file-ignores' pyproject.toml && grep -q '"S101"' pyproject.toml; then
+    pass "S101 (assert) allowed in tests"
+else
+    fail "S101 not exempted for tests"
+fi
+
+# ---------------------------------------------------------------------------
+section "Testing"
+# ---------------------------------------------------------------------------
+
+if grep -q 'pytest' pyproject.toml; then pass "pytest configured"; else fail "pytest not found"; fi
+if grep -q 'pytest-cov' pyproject.toml; then pass "pytest-cov configured"; else fail "pytest-cov not found"; fi
+if grep -q 'pytest-randomly' pyproject.toml; then pass "pytest-randomly configured"; else fail "pytest-randomly not found"; fi
+if grep -q 'pytest-xdist' pyproject.toml; then pass "pytest-xdist configured"; else fail "pytest-xdist not found"; fi
+
+if grep -q 'branch = true' pyproject.toml; then
+    pass "Branch coverage enabled"
+else
+    fail "Branch coverage not enabled"
+fi
+
+# ---------------------------------------------------------------------------
+section "Type Checking"
+# ---------------------------------------------------------------------------
+
+if grep -q 'ty' pyproject.toml; then pass "ty type checker configured"; else fail "ty not found"; fi
+if grep -q 'python-version.*3\.14' pyproject.toml; then pass "ty targets Python 3.14"; else warn "ty python version mismatch"; fi
+
+# ---------------------------------------------------------------------------
+section "Pre-commit Hooks"
+# ---------------------------------------------------------------------------
+
+for hook in trailing-whitespace end-of-file-fixer check-yaml check-toml \
+            check-json check-added-large-files check-merge-conflict \
+            mixed-line-ending detect-private-key gitleaks ruff ruff-format \
+            uv-lock shellcheck typos markdownlint \
+            conventional-pre-commit; do
+    if grep -q "$hook" .pre-commit-config.yaml; then
+        pass "Hook: $hook"
+    else
+        fail "Hook missing: $hook"
+    fi
+done
+
+# GitHub-only hooks
+if [[ "$repo_provider" == "github.com" ]]; then
+    if grep -q 'actionlint' .pre-commit-config.yaml; then
+        pass "Hook: actionlint"
+    else
+        fail "Hook missing: actionlint"
+    fi
+fi
+
+# Local hooks
+if grep -q 'ty check' .pre-commit-config.yaml; then
+    pass "Local hook: ty type checker"
+else
+    fail "Local hook missing: ty"
+fi
+
+if grep -q 'pytest.*cov-fail-under' .pre-commit-config.yaml; then
+    pass "Local hook: pytest with coverage gate"
+else
+    fail "Local hook missing: pytest coverage gate"
+fi
+
+# ---------------------------------------------------------------------------
+section "CI Workflows"
+# ---------------------------------------------------------------------------
+
+ci=".github/workflows/ci.yml"
+if grep -q 'ubuntu' "$ci" && grep -q 'macos' "$ci" && grep -q 'windows' "$ci"; then
+    pass "CI: multi-OS matrix (Linux, macOS, Windows)"
+else
+    fail "CI: missing OS variants in matrix"
+fi
+
+if grep -q 'lowest-direct' "$ci"; then
+    pass "CI: resolution testing (highest + lowest-direct)"
+else
+    fail "CI: no resolution testing"
+fi
+
+if grep -q 'concurrency' "$ci"; then
+    pass "CI: concurrency group configured"
+else
+    warn "CI: no concurrency group"
+fi
+
+rel=".github/workflows/release.yml"
+if grep -q 'semantic-release' "$rel"; then
+    pass "Release: semantic-release configured"
+else
+    fail "Release: semantic-release not found"
+fi
+
+if grep -q 'uv publish' "$rel"; then
+    pass "Release: PyPI publishing configured"
+else
+    warn "Release: no PyPI publishing step"
+fi
+
+# Coverage upload
+if grep -qi 'codecov\|coveralls\|coverage' "$ci" 2>/dev/null; then
+    pass "CI: coverage upload configured"
+else
+    fail "CI: no coverage upload (Codecov/Coveralls) — coverage data goes nowhere"
+fi
+
+# ---------------------------------------------------------------------------
+section "Documentation"
+# ---------------------------------------------------------------------------
+
+if grep -q 'name: material' mkdocs.yml; then pass "MkDocs Material theme"; else fail "Not using Material theme"; fi
+if grep -q 'mkdocstrings' mkdocs.yml; then pass "mkdocstrings configured"; else fail "mkdocstrings missing"; fi
+if grep -q 'llmstxt' mkdocs.yml; then pass "llms.txt plugin enabled"; else warn "llms.txt plugin missing"; fi
+if grep -q 'git-revision-date' mkdocs.yml; then pass "Git revision date plugin"; else warn "Git revision date plugin missing"; fi
+
+# ---------------------------------------------------------------------------
+section "Poe Tasks"
+# ---------------------------------------------------------------------------
+
+for task in setup lint format typecheck test test-all test-cov check fix \
+            docs docs-build prek; do
+    if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml; then
+        pass "Poe task: $task"
+    else
+        fail "Poe task missing: $task"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+section "README Quality"
+# ---------------------------------------------------------------------------
+
+if grep -q '\[!\[ci\]' README.md; then pass "CI badge present"; else warn "CI badge missing"; fi
+if grep -q '\[!\[release\]' README.md; then pass "Release badge present"; else warn "Release badge missing"; fi
+if grep -q '\[!\[documentation\]' README.md; then pass "Docs badge present"; else warn "Docs badge missing"; fi
+if grep -qi 'codecov\|coveralls\|coverage.*badge\|coverage.*img' README.md; then pass "Coverage badge present"; else fail "Coverage badge missing in README"; fi
+
+# Check for the known README formatting bug (#83)
+if grep -q '```##' README.md; then
+    fail "README: code fence merged with heading (no blank line) — copier-uv-bleeding#83"
+else
+    pass "README: no code fence / heading collision"
+fi
+
+# ---------------------------------------------------------------------------
+section "CONTRIBUTING.md Consistency"
+# ---------------------------------------------------------------------------
+
+if grep -q 'make setup' CONTRIBUTING.md; then
+    fail "CONTRIBUTING.md still references 'make setup' (no Makefile)"
+else
+    pass "CONTRIBUTING.md does not reference 'make setup'"
+fi
+
+if grep -q 'uv sync\|uv run' CONTRIBUTING.md; then
+    pass "CONTRIBUTING.md references uv commands"
+else
+    fail "CONTRIBUTING.md missing uv commands"
+fi
+
+# ---------------------------------------------------------------------------
+section "Markdown Lint"
+# ---------------------------------------------------------------------------
+
+if command -v markdownlint &>/dev/null; then
+    md_errors=$(markdownlint README.md CONTRIBUTING.md CHANGELOG.md 2>&1 || true)
+    if [[ -z "$md_errors" ]]; then
+        pass "Core .md files pass markdownlint"
+    else
+        fail "Markdownlint errors found:"
+        echo "$md_errors" | head -20 | sed 's/^/       /'
+    fi
+else
+    warn "markdownlint not installed — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+section "Ruff Check (quick)"
+# ---------------------------------------------------------------------------
+
+if command -v ruff &>/dev/null || [[ -f ".venv/bin/ruff" ]]; then
+    ruff_bin="${VIRTUAL_ENV:-$PWD/.venv}/bin/ruff"
+    if [[ ! -x "$ruff_bin" ]]; then ruff_bin="ruff"; fi
+    if "$ruff_bin" check src tests &>/dev/null; then
+        pass "ruff check passes on src/ tests/"
+    else
+        ruff_errors=$("$ruff_bin" check src tests 2>&1 || true)
+        fail "ruff errors found:"
+        echo "$ruff_errors" | head -20 | sed 's/^/       /'
+    fi
+else
+    warn "ruff not available — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+printf "\n━━━ Summary ━━━\n"
+printf "  ✅ Passed:   %d\n" "$passed"
+printf "  ❌ Failed:   %d\n" "$failed"
+printf "  ⚠️  Warnings: %d\n" "$warnings"
+echo ""
+
+if ((failed > 0)); then
+    printf "🔴 %d check(s) failed.\n" "$failed"
+    exit 1
+else
+    printf "🟢 All checks passed"
+    if ((warnings > 0)); then printf " (%d warnings)" "$warnings"; fi
+    printf ".\n"
+    exit 0
+fi

--- a/scripts/lint_templates.py
+++ b/scripts/lint_templates.py
@@ -79,6 +79,7 @@ def _build_context(overrides: dict) -> dict:
         "publish_to_pypi": True,
         "use_blacksmith_runners": False,
         "use_polar": False,
+        "include_template_dev_scripts": False,
         "is_existing_project": False,
         **_COMMON,
     }

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -720,11 +720,9 @@ class TestTyperOption:
 class TestIntegration:
     """Integration tests that run uv sync and checks on generated project."""
 
-    def test_uv_sync_succeeds(self, tmp_path: Path, copier_defaults: dict) -> None:
-        """Generated project should successfully run uv sync."""
-        project = generate_project(tmp_path, copier_defaults)
-
-        # Initialize git (required for some tools)
+    @staticmethod
+    def _init_git_repo(project: Path) -> None:
+        """Initialize a git repo with an initial commit in the given project."""
         subprocess.run(["git", "init"], cwd=project, check=True, capture_output=True)
         subprocess.run(["git", "add", "-A"], cwd=project, check=True, capture_output=True)
         subprocess.run(
@@ -741,6 +739,33 @@ class TestIntegration:
             },
         )
 
+    def test_uv_sync_succeeds(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Generated project should successfully run uv sync."""
+        project = generate_project(tmp_path, copier_defaults)
+        self._init_git_repo(project)
+
         # Run uv sync
         result = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True)
         assert result.returncode == 0, f"uv sync failed: {result.stderr}"
+
+    @pytest.mark.slow
+    def test_verify_scaffold_passes(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Generated project with dev scripts should pass verify-scaffold checks."""
+        answers = {**copier_defaults, "include_template_dev_scripts": True, "publish_to_pypi": True}
+        project = generate_project(tmp_path, answers)
+        self._init_git_repo(project)
+
+        # Run uv sync to create .venv and uv.lock
+        sync_result = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True)
+        assert sync_result.returncode == 0, f"uv sync failed: {sync_result.stderr}"
+
+        # Run verify-scaffold.sh
+        script = project / "scripts" / "verify-scaffold.sh"
+        assert script.exists(), "verify-scaffold.sh not generated"
+        result = subprocess.run(
+            ["bash", str(script)],
+            cwd=project,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"verify-scaffold.sh failed:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## Summary

Add a comprehensive scaffold verification script (110+ checks) gated behind a new `include_template_dev_scripts` copier question (default: false).

## What it does

`verify-scaffold.sh` validates a generated project against all template expectations:
- **Project structure** — core files, source package, tests, docs, GitHub config
- **Security** — `.env` gitignored, gitleaks, detect-private-key, SECURITY.md
- **Python/uv config** — build backend, dependency groups, requires-python
- **Ruff rules** — all expected lint rules enabled, per-file-ignores correct
- **Testing** — pytest, coverage, randomly, xdist, branch coverage
- **Type checking** — ty configured and targeting correct Python version
- **Pre-commit hooks** — all 20+ expected hooks present
- **CI workflows** — multi-OS matrix, resolution testing, concurrency, coverage upload
- **Documentation** — Material theme, mkdocstrings, llms.txt
- **Poe tasks** — all expected tasks defined
- **README/CONTRIBUTING quality** — badges, formatting, consistency
- **Markdown lint + ruff check** — runs tools if available

## How it found real bugs

This script already caught template issues: #83, #84, #85, #95, and a missing T201 per-file-ignore for `debug.py` (fixed in this PR).

## Changes
- Added `include_template_dev_scripts` copier question (default: false)
- Added `_exclude` rule to omit script when not requested
- Added `project/scripts/verify-scaffold.sh` (shellcheck-clean)
- Added conditional `verify-scaffold` poe task
- Added T201 per-file-ignore for `debug.py` (print is intentional there)
- Added `include_template_dev_scripts` to template linter context
- Added `test_verify_scaffold_passes` integration test

Closes #97
Closes #98