### PR TITLE
fix: remove .vscode/ from template, standardize on .editorconfig

### DIFF
--- a/.tickets/cub-z2ba.md
+++ b/.tickets/cub-z2ba.md
@@ -1,6 +1,6 @@
 ---
 id: cub-z2ba
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-02-07T11:28:19Z

--- a/copier.yml
+++ b/copier.yml
@@ -22,7 +22,6 @@ _skip_if_exists:
 - CHANGELOG.md
 - README.md
 - "src/{{ python_package_import_name }}/__init__.py"
-- "src/{{ python_package_import_name }}/cli.py"
 - "src/{{ python_package_import_name }}/_internal/__init__.py"
 - "src/{{ python_package_import_name }}/_internal/cli.py"
 - "src/{{ python_package_import_name }}/_internal/debug.py"


### PR DESCRIPTION
## Summary

Remove dead `_skip_if_exists` entry and clean up .vscode template files.

## Problem

1. `copier.yml` had `src/{{ python_package_import_name }}/cli.py` in `_skip_if_exists` but no such file is generated — the template generates `_internal/cli.py` instead (already covered separately)
2. `.vscode/` directory in the template contained stale configs referencing removed paths (`config/ruff.toml`, `config/pytest.ini`, `config/mypy.ini`) and non-existent poe tasks — deleted entirely in favor of `.editorconfig` which is editor-agnostic

## Changes

- Remove dead `cli.py` entry from `_skip_if_exists` in `copier.yml`
- Delete `project/.vscode/` (settings.json, launch.json, tasks.json) — standardize on `.editorconfig`

Closes cub-3q9c, cub-fypd, cub-z2ba