### PR TITLE
fix: remove unconditional xdist, fix missing blank line before semantic_release (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It is designed to be used as a starting point for new Python projects, providing
 - **[ty](https://github.com/astral-sh/ty)** — next-gen type checker from Astral (fast, modern, replaces mypy)
 - **[prek](https://github.com/j178/prek)** — Rust-powered pre-commit hook runner (replaces pre-commit)
 - **[poethepoet](https://github.com/nat-n/poethepoet)** — task runner with pre-configured tasks for every workflow
-- **[pytest](https://github.com/pytest-dev/pytest)** — testing with coverage, randomization, and parallel execution
+- **[pytest](https://github.com/pytest-dev/pytest)** — testing with coverage and randomization
 - **[MkDocs Material](https://github.com/squidfunk/mkdocs-material)** — beautiful documentation with API autodoc
 - **[semantic-release](https://github.com/python-semantic-release/python-semantic-release)** — automated versioning and changelogs from conventional commits
 - **[lychee](https://github.com/lycheeverse/lychee)** — fast link checking in CI

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -65,9 +65,6 @@ ci = [
     "pytest>=8",
     "pytest-cov>=6",
     "pytest-randomly>=3.15",
-{%- if use_ci %}
-    "pytest-xdist>=3.5",
-{%- endif %}
     "ty>=0.0.14",
     "poethepoet>=0.32",
 ]
@@ -173,9 +170,6 @@ markers = [
 filterwarnings = [
     "error",
     "error::EncodingWarning",
-{%- if use_ci %}
-    "ignore:.*rsyncdir:DeprecationWarning:xdist",
-{%- endif %}
 ]
 
 [tool.coverage.run]
@@ -239,6 +233,7 @@ watch = "gh run watch"
 {%- endif %}
 
 {%- if use_semantic_release %}
+
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"


### PR DESCRIPTION
## Summary

Fixes bugs 1 and 2 from #113, plus a pre-existing bug in verify-scaffold.sh.

## Changes

- **Remove pytest-xdist** from `ci` dependency group — not every CI project needs parallel testing. Users can add it themselves.
- **Remove xdist filterwarning** — no longer needed without the dep.
- **Remove xdist check** from `verify-scaffold.sh`.
- **Update README** — remove "parallel execution" claim now that xdist is gone.
- **Fix missing blank line** before `[tool.semantic_release]` — Jinja `{%-` was stripping the separator between poe tasks and semantic_release config.
- **Guard CI section in verify-scaffold.sh** — wrap all `ci.yml`/`release.yml` grep calls in `[ -f ]` checks so the script doesn't error on GitLab or no-CI projects.

## Bug 3 (htmlcov hack) — not addressed

mkdocs-coverage has no `fail_on_missing` config option. The current workaround (creating a stub `htmlcov/index.html`) is ugly but functional. Left for a future fix if upstream adds graceful handling.

Closes #113