### PR TITLE
fix: exclude copier-update.yml when use_ci is false

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -37,6 +37,7 @@ _exclude:
 - "{% if repository_provider != 'github.com' %}.github{% endif %}"
 - "{% if repository_provider != 'gitlab.com' %}.gitlab-ci.yml{% endif %}"
 - "{% if not use_ci %}.github/workflows/ci.yml{% endif %}"
+- "{% if not use_ci %}.github/workflows/copier-update.yml{% endif %}"
 - "{% if not use_ci %}.gitlab-ci.yml{% endif %}"
 - "{% if not use_semantic_release %}.github/workflows/release.yml{% endif %}"
 - "{% if not include_template_dev_scripts %}scripts/verify-scaffold.sh{% endif %}"


### PR DESCRIPTION
## Summary

Exclude `copier-update.yml` workflow when `use_ci` is false.

## Problem

The `copier-update.yml` GitHub Actions workflow was not gated on the `use_ci` flag. Users who opted out of CI still received this workflow file, which would fail since they don't expect CI infrastructure.

## Solution

Add `copier-update.yml` to the conditional `_exclude` list alongside `ci.yml`.

## Changes

- `copier.yml`: add `{% if not use_ci %}.github/workflows/copier-update.yml{% endif %}` to `_exclude`

Closes cub-tvf1