### PR TITLE
chore: dogfood template conventions in template project itself

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+
+<!-- Brief description of what this PR does -->
+
+## Checklist
+
+- [ ] Tests added/updated
+- [ ] Documentation updated (if applicable)
+- [ ] `poe check` passes
+- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)
+
+## Related Issues
+
+<!-- Link related issues: Fixes #123, Related to #456 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ name: ci
     branches:
     - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
@@ -109,4 +113,10 @@ jobs:
     - name: Test project generation and workflow
       env:
         PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
-      run: uv run pytest tests/test_template.py -v
+      run: uv run pytest tests/test_template.py -v --cov=tests --cov-report=term-missing
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup uv and Python
       uses: astral-sh/setup-uv@v7.1.5
       with:
-        python-version: "3.13"
+        python-version: "3.14"
         enable-cache: true
     - name: Install dependencies
       run: uv sync

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__/
 .pytest_cache/
 .coverage
 htmlcov/
+.env
+!.env.example
 
 # bv (beads viewer) local config and caches
 .bv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,12 @@ repos:
       - id: detect-private-key
         priority: 0
 
+  - repo: https://github.com/tsvikas/sync-with-uv
+    rev: v0.5.0
+    hooks:
+      - id: sync-with-uv
+        priority: 0
+
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.0
     hooks:
@@ -75,10 +81,22 @@ repos:
       - id: shellcheck
         priority: 1
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.10.0
+    hooks:
+      - id: uv-lock
+        priority: 1
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.10
     hooks:
       - id: actionlint
+        priority: 1
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.43.3
+    hooks:
+      - id: typos
         priority: 1
 
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do NOT open a public issue.**
+
+Instead, please email [dev@ichoosetoaccept.com](mailto:dev@ichoosetoaccept.com) with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+You should receive a response within 48 hours. We will work with you to understand and address the issue before any public disclosure.
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -114,6 +114,12 @@ select = [
     "PIE",  # flake8-pie - misc improvements
     "RET",  # flake8-return - return statement issues
     "RUF",  # Ruff-specific rules
+    "FA",   # flake8-future-annotations
+    "ISC",  # flake8-implicit-str-concat - catch missing commas
+    "ICN",  # flake8-import-conventions
+    "TID",  # flake8-tidy-imports - absolute imports
+    "TC",   # flake8-type-checking - TYPE_CHECKING imports
+    "PTH",  # flake8-use-pathlib - prefer pathlib over os.path
 
     # Performance
     "PERF", # Perflint - performance anti-patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
     "poethepoet",
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",
+    "pytest-randomly>=3.16",
     "pytest-xdist>=3.5",
     "python-semantic-release>=10.5.2",
     "pyyaml>=6.0.3",
@@ -75,6 +76,12 @@ select = [
     "PIE",  # flake8-pie - misc improvements
     "RET",  # flake8-return - return statement issues
     "RUF",  # Ruff-specific rules
+    "FA",   # flake8-future-annotations
+    "ISC",  # flake8-implicit-str-concat - catch missing commas
+    "ICN",  # flake8-import-conventions
+    "TID",  # flake8-tidy-imports - absolute imports
+    "TC",   # flake8-type-checking - TYPE_CHECKING imports
+    "PTH",  # flake8-use-pathlib - prefer pathlib over os.path
 
     # Performance
     "PERF", # Perflint - performance anti-patterns
@@ -100,9 +107,12 @@ select = [
     "PLW1514",  # unspecified-encoding - require encoding in open()
 ]
 
+[tool.ruff.lint.isort]
+known-first-party = ["tests", "scripts"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "S404", "S603", "S607", "S701", "T201"]  # Allow assert, subprocess, jinja2, print in tests
-"extensions.py" = ["S602", "S605", "S607"]  # Template extensions use subprocess for git commands
+"extensions.py" = ["S404", "S602", "S605", "S607"]  # Template extensions use subprocess for git commands
 "scripts/**" = ["T201"]  # CLI scripts need print
 
 [tool.ruff.lint.flake8-pytest-style]
@@ -145,3 +155,13 @@ releases = "gh release list --limit 10"
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
 runs = "gh run list --limit 10"
 watch = "gh run watch"
+
+[tool.coverage.run]
+branch = true
+parallel = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+]

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -6,7 +6,7 @@ import reuse
 import yaml
 from jinja2 import Environment
 
-with open("copier.yml") as file:
+with Path("copier.yml").open(encoding="utf-8") as file:
     copier = yaml.safe_load(file)
 licenses = {identifier: name for name, identifier in copier["copyright_license"]["choices"].items()}
 
@@ -26,7 +26,7 @@ if errors:
 
 
 env = Environment()
-template = env.from_string(Path("project/LICENSE.jinja").read_text())
+template = env.from_string(Path("project/LICENSE.jinja").read_text(encoding="utf-8"))
 
 
 for license in licenses:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -528,7 +528,7 @@ class TestTemplateCleanup:
         project = generate_project(tmp_path, answers)
 
         pyproject = project / "pyproject.toml"
-        with open(pyproject, "rb") as f:
+        with pyproject.open("rb") as f:
             data = tomllib.load(f)
         assert data["project"]["description"] == 'Helps you "close the loop"'
 

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,7 @@ dev = [
     { name = "poethepoet" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
     { name = "pytest-xdist" },
     { name = "python-semantic-release" },
     { name = "pyyaml" },
@@ -269,6 +270,7 @@ dev = [
     { name = "poethepoet" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-randomly", specifier = ">=3.16" },
     { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "python-semantic-release", specifier = ">=10.5.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -1026,6 +1028,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-randomly"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1d/258a4bf1109258c00c35043f40433be5c16647387b6e7cd5582d638c116b/pytest_randomly-4.0.1.tar.gz", hash = "sha256:174e57bb12ac2c26f3578188490bd333f0e80620c3f47340158a86eca0593cd8", size = 14130, upload-time = "2025-09-12T15:23:00.085Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/3e/a4a9227807b56869790aad3e24472a554b585974fe7e551ea350f50897ae/pytest_randomly-4.0.1-py3-none-any.whl", hash = "sha256:e0dfad2fd4f35e07beff1e47c17fbafcf98f9bf4531fd369d9260e2f858bfcb7", size = 8304, upload-time = "2025-09-12T15:22:58.946Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Dogfood our own template conventions — the template project itself was missing several things we generate for users.

## Changes

### Files added
- `.editorconfig` — editor consistency (we generate this for users since PR #100)
- `SECURITY.md` — vulnerability reporting policy (since PR #102)
- `.github/pull_request_template.md` — PR quality checklist (since PR #101)

### Pre-commit hooks added
- `sync-with-uv` — auto-syncs pre-commit hook versions from `uv.lock` ([blog post](https://pydevtools.com/blog/sync-with-uv-eliminate-pre-commit-version-drift/))
- `typos` — spell checking
- `uv-lock` — ensures lockfile stays in sync

### pyproject.toml improvements
- `pytest-randomly` — randomize test order to catch hidden dependencies
- `[tool.coverage]` — branch coverage config
- `[tool.ruff.lint.isort]` — known-first-party for correct import sorting
- `S404` added to extensions.py per-file-ignores

### CI improvements
- Added concurrency group to cancel redundant runs on rapid pushes
- Added Codecov upload step to test-project job
- Fixed release.yml Python version: 3.13 → 3.14

### Lint fixes
- `test_licenses.py`: added explicit `encoding='utf-8'` to `open()` / `read_text()` calls (PLW1514)

### Security
- Added `.env` to `.gitignore`