### PR TITLE
feat: support self-hosted repository URLs (repository_host)

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -100,6 +100,11 @@ repository_provider:
   - github.com
   - gitlab.com
 
+repository_host:
+  type: str
+  help: "Repository hostname (e.g. gitlab.company.com for self-hosted)"
+  default: "{{ repository_provider }}"
+
 repository_namespace:
   type: str
   help: Your repository namespace (username or organization)

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -1,12 +1,16 @@
 # {{ project_name }}
 
 {% if repository_provider == "github.com" -%}
-[![ci](https://github.com/{{ repository_namespace }}/{{ repository_name }}/workflows/ci/badge.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/actions?query=workflow%3Aci)
-[![release](https://github.com/{{ repository_namespace }}/{{ repository_name }}/workflows/release/badge.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/actions?query=workflow%3Arelease)
+[![ci](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/workflows/ci/badge.svg)](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/actions?query=workflow%3Aci)
+[![release](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/workflows/release/badge.svg)](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/actions?query=workflow%3Arelease)
 {% elif repository_provider == "gitlab.com" -%}
-[![pipeline](https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}/badges/main/pipeline.svg)](https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}/-/pipelines)
+[![pipeline](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/badges/main/pipeline.svg)](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/-/pipelines)
 {% endif -%}
-[![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://{{ repository_namespace }}.{{ repository_provider[:-4] }}.io/{{ repository_name }}/)
+{%- if repository_host in ['github.com', 'gitlab.com'] -%}
+[![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://{{ repository_namespace }}.{{ repository_host.rsplit('.', 1)[0] }}.io/{{ repository_name }}/)
+{%- else -%}
+[![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }})
+{%- endif %}
 [![pypi version](https://img.shields.io/pypi/v/{{ python_package_distribution_name }}.svg)](https://pypi.org/project/{{ python_package_distribution_name }}/)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
 {%- if repository_provider == "github.com" %}

--- a/project/mkdocs.yml.jinja
+++ b/project/mkdocs.yml.jinja
@@ -1,7 +1,11 @@
 site_name: "{{ project_name | replace('\\', '\\\\') | replace('\"', '\\\"') }}"
 site_description: "{{ project_description | replace('\\', '\\\\') | replace('\"', '\\\"') }}"
-site_url: "https://{{ repository_namespace }}.{{ repository_provider.rsplit('.', 1)[0] }}.io/{{ repository_name }}"
-repo_url: "https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}"
+{%- if repository_host in ['github.com', 'gitlab.com'] %}
+site_url: "https://{{ repository_namespace }}.{{ repository_host.rsplit('.', 1)[0] }}.io/{{ repository_name }}"
+{%- else %}
+site_url: "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}"
+{%- endif %}
+repo_url: "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}"
 repo_name: "{{ repository_namespace }}/{{ repository_name }}"
 site_dir: site
 watch: [mkdocs.yml, README.md,{% if project_visibility == 'public' %} CONTRIBUTING.md,{% endif %} CHANGELOG.md, src/{{ python_package_import_name }}]
@@ -148,7 +152,7 @@ plugins:
 extra:
   social:
   - icon: fontawesome/brands/{{ repository_provider.rsplit('.', 1)[0] }}
-    link: https://{{ repository_provider }}/{{ author_username }}
+    link: https://{{ repository_host }}/{{ author_username }}
   - icon: fontawesome/brands/python
     link: https://pypi.org/project/{{ python_package_distribution_name }}/
   analytics:

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -37,16 +37,22 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://{{ repository_namespace }}.{{ repository_provider.rsplit('.', 1)[0] }}.io/{{ repository_name }}"
-Documentation = "https://{{ repository_namespace }}.{{ repository_provider.rsplit('.', 1)[0] }}.io/{{ repository_name }}"
-Changelog = "https://{{ repository_namespace }}.{{ repository_provider.rsplit('.', 1)[0] }}.io/{{ repository_name }}/changelog"
-Repository = "https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}"
-Issues = "https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}/issues"
-{%- if repository_provider == "github.com" %}
-Discussions = "https://{{ repository_provider }}/{{ repository_namespace }}/{{ repository_name }}/discussions"
+{%- if repository_host in ['github.com', 'gitlab.com'] %}
+Homepage = "https://{{ repository_namespace }}.{{ repository_host.rsplit('.', 1)[0] }}.io/{{ repository_name }}"
+Documentation = "https://{{ repository_namespace }}.{{ repository_host.rsplit('.', 1)[0] }}.io/{{ repository_name }}"
+Changelog = "https://{{ repository_namespace }}.{{ repository_host.rsplit('.', 1)[0] }}.io/{{ repository_name }}/changelog"
+{%- else %}
+Homepage = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}"
+Documentation = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}"
+Changelog = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/changelog"
 {%- endif %}
-{%- if repository_provider == "github.com" and project_visibility == 'public' %}
-Funding = "https://{{ repository_provider }}/sponsors/{{ author_username }}"
+Repository = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}"
+Issues = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/issues"
+{%- if repository_host == "github.com" %}
+Discussions = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/discussions"
+{%- endif %}
+{%- if repository_host == "github.com" and project_visibility == 'public' %}
+Funding = "https://{{ repository_host }}/sponsors/{{ author_username }}"
 {%- endif %}
 
 {% if project_type == 'package' -%}

--- a/scripts/lint_templates.py
+++ b/scripts/lint_templates.py
@@ -64,6 +64,7 @@ def _build_context(overrides: dict) -> dict:
         "author_email": "test@example.com",
         "author_username": "testuser",
         "repository_provider": "github.com",
+        "repository_host": "github.com",
         "repository_namespace": "testuser",
         "repository_name": "my-test-project",
         "copyright_holder": "Test Author",
@@ -84,6 +85,9 @@ def _build_context(overrides: dict) -> dict:
         **_COMMON,
     }
     base.update(overrides)
+    # Auto-derive repository_host from repository_provider (mirrors copier.yml default)
+    if "repository_provider" in overrides and "repository_host" not in overrides:
+        base["repository_host"] = overrides["repository_provider"]
     # Derive slug-based fields if project_name changed
     if "project_name" in overrides and "repository_name" not in overrides:
         base["repository_name"] = slugify(overrides["project_name"])
@@ -103,6 +107,7 @@ CONTEXT_VARIANTS: dict[str, dict] = {
     }),
     "gitlab-ci": _build_context({
         "repository_provider": "gitlab.com",
+        "repository_host": "gitlab.com",
         "use_blacksmith_runners": False,
     }),
     "github-no-ci": _build_context({
@@ -113,6 +118,7 @@ CONTEXT_VARIANTS: dict[str, dict] = {
     }),
     "gitlab-no-ci": _build_context({
         "repository_provider": "gitlab.com",
+        "repository_host": "gitlab.com",
         "use_ci": False,
         "use_semantic_release": False,
         "publish_to_pypi": False,
@@ -133,6 +139,22 @@ CONTEXT_VARIANTS: dict[str, dict] = {
         "project_visibility": "internal",
         "publish_to_pypi": False,
         "use_polar": False,
+    }),
+    "internal-selfhosted-gitlab": _build_context({
+        "project_visibility": "internal",
+        "repository_provider": "gitlab.com",
+        "repository_host": "gitlab.company.com",
+        "publish_to_pypi": False,
+        "use_polar": False,
+        "use_blacksmith_runners": False,
+    }),
+    "internal-selfhosted-github": _build_context({
+        "project_visibility": "internal",
+        "repository_provider": "github.com",
+        "repository_host": "github.company.com",
+        "publish_to_pypi": False,
+        "use_polar": False,
+        "use_blacksmith_runners": False,
     }),
 }
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -916,6 +916,47 @@ class TestProjectVisibility:
             data = tomllib.load(f)
         assert "accept" in data
 
+    # -- Self-hosted repository URLs --
+
+    def test_selfhosted_pyproject_urls(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Self-hosted GitLab should use repository_host for URLs, no Pages pattern."""
+        answers = {
+            **copier_defaults,
+            "project_visibility": "internal",
+            "repository_provider": "gitlab.com",
+            "repository_host": "gitlab.company.com",
+        }
+        project = generate_project(tmp_path, answers)
+
+        content = (project / "pyproject.toml").read_text()
+        assert "gitlab.company.com" in content
+        # URLs should use self-hosted host, not gitlab.com directly
+        assert "://gitlab.com/" not in content
+        # No Pages URL pattern for self-hosted
+        assert ".gitlab.io" not in content
+
+    def test_selfhosted_mkdocs_urls(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Self-hosted GitLab should use repository_host in mkdocs.yml."""
+        answers = {
+            **copier_defaults,
+            "project_visibility": "internal",
+            "repository_provider": "gitlab.com",
+            "repository_host": "gitlab.company.com",
+        }
+        project = generate_project(tmp_path, answers)
+
+        content = (project / "mkdocs.yml").read_text()
+        assert "gitlab.company.com" in content
+        # No Pages URL pattern for self-hosted
+        assert ".gitlab.io" not in content
+
+    def test_standard_host_uses_pages_urls(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """Standard github.com/gitlab.com should use Pages URL pattern."""
+        project = generate_project(tmp_path, copier_defaults)
+
+        content = (project / "pyproject.toml").read_text()
+        assert ".github.io" in content
+
 
 class TestIntegration:
     """Integration tests that run uv sync and checks on generated project."""


### PR DESCRIPTION
## Summary

Add `repository_host` question to support self-hosted GitLab/GitHub Enterprise instances. URLs in generated projects now use the actual hostname instead of hardcoded `github.com`/`gitlab.com`.

Closes #129

## Problem

When using the template for projects on self-hosted GitLab (e.g. `gitlab.company.com`), all generated URLs incorrectly pointed to `gitlab.com`. Pages URLs used the `namespace.gitlab.io/repo` pattern which doesn't apply to self-hosted instances.

## Solution

- **New `repository_host` question** in `copier.yml` — defaults to `repository_provider` (transparent for standard github.com/gitlab.com users)
- **`repository_provider`** kept for **feature detection** (GitHub Actions, Discussions, FUNDING.yml, actionlint, icon selection)
- **`repository_host`** used for **URL building** (Repository, Issues, Discussions, Funding, badge links, social links)
- **Pages URLs** (Homepage, Documentation, Changelog) use the `.io` pattern only for known providers (`github.com`, `gitlab.com`); self-hosted falls back to repository URL

## Files changed

- **`copier.yml`** — new `repository_host` question
- **`project/pyproject.toml.jinja`** — `[project.urls]` uses `repository_host`, Pages conditional
- **`project/mkdocs.yml.jinja`** — `site_url`, `repo_url`, social links use `repository_host`
- **`project/README.md.jinja`** — badge URLs use `repository_host`, docs badge conditional
- **`scripts/lint_templates.py`** — `repository_host` in all contexts + new `internal-selfhosted` variant
- **`tests/test_template.py`** — 3 new tests: self-hosted pyproject URLs, mkdocs URLs, standard Pages pattern

## Testing

```
poe test -v               # 82 passed
poe lint-templates         # 37 templates × 10 variants = 311 checks, all valid
```