### PR TITLE
fix: lychee exclude_path for own config file + remove no_progress from generated projects

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,6 +1,9 @@
 # Lychee link checker configuration
 # https://github.com/lycheeverse/lychee
 
+# Don't check the config file itself (regex patterns get parsed as URLs)
+exclude_path = [".lychee.toml"]
+
 # Exclude placeholder and example URLs in templates
 exclude = [
     '^https://example\.com',

--- a/.tickets/cub-3q9c.md
+++ b/.tickets/cub-3q9c.md
@@ -1,6 +1,6 @@
 ---
 id: cub-3q9c
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-02-07T11:28:13Z

--- a/.tickets/cub-fypd.md
+++ b/.tickets/cub-fypd.md
@@ -1,6 +1,6 @@
 ---
 id: cub-fypd
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-02-07T11:28:18Z

--- a/.tickets/cub-tvf1.md
+++ b/.tickets/cub-tvf1.md
@@ -1,6 +1,6 @@
 ---
 id: cub-tvf1
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-02-07T11:28:24Z

--- a/project/.lychee.toml
+++ b/project/.lychee.toml
@@ -1,6 +1,9 @@
 # Lychee link checker configuration
 # https://github.com/lycheeverse/lychee
 
+# Don't check the config file itself (regex patterns get parsed as URLs)
+exclude_path = [".lychee.toml"]
+
 # Exclude placeholder and example URLs
 exclude = [
     '^https://example\.com',
@@ -24,6 +27,3 @@ timeout = 30
 
 # Max concurrent requests
 max_concurrency = 16
-
-# Don't show progress bar (cleaner CI output)
-no_progress = true


### PR DESCRIPTION
## Summary

Fix lychee checking its own config file and remove `no_progress` from generated projects.

## Problem

1. Lychee parses regex patterns in `.lychee.toml` as URLs, causing false errors like `[ERROR] https://codecov/ | Network error: Connection failed` (GH #116)
2. Generated projects had `no_progress = true` hardcoded — user prefers seeing progress locally; CI workflows pass `--no-progress` separately

## Solution

- Add `exclude_path = [".lychee.toml"]` to both the template project's and generated project's `.lychee.toml`
- Remove `no_progress = true` from the generated project's config

## Changes

- `project/.lychee.toml`: add `exclude_path`, remove `no_progress`
- `.lychee.toml`: add `exclude_path`

Closes #116