### PR TITLE
refactor: remove is_existing_project question — redundant with _skip_if_exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ When you run `copier copy`, you'll be asked:
 | **Publish to PyPI?** | Include PyPI publishing in release workflow |
 | **Use Blacksmith runners?** | 2x faster, 75% cheaper CI runners |
 | **Enable Polar.sh?** | Sponsorship integration |
-| **Existing project?** | Skip generating scaffolding files for existing codebases |
 
 ## Quick Start
 

--- a/copier.yml
+++ b/copier.yml
@@ -40,14 +40,7 @@ _exclude:
 - "{% if not use_ci %}.github/workflows/ci.yml{% endif %}"
 - "{% if not use_ci %}.gitlab-ci.yml{% endif %}"
 - "{% if not use_semantic_release %}.github/workflows/release.yml{% endif %}"
-# Exclude scaffolding files when adopting an existing project
 - "{% if not include_template_dev_scripts %}scripts/verify-scaffold.sh{% endif %}"
-- "{% if is_existing_project %}src/{{ python_package_import_name }}/_internal{% endif %}"
-- "{% if is_existing_project %}src/{{ python_package_import_name }}/__main__.py{% endif %}"
-- "{% if is_existing_project %}src/{{ python_package_import_name }}/py.typed{% endif %}"
-- "{% if is_existing_project %}tests/__init__.py{% endif %}"
-- "{% if is_existing_project %}tests/conftest.py{% endif %}"
-- "{% if is_existing_project %}tests/test_api.py{% endif %}"
 
 # PROMPT --------------------------------
 project_name:
@@ -213,11 +206,6 @@ use_polar:
 include_template_dev_scripts:
   type: bool
   help: Include helper scripts for template development? (verify-scaffold)
-  default: false
-
-is_existing_project:
-  type: bool
-  help: Is this an existing project? (Skip generating CLI scaffolding files)
   default: false
 
 # TASKS --------------------------------

--- a/scripts/lint_templates.py
+++ b/scripts/lint_templates.py
@@ -80,7 +80,6 @@ def _build_context(overrides: dict) -> dict:
         "use_blacksmith_runners": False,
         "use_polar": False,
         "include_template_dev_scripts": False,
-        "is_existing_project": False,
         **_COMMON,
     }
     base.update(overrides)


### PR DESCRIPTION
## Summary

Remove the `is_existing_project` copier question — it was redundant with `_skip_if_exists` and had a design flaw.

## Problem

The `is_existing_project` question persisted in `.copier-answers.yml` permanently. Once set to `true`, every future `copier update` would continue excluding scaffolding files, preventing users from receiving template improvements to those files.

Every file in the `is_existing_project` exclude list was already covered by `_skip_if_exists`, which correctly protects existing files without permanently blocking new ones.

## Changes

- Removed `is_existing_project` question from `copier.yml`
- Removed 6 associated `_exclude` entries
- Removed from `lint_templates.py` test variants