### PR TITLE
feat: adjust lychee config for internal projects

### DIFF
--- a/project/.lychee.toml.jinja
+++ b/project/.lychee.toml.jinja
@@ -20,7 +20,12 @@ exclude_all_private = true
 include_mail = false
 
 # Accept common status codes
+{%- if project_visibility == 'internal' %}
+# 401 included for internal projects with auth-gated URLs
+accept = [200, 204, 301, 302, 401, 403, 429]
+{%- else %}
 accept = [200, 204, 301, 302, 403, 429]
+{%- endif %}
 
 # Timeout per request
 timeout = 30

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -889,6 +889,33 @@ class TestProjectVisibility:
             data = tomllib.load(f)
         assert "project" in data
 
+    # -- Lychee config --
+
+    def test_internal_lychee_accepts_401(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Internal projects .lychee.toml should accept 401 for auth-gated URLs."""
+        answers = {**copier_defaults, "project_visibility": "internal"}
+        project = generate_project(tmp_path, answers)
+
+        content = (project / ".lychee.toml").read_text()
+        assert "401" in content
+
+    def test_public_lychee_no_401(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Public projects .lychee.toml should not accept 401."""
+        answers = {**copier_defaults, "project_visibility": "public"}
+        project = generate_project(tmp_path, answers)
+
+        content = (project / ".lychee.toml").read_text()
+        assert "401" not in content
+
+    def test_internal_lychee_valid_toml(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Internal projects .lychee.toml should be valid TOML."""
+        answers = {**copier_defaults, "project_visibility": "internal"}
+        project = generate_project(tmp_path, answers)
+
+        with (project / ".lychee.toml").open("rb") as f:
+            data = tomllib.load(f)
+        assert "accept" in data
+
 
 class TestIntegration:
     """Integration tests that run uv sync and checks on generated project."""


### PR DESCRIPTION
## Summary

Adjust lychee link checker config for internal projects by accepting 401 (Unauthorized) status codes.

Closes #128

## Problem

Internal projects often have auth-gated URLs (SSO, private GitLab, internal wikis) that return 401. Lychee flags these as broken links, creating false positives in both pre-commit and CI.

## Solution

Convert `project/.lychee.toml` to a Jinja template. For internal projects, add 401 to the accepted status codes list.

## Changes

- **`project/.lychee.toml` → `project/.lychee.toml.jinja`** — now rendered by copier with `project_visibility` conditional
- **Internal projects**: `accept = [200, 204, 301, 302, 401, 403, 429]`
- **Public projects**: `accept = [200, 204, 301, 302, 403, 429]` (unchanged)
- **3 new tests** in `TestProjectVisibility`: 401 presence/absence by visibility, TOML validity

## Testing

```
poe test -k 'test_internal_lychee or test_public_lychee' -v  # 3 passed
poe lint-templates  # 292 checks, all valid
```