### PR TITLE
fix: add main.py to _skip_if_exists for app type adopt

### DIFF
--- a/.tickets/cub-d91e.md
+++ b/.tickets/cub-d91e.md
@@ -1,6 +1,6 @@
 ---
 id: cub-d91e
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-02-07T11:29:33Z

--- a/.tickets/cub-wwhh.md
+++ b/.tickets/cub-wwhh.md
@@ -1,6 +1,6 @@
 ---
 id: cub-wwhh
-status: open
+status: closed
 deps: []
 links: []
 created: 2026-02-07T11:29:34Z

--- a/copier.yml
+++ b/copier.yml
@@ -32,6 +32,7 @@ _skip_if_exists:
 - "tests/test_cli.py"
 - "tests/test_api.py"
 - .gitignore
+- main.py
 
 _exclude:
 - "{% if repository_provider != 'github.com' %}.github{% endif %}"


### PR DESCRIPTION
## Summary

Add `main.py` to `_skip_if_exists` to protect existing app entry points during `copier adopt`.

## Problem

For app-type projects, `main.py` is user-owned code (their application entry point). During `copier adopt`, the template's scaffolding `main.py` would overwrite or create conflict markers against the user's actual application code.

This violates the stated philosophy in `copier.yml`: "Only truly user-owned files (README, CHANGELOG, source code) should be skipped."

## Solution

Add `main.py` to `_skip_if_exists`. During adopt, existing `main.py` files are preserved. For new projects, the template scaffolding is still generated.

## Changes

- `copier.yml`: add `main.py` to `_skip_if_exists`