### PR TITLE
chore: add tk tickets for template audit findings and GH issue tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,3 @@ __pycache__/
 htmlcov/
 .env
 !.env.example
-
-# bv (beads viewer) local config and caches
-.bv/
-AI_PR_REVIEW_AGENT_FEEDBACK.md
-project/windsurf-issues.code-workspace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,9 @@ repos:
   # prek builtin hooks - no network/env needed, instant execution
   - repo: builtin
     hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]
+        priority: 0
       - id: trailing-whitespace
         priority: 0
       - id: end-of-file-fixer

--- a/.tickets/cub-3q9c.md
+++ b/.tickets/cub-3q9c.md
@@ -1,0 +1,17 @@
+---
+id: cub-3q9c
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:28:13Z
+type: bug
+priority: 2
+assignee: Ismar Iljazovic
+---
+# Remove dead _skip_if_exists entry for cli.py
+
+## Notes
+
+**2026-02-07T11:28:30Z**
+
+copier.yml line 25: src/{{ python_package_import_name }}/cli.py doesn't match any generated file. Template generates_internal/cli.py. The _internal/ paths are already covered on lines 26-28.

--- a/.tickets/cub-9w9e.md
+++ b/.tickets/cub-9w9e.md
@@ -1,0 +1,17 @@
+---
+id: cub-9w9e
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:28:23Z
+type: feature
+priority: 3
+assignee: Ismar Iljazovic
+---
+# Review LICENSE _skip_if_exists behavior for adopt
+
+## Notes
+
+**2026-02-07T11:28:38Z**
+
+During adopt, LICENSE gets conflict markers if it differs from template-generated version. May be fine since user picks license in prompt. Decide if this should be in _skip_if_exists.

--- a/.tickets/cub-bm17.md
+++ b/.tickets/cub-bm17.md
@@ -1,0 +1,11 @@
+---
+id: cub-bm17
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:29:30Z
+type: feature
+priority: 3
+assignee: Ismar Iljazovic
+---
+# Explore Windsurf hooks for uv workflow enforcement (GH #107)

--- a/.tickets/cub-d91e.md
+++ b/.tickets/cub-d91e.md
@@ -1,0 +1,11 @@
+---
+id: cub-d91e
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:29:33Z
+type: bug
+priority: 2
+assignee: Ismar Iljazovic
+---
+# Fix lychee checking its own config file (GH #116)

--- a/.tickets/cub-duhy.md
+++ b/.tickets/cub-duhy.md
@@ -1,0 +1,11 @@
+---
+id: cub-duhy
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:29:29Z
+type: feature
+priority: 2
+assignee: Ismar Iljazovic
+---
+# Align template output with uv init conventions + drift detection tests (GH #99)

--- a/.tickets/cub-fypd.md
+++ b/.tickets/cub-fypd.md
@@ -1,0 +1,17 @@
+---
+id: cub-fypd
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:28:18Z
+type: bug
+priority: 2
+assignee: Ismar Iljazovic
+---
+# Fix stale .vscode/settings.json.jinja paths
+
+## Notes
+
+**2026-02-07T11:28:33Z**
+
+project/.vscode/settings.json.jinja references config/ruff.toml, config/pytest.ini, config/mypy.ini — all consolidated into pyproject.toml. Fix paths or remove stale entries.

--- a/.tickets/cub-jnwi.md
+++ b/.tickets/cub-jnwi.md
@@ -1,0 +1,11 @@
+---
+id: cub-jnwi
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:29:31Z
+type: feature
+priority: 3
+assignee: Ismar Iljazovic
+---
+# README improvements — decision rationale, self-hosting, opinionated defaults (GH #109)

--- a/.tickets/cub-rrcu.md
+++ b/.tickets/cub-rrcu.md
@@ -1,0 +1,11 @@
+---
+id: cub-rrcu
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:29:32Z
+type: feature
+priority: 3
+assignee: Ismar Iljazovic
+---
+# Support internal/company projects — skip open-source scaffolding (GH #114)

--- a/.tickets/cub-soxn.md
+++ b/.tickets/cub-soxn.md
@@ -1,0 +1,17 @@
+---
+id: cub-soxn
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:28:21Z
+type: bug
+priority: 3
+assignee: Ismar Iljazovic
+---
+# Add main.py to _skip_if_exists for app type adopt
+
+## Notes
+
+**2026-02-07T11:28:36Z**
+
+main.py for app type is user-owned code per the stated philosophy but isn't in _skip_if_exists. During copier adopt on existing app, creates conflicts on their main entry point.

--- a/.tickets/cub-tvf1.md
+++ b/.tickets/cub-tvf1.md
@@ -1,0 +1,17 @@
+---
+id: cub-tvf1
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:28:24Z
+type: bug
+priority: 2
+assignee: Ismar Iljazovic
+---
+# Exclude copier-update.yml when use_ci is false
+
+## Notes
+
+**2026-02-07T11:28:34Z**
+
+copier-update.yml is a GitHub Actions workflow but isn't excluded when use_ci is false. Add to_exclude: {% if not use_ci %}.github/workflows/copier-update.yml{% endif %}

--- a/.tickets/cub-wwhh.md
+++ b/.tickets/cub-wwhh.md
@@ -1,0 +1,11 @@
+---
+id: cub-wwhh
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:29:34Z
+type: feature
+priority: 2
+assignee: Ismar Iljazovic
+---
+# Include dependabot.yml by default for GitHub projects (GH #117)

--- a/.tickets/cub-z2ba.md
+++ b/.tickets/cub-z2ba.md
@@ -1,0 +1,17 @@
+---
+id: cub-z2ba
+status: open
+deps: []
+links: []
+created: 2026-02-07T11:28:19Z
+type: bug
+priority: 2
+assignee: Ismar Iljazovic
+---
+# Remove windsurf-issues.code-workspace from template
+
+## Notes
+
+**2026-02-07T11:28:32Z**
+
+project/windsurf-issues.code-workspace is a dev artifact from the template repo that ships to every generated/adopted project. Should be deleted from project/ directory.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,2 @@
 [files]
-extend-exclude = ["CHANGELOG.md", "uv.lock"]
+extend-exclude = ["CHANGELOG.md", "uv.lock", ".tickets/"]


### PR DESCRIPTION
## Summary

Add tk tickets tracking template audit findings and mirror open GitHub issues locally.

## Changes

- **12 new tk tickets** in `.tickets/` covering:
  - 6 audit findings from `_skip_if_exists`/`_exclude` review (dead entries, missing exclusions, stale configs)
  - 6 mirrors of open GitHub issues (#99, #107, #109, #114, #116, #117)
- **`_typos.toml`**: exclude `.tickets/` (random ticket IDs trigger false positives)
- **`.gitignore`**: cleanup stale entries
- **`.pre-commit-config.yaml`**: add `no-commit-to-branch` hook protecting main