### PR TITLE
perf: speed up test suite with fixture caching and xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ fix = ["lint --fix", "format"]
 
 # Testing
 test = "pytest tests/ -v -m 'not slow'"
+test-fast = "pytest tests/ -v -m 'not slow' -n auto --dist loadscope"
 test-all = "pytest tests/ -v"
 test-cov = "pytest tests/ -v --cov=tests --cov-report=term-missing"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,95 @@
+"""Shared fixtures for copier template tests."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+@pytest.fixture
+def copier_defaults() -> dict:
+    """Default answers for copier prompts."""
+    return {
+        "project_name": "Test Project",
+        "project_description": "A test project",
+        "author_fullname": "Test Author",
+        "author_email": "test@example.com",
+        "author_username": "testuser",
+        "repository_namespace": "testuser",
+        "copyright_license": "MIT",
+        "use_ci": True,
+        "use_semantic_release": True,
+        "publish_to_pypi": False,
+        "use_blacksmith_runners": False,
+        "use_polar": False,
+    }
+
+
+def generate_project(
+    tmp_path: Path,
+    answers: dict,
+    project_type: str = "package",
+) -> Path:
+    """Generate a project using copier.
+
+    IMPORTANT: We use ``-r HEAD`` to test against the current commit, not the latest
+    git tag.  Copier resolves ``copier.yml`` (questions, defaults, ``_exclude`` patterns)
+    from the checked-out VCS ref — *not* from the working directory.  Dirty template
+    files under ``project/`` are overlaid automatically, but ``copier.yml`` itself is
+    read from the ref.  Without ``-r HEAD``, tests would silently run against the last
+    *tagged* release and miss any uncommitted configuration changes.
+    """
+    answers = {**answers, "project_type": project_type}
+
+    cmd = [
+        "copier",
+        "copy",
+        "--trust",
+        "-f",
+        "-r",
+        "HEAD",
+        str(REPO_ROOT),
+        str(tmp_path),
+    ]
+
+    for key, value in answers.items():
+        if isinstance(value, bool):
+            cmd.extend(["-d", f"{key}={str(value).lower()}"])
+        else:
+            cmd.extend(["-d", f"{key}={value}"])
+
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        pytest.fail(f"Copier failed: {result.stderr}")
+
+    return tmp_path
+
+
+def _cache_key(answers: dict, project_type: str) -> str:
+    """Create a stable cache key from answers dict and project type."""
+    merged = {**answers, "project_type": project_type}
+    return str(sorted(merged.items()))
+
+
+@pytest.fixture(scope="module")
+def project_factory(tmp_path_factory: pytest.TempPathFactory):
+    """Module-scoped factory that caches copier generations by answer key.
+
+    Tests sharing the same answer set reuse a single generated project instead of
+    invoking ``copier copy`` for each test.  All consuming tests MUST be read-only —
+    they may read files but must not modify the generated project directory.
+    """
+    cache: dict[str, Path] = {}
+
+    def _generate(answers: dict, project_type: str = "package") -> Path:
+        key = _cache_key(answers, project_type)
+        if key not in cache:
+            path = tmp_path_factory.mktemp("project")
+            cache[key] = generate_project(path, answers, project_type)
+        return cache[key]
+
+    return _generate

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -5,79 +5,21 @@ from __future__ import annotations
 import os
 import subprocess
 import tomllib
-from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
+from conftest import generate_project
 
-REPO_ROOT = Path(__file__).parent.parent
-
-
-@pytest.fixture
-def copier_defaults() -> dict:
-    """Default answers for copier prompts."""
-    return {
-        "project_name": "Test Project",
-        "project_description": "A test project",
-        "author_fullname": "Test Author",
-        "author_email": "test@example.com",
-        "author_username": "testuser",
-        "repository_namespace": "testuser",
-        "copyright_license": "MIT",
-        "use_ci": True,
-        "use_semantic_release": True,
-        "publish_to_pypi": False,
-        "use_blacksmith_runners": False,
-        "use_polar": False,
-    }
-
-
-def generate_project(
-    tmp_path: Path,
-    answers: dict,
-    project_type: str = "package",
-) -> Path:
-    """Generate a project using copier.
-
-    IMPORTANT: We use ``-r HEAD`` to test against the current commit, not the latest
-    git tag.  Copier resolves ``copier.yml`` (questions, defaults, ``_exclude`` patterns)
-    from the checked-out VCS ref — *not* from the working directory.  Dirty template
-    files under ``project/`` are overlaid automatically, but ``copier.yml`` itself is
-    read from the ref.  Without ``-r HEAD``, tests would silently run against the last
-    *tagged* release and miss any uncommitted configuration changes.
-    """
-    answers = {**answers, "project_type": project_type}
-
-    cmd = [
-        "copier",
-        "copy",
-        "--trust",
-        "-f",
-        "-r",
-        "HEAD",
-        str(REPO_ROOT),
-        str(tmp_path),
-    ]
-
-    for key, value in answers.items():
-        if isinstance(value, bool):
-            cmd.extend(["-d", f"{key}={str(value).lower()}"])
-        else:
-            cmd.extend(["-d", f"{key}={value}"])
-
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    if result.returncode != 0:
-        pytest.fail(f"Copier failed: {result.stderr}")
-
-    return tmp_path
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestProjectTypes:
     """Test different project types generate correctly."""
 
-    def test_package_type_has_cli(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_package_type_has_cli(self, copier_defaults: dict, project_factory) -> None:
         """Package type should have CLI entry point."""
-        project = generate_project(tmp_path, copier_defaults, "package")
+        project = project_factory(copier_defaults, "package")
 
         pyproject = project / "pyproject.toml"
         assert pyproject.exists()
@@ -86,17 +28,17 @@ class TestProjectTypes:
         assert "[project.scripts]" in content
         assert "test-project" in content  # CLI name from slugified project_name
 
-    def test_lib_type_no_cli(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_lib_type_no_cli(self, copier_defaults: dict, project_factory) -> None:
         """Library type should not have CLI entry point."""
-        project = generate_project(tmp_path, copier_defaults, "lib")
+        project = project_factory(copier_defaults, "lib")
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "[project.scripts]" not in content
 
-    def test_app_type_has_main(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_app_type_has_main(self, copier_defaults: dict, project_factory) -> None:
         """App type should have main.py."""
-        project = generate_project(tmp_path, copier_defaults, "app")
+        project = project_factory(copier_defaults, "app")
 
         main_py = project / "main.py"
         assert main_py.exists()
@@ -105,77 +47,77 @@ class TestProjectTypes:
 class TestCoreFiles:
     """Test core files are generated correctly."""
 
-    def test_pyproject_toml_exists(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_pyproject_toml_exists(self, copier_defaults: dict, project_factory) -> None:
         """pyproject.toml should exist."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
         assert (project / "pyproject.toml").exists()
 
-    def test_precommit_config_exists(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_precommit_config_exists(self, copier_defaults: dict, project_factory) -> None:
         """Pre-commit config should exist."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
         assert (project / "prek.toml").exists()
 
-    def test_ruff_config_in_pyproject(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_ruff_config_in_pyproject(self, copier_defaults: dict, project_factory) -> None:
         """Ruff config should be in pyproject.toml."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "[tool.ruff]" in content
         assert "[tool.ruff.lint]" in content
 
-    def test_src_directory_exists(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_src_directory_exists(self, copier_defaults: dict, project_factory) -> None:
         """src directory should exist."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
         assert (project / "src").is_dir()
 
-    def test_tests_directory_exists(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_tests_directory_exists(self, copier_defaults: dict, project_factory) -> None:
         """tests directory should exist."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
         assert (project / "tests").is_dir()
 
 
 class TestCIConfiguration:
     """Test CI configuration options."""
 
-    def test_ci_enabled_creates_workflow(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_ci_enabled_creates_workflow(self, copier_defaults: dict, project_factory) -> None:
         """CI enabled should create workflow file."""
         answers = {**copier_defaults, "use_ci": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
         assert (project / ".github" / "workflows" / "ci.yml").exists()
 
-    def test_ci_disabled_no_workflow(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_ci_disabled_no_workflow(self, copier_defaults: dict, project_factory) -> None:
         """CI disabled should not create workflow file."""
         answers = {**copier_defaults, "use_ci": False}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
         assert not (project / ".github" / "workflows" / "ci.yml").exists()
 
-    def test_semantic_release_creates_workflow(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_semantic_release_creates_workflow(self, copier_defaults: dict, project_factory) -> None:
         """Semantic release enabled should create release workflow."""
         answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
         assert (project / ".github" / "workflows" / "release.yml").exists()
 
-    def test_semantic_release_disabled_no_workflow(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_semantic_release_disabled_no_workflow(self, copier_defaults: dict, project_factory) -> None:
         """Semantic release disabled should not create release workflow."""
         answers = {**copier_defaults, "use_ci": True, "use_semantic_release": False}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
         assert not (project / ".github" / "workflows" / "release.yml").exists()
 
 
 class TestPythonVersion:
     """Test Python version configuration."""
 
-    def test_requires_python_314(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_requires_python_314(self, copier_defaults: dict, project_factory) -> None:
         """Generated project should require Python 3.14+."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert 'requires-python = ">=3.14"' in content
 
-    def test_ruff_target_py314(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_ruff_target_py314(self, copier_defaults: dict, project_factory) -> None:
         """Ruff should target Python 3.14."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
@@ -185,25 +127,25 @@ class TestPythonVersion:
 class TestPreCommitConfig:
     """Test pre-commit configuration."""
 
-    def test_prek_version(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_prek_version(self, copier_defaults: dict, project_factory) -> None:
         """Pre-commit config should have correct prek version."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         config = project / "prek.toml"
         content = config.read_text()
         assert 'minimum_prek_version = "0.3.2"' in content
 
-    def test_has_gitleaks(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_has_gitleaks(self, copier_defaults: dict, project_factory) -> None:
         """Pre-commit config should have gitleaks."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         config = project / "prek.toml"
         content = config.read_text()
         assert "gitleaks" in content
 
-    def test_no_pyupgrade(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_no_pyupgrade(self, copier_defaults: dict, project_factory) -> None:
         """Pre-commit config should not have pyupgrade (replaced by ruff UP)."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         config = project / "prek.toml"
         content = config.read_text()
@@ -213,25 +155,25 @@ class TestPreCommitConfig:
 class TestDependencies:
     """Test dependency configuration."""
 
-    def test_no_yore_dependency(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_no_yore_dependency(self, copier_defaults: dict, project_factory) -> None:
         """Generated project should not have yore dependency."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "yore" not in content
 
-    def test_no_tomli_dependency(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_no_tomli_dependency(self, copier_defaults: dict, project_factory) -> None:
         """Generated project should not have tomli dependency."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "tomli" not in content
 
-    def test_prek_version_updated(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_prek_version_updated(self, copier_defaults: dict, project_factory) -> None:
         """prek dependency should be >= 0.3.1."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
@@ -241,21 +183,21 @@ class TestDependencies:
 class TestCIWorkflows:
     """Test CI workflow configuration (from smoke_test.sh assertions)."""
 
-    def test_ci_has_setup_uv(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_ci_has_setup_uv(self, copier_defaults: dict, project_factory) -> None:
         """CI workflow should use setup-uv action."""
         answers = {**copier_defaults, "use_ci": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         ci_yml = project / ".github" / "workflows" / "ci.yml"
         content = ci_yml.read_text()
         assert "astral-sh/setup-uv" in content
 
-    def test_ci_poe_tasks_exist_in_pyproject(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_ci_poe_tasks_exist_in_pyproject(self, copier_defaults: dict, project_factory) -> None:
         """All poe tasks referenced in CI workflow should exist in pyproject.toml."""
         import re
 
         answers = {**copier_defaults, "use_ci": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         ci_yml = project / ".github" / "workflows" / "ci.yml"
         pyproject = project / "pyproject.toml"
@@ -274,65 +216,65 @@ class TestCIWorkflows:
                 f"poe task '{task}' referenced in CI but not defined in pyproject.toml"
             )
 
-    def test_release_has_semantic_release(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_release_has_semantic_release(self, copier_defaults: dict, project_factory) -> None:
         """Release workflow should use semantic-release."""
         answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         release_yml = project / ".github" / "workflows" / "release.yml"
         content = release_yml.read_text()
         assert "semantic-release" in content
 
-    def test_release_has_uv_publish(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_release_has_uv_publish(self, copier_defaults: dict, project_factory) -> None:
         """Release workflow should use uv publish."""
         answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True, "publish_to_pypi": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         release_yml = project / ".github" / "workflows" / "release.yml"
         content = release_yml.read_text()
         assert "uv publish" in content
 
-    def test_pyproject_has_build_system(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_pyproject_has_build_system(self, copier_defaults: dict, project_factory) -> None:
         """pyproject.toml should have build-system section."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "[build-system]" in content
 
-    def test_pypi_false_excludes_classifiers_and_keywords(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_pypi_false_excludes_classifiers_and_keywords(self, copier_defaults: dict, project_factory) -> None:
         """When publish_to_pypi is false, classifiers and keywords should not be in pyproject.toml."""
         answers = {**copier_defaults, "publish_to_pypi": False}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "classifiers" not in content
         assert "keywords" not in content
 
-    def test_pypi_true_includes_classifiers_and_keywords(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_pypi_true_includes_classifiers_and_keywords(self, copier_defaults: dict, project_factory) -> None:
         """When publish_to_pypi is true, classifiers and keywords should be in pyproject.toml."""
         answers = {**copier_defaults, "publish_to_pypi": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "classifiers" in content
         assert "keywords" in content
 
-    def test_pypi_true_has_environment(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_pypi_true_has_environment(self, copier_defaults: dict, project_factory) -> None:
         """When publish_to_pypi is true, release workflow should have environment: pypi."""
         answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True, "publish_to_pypi": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         release_yml = project / ".github" / "workflows" / "release.yml"
         content = release_yml.read_text()
         assert "environment: pypi" in content
 
-    def test_pypi_false_no_environment(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_pypi_false_no_environment(self, copier_defaults: dict, project_factory) -> None:
         """When publish_to_pypi is false, release workflow should not have environment: pypi."""
         answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True, "publish_to_pypi": False}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         release_yml = project / ".github" / "workflows" / "release.yml"
         content = release_yml.read_text()
@@ -348,7 +290,7 @@ class TestCascadingBooleanDefaults:
     prevent them from being asked.
     """
 
-    def test_use_ci_false_no_classifiers(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_ci_false_no_classifiers(self, copier_defaults: dict, project_factory) -> None:
         """When use_ci=false (without explicit publish_to_pypi), classifiers should not appear."""
         answers = {
             **copier_defaults,
@@ -358,14 +300,14 @@ class TestCascadingBooleanDefaults:
         answers.pop("use_semantic_release", None)
         answers.pop("publish_to_pypi", None)
         answers.pop("use_blacksmith_runners", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "classifiers" not in content
         assert "keywords" not in content
 
-    def test_use_ci_false_no_release_workflow(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_ci_false_no_release_workflow(self, copier_defaults: dict, project_factory) -> None:
         """When use_ci=false, release.yml should not be created."""
         answers = {
             **copier_defaults,
@@ -374,12 +316,12 @@ class TestCascadingBooleanDefaults:
         answers.pop("use_semantic_release", None)
         answers.pop("publish_to_pypi", None)
         answers.pop("use_blacksmith_runners", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert not (project / ".github" / "workflows" / "release.yml").exists()
         assert not (project / ".github" / "workflows" / "ci.yml").exists()
 
-    def test_use_ci_false_no_pypi_environment(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_ci_false_no_pypi_environment(self, copier_defaults: dict, project_factory) -> None:
         """When use_ci=false, no PyPI-related config should appear in release workflow."""
         answers = {
             **copier_defaults,
@@ -388,12 +330,12 @@ class TestCascadingBooleanDefaults:
         answers.pop("use_semantic_release", None)
         answers.pop("publish_to_pypi", None)
         answers.pop("use_blacksmith_runners", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         # No release workflow at all
         assert not (project / ".github" / "workflows" / "release.yml").exists()
 
-    def test_use_ci_false_no_matrix_in_nonexistent_ci(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_ci_false_no_matrix_in_nonexistent_ci(self, copier_defaults: dict, project_factory) -> None:
         """When use_ci=false, CI workflow should not exist (no matrix testing)."""
         answers = {
             **copier_defaults,
@@ -402,11 +344,11 @@ class TestCascadingBooleanDefaults:
         answers.pop("use_semantic_release", None)
         answers.pop("publish_to_pypi", None)
         answers.pop("use_blacksmith_runners", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert not (project / ".github" / "workflows" / "ci.yml").exists()
 
-    def test_use_ci_true_defaults_include_classifiers(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_ci_true_defaults_include_classifiers(self, copier_defaults: dict, project_factory) -> None:
         """When use_ci=true with defaults, classifiers should appear (positive case)."""
         answers = {
             **copier_defaults,
@@ -416,14 +358,14 @@ class TestCascadingBooleanDefaults:
         answers.pop("use_semantic_release", None)
         answers.pop("publish_to_pypi", None)
         answers.pop("use_blacksmith_runners", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "classifiers" in content
         assert "keywords" in content
 
-    def test_use_ci_true_defaults_create_all_workflows(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_ci_true_defaults_create_all_workflows(self, copier_defaults: dict, project_factory) -> None:
         """When use_ci=true with defaults, both CI and release workflows should exist."""
         answers = {
             **copier_defaults,
@@ -432,12 +374,12 @@ class TestCascadingBooleanDefaults:
         answers.pop("use_semantic_release", None)
         answers.pop("publish_to_pypi", None)
         answers.pop("use_blacksmith_runners", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert (project / ".github" / "workflows" / "ci.yml").exists()
         assert (project / ".github" / "workflows" / "release.yml").exists()
 
-    def test_use_semantic_release_false_no_classifiers(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_semantic_release_false_no_classifiers(self, copier_defaults: dict, project_factory) -> None:
         """When use_semantic_release=false, publish_to_pypi should cascade to false."""
         answers = {
             **copier_defaults,
@@ -445,14 +387,14 @@ class TestCascadingBooleanDefaults:
             "use_semantic_release": False,
         }
         answers.pop("publish_to_pypi", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "classifiers" not in content
         assert "keywords" not in content
 
-    def test_use_ci_false_no_semantic_release_config(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_ci_false_no_semantic_release_config(self, copier_defaults: dict, project_factory) -> None:
         """When use_ci=false, semantic_release config and maintain group should not appear."""
         answers = {
             **copier_defaults,
@@ -461,7 +403,7 @@ class TestCascadingBooleanDefaults:
         answers.pop("use_semantic_release", None)
         answers.pop("publish_to_pypi", None)
         answers.pop("use_blacksmith_runners", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
@@ -469,7 +411,7 @@ class TestCascadingBooleanDefaults:
         assert "python-semantic-release" not in content
         assert "maintain" not in content
 
-    def test_use_semantic_release_false_no_semantic_release_config(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_semantic_release_false_no_semantic_release_config(self, copier_defaults: dict, project_factory) -> None:
         """When use_semantic_release=false explicitly, semantic_release config should not appear."""
         answers = {
             **copier_defaults,
@@ -477,7 +419,7 @@ class TestCascadingBooleanDefaults:
             "use_semantic_release": False,
         }
         answers.pop("publish_to_pypi", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
@@ -485,14 +427,14 @@ class TestCascadingBooleanDefaults:
         assert "python-semantic-release" not in content
         assert "maintain" not in content
 
-    def test_use_semantic_release_true_has_config(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_use_semantic_release_true_has_config(self, copier_defaults: dict, project_factory) -> None:
         """When use_semantic_release=true, semantic_release config and maintain group should appear."""
         answers = {
             **copier_defaults,
             "use_ci": True,
             "use_semantic_release": True,
         }
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
@@ -507,60 +449,60 @@ class TestTemplateCleanup:
     Regression tests for #49 (docs-deploy) and #50 (coverage.paths, ty.src.exclude).
     """
 
-    def test_no_coverage_paths(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_no_coverage_paths(self, copier_defaults: dict, project_factory) -> None:
         """Generated pyproject.toml should not have [tool.coverage.paths]."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "[tool.coverage.paths]" not in content
 
-    def test_coverage_excludes_main_guard(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_coverage_excludes_main_guard(self, copier_defaults: dict, project_factory) -> None:
         """Coverage exclude_lines should include if __name__ == '__main__' (#57)."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "if __name__ == .__main__." in content
 
-    def test_description_with_quotes(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_description_with_quotes(self, copier_defaults: dict, project_factory) -> None:
         """Project description containing double quotes should produce valid TOML."""
         answers = {**copier_defaults, "project_description": 'Helps you "close the loop"'}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         with pyproject.open("rb") as f:
             data = tomllib.load(f)
         assert data["project"]["description"] == 'Helps you "close the loop"'
 
-    def test_envrc_activates_venv(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_envrc_activates_venv(self, copier_defaults: dict, project_factory) -> None:
         """Generated .envrc should activate the uv-managed virtualenv (#59)."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         envrc = project / ".envrc"
         content = envrc.read_text()
         assert "VIRTUAL_ENV" in content
 
-    def test_no_ty_src_exclude_fixtures(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_no_ty_src_exclude_fixtures(self, copier_defaults: dict, project_factory) -> None:
         """Generated pyproject.toml should not have ty.src.exclude for fixtures."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "tests/fixtures" not in content
 
-    def test_github_has_docs_deploy(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_github_has_docs_deploy(self, copier_defaults: dict, project_factory) -> None:
         """GitHub projects should have docs-deploy poe task."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "docs-deploy" in content
         assert "gh-deploy" in content
 
-    def test_github_has_gh_cli_tasks(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_github_has_gh_cli_tasks(self, copier_defaults: dict, project_factory) -> None:
         """GitHub projects should have gh CLI poe tasks."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
@@ -575,17 +517,17 @@ class TestGitLabSupport:
     Regression tests for #51 (GitHub-specific files) and #52 (GitLab support).
     """
 
-    def test_gitlab_no_github_directory(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_no_github_directory(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects should not have .github/ directory."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert not (project / ".github").exists()
 
-    def test_gitlab_has_gitlab_ci(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_has_gitlab_ci(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects with CI should have .gitlab-ci.yml."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com", "use_ci": True}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert (project / ".gitlab-ci.yml").exists()
         content = (project / ".gitlab-ci.yml").read_text()
@@ -593,7 +535,7 @@ class TestGitLabSupport:
         assert "test" in content
         assert "pages" in content
 
-    def test_gitlab_no_ci_no_gitlab_ci(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_no_ci_no_gitlab_ci(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects without CI should not have .gitlab-ci.yml."""
         answers = {
             **copier_defaults,
@@ -603,24 +545,24 @@ class TestGitLabSupport:
         answers.pop("use_semantic_release", None)
         answers.pop("publish_to_pypi", None)
         answers.pop("use_blacksmith_runners", None)
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert not (project / ".gitlab-ci.yml").exists()
         assert not (project / ".github").exists()
 
-    def test_gitlab_no_actionlint_in_precommit(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_no_actionlint_in_precommit(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects should not have actionlint pre-commit hook."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         config = project / "prek.toml"
         content = config.read_text()
         assert "actionlint" not in content
 
-    def test_gitlab_precommit_valid_toml(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_precommit_valid_toml(self, copier_defaults: dict, project_factory) -> None:
         """GitLab prek.toml should be valid TOML with expected repos."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         config = project / "prek.toml"
         with config.open("rb") as f:
@@ -628,19 +570,19 @@ class TestGitLabSupport:
         repo_urls = [r["repo"] for r in data["repos"]]
         assert "https://github.com/crate-ci/typos" in repo_urls
 
-    def test_gitlab_no_giscus(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_no_giscus(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects should not have Giscus comments."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         comments = project / "docs" / ".overrides" / "partials" / "comments.html"
         content = comments.read_text()
         assert "giscus" not in content
 
-    def test_gitlab_no_gh_cli_tasks(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_no_gh_cli_tasks(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects should not have gh CLI poe tasks."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
@@ -648,38 +590,38 @@ class TestGitLabSupport:
         assert "gh run list" not in content
         assert "docs-deploy" not in content
 
-    def test_gitlab_no_discussions_url(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_no_discussions_url(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects should not have Discussions URL."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "Discussions" not in content
 
-    def test_gitlab_has_pipeline_badge(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_has_pipeline_badge(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects should have pipeline badge in README."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         readme = project / "README.md"
         content = readme.read_text()
         assert "pipeline" in content
         assert "gitlab.com" in content
 
-    def test_gitlab_has_gitlab_urls(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_gitlab_has_gitlab_urls(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects should have gitlab.com URLs in pyproject.toml."""
         answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "gitlab.com" in content
         assert "gitlab.io" in content
 
-    def test_github_still_has_github_directory(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_github_still_has_github_directory(self, copier_defaults: dict, project_factory) -> None:
         """GitHub projects should still have .github/ directory (positive case)."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         assert (project / ".github").exists()
         assert not (project / ".gitlab-ci.yml").exists()
@@ -688,28 +630,28 @@ class TestGitLabSupport:
 class TestTyperOption:
     """Test typer CLI option."""
 
-    def test_typer_enabled_has_typer_dependency(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_typer_enabled_has_typer_dependency(self, copier_defaults: dict, project_factory) -> None:
         """Typer enabled should add typer dependency."""
         answers = {**copier_defaults, "use_typer": True}
-        project = generate_project(tmp_path, answers, "package")
+        project = project_factory(answers, "package")
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert '"typer>=' in content
 
-    def test_typer_disabled_no_typer_dependency(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_typer_disabled_no_typer_dependency(self, copier_defaults: dict, project_factory) -> None:
         """Typer disabled should not add typer dependency."""
         answers = {**copier_defaults, "use_typer": False}
-        project = generate_project(tmp_path, answers, "package")
+        project = project_factory(answers, "package")
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "typer" not in content
 
-    def test_typer_enabled_uses_typer_in_cli(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_typer_enabled_uses_typer_in_cli(self, copier_defaults: dict, project_factory) -> None:
         """Typer enabled should use typer in cli.py."""
         answers = {**copier_defaults, "use_typer": True}
-        project = generate_project(tmp_path, answers, "package")
+        project = project_factory(answers, "package")
 
         cli_py = project / "src" / "test_project" / "_internal" / "cli.py"
         content = cli_py.read_text()
@@ -741,83 +683,83 @@ class TestProjectVisibility:
         "docs/license.md",
     ]
 
-    def test_public_has_community_files(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_public_has_community_files(self, copier_defaults: dict, project_factory) -> None:
         """Public projects should have all community files."""
         answers = {**copier_defaults, "project_visibility": "public"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         for f in self.COMMUNITY_FILES:
             assert (project / f).exists(), f"{f} should exist for public projects"
         for f in self.COMMUNITY_DOCS:
             assert (project / f).exists(), f"{f} should exist for public projects"
 
-    def test_internal_no_community_files(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_no_community_files(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects should not have community files."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         for f in self.COMMUNITY_FILES:
             assert not (project / f).exists(), f"{f} should NOT exist for internal projects"
         for f in self.COMMUNITY_DOCS:
             assert not (project / f).exists(), f"{f} should NOT exist for internal projects"
 
-    def test_internal_no_funding_yml(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_no_funding_yml(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects should not have FUNDING.yml."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert not (project / ".github" / "FUNDING.yml").exists()
 
-    def test_public_has_funding_yml(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_public_has_funding_yml(self, copier_defaults: dict, project_factory) -> None:
         """Public projects should have FUNDING.yml."""
         answers = {**copier_defaults, "project_visibility": "public"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert (project / ".github" / "FUNDING.yml").exists()
 
     # -- pyproject.toml license metadata --
 
-    def test_internal_no_license_in_pyproject(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_no_license_in_pyproject(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects should not have license metadata in pyproject.toml."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "pyproject.toml").read_text()
         assert "license = " not in content
         assert "license-files" not in content
 
-    def test_public_has_license_in_pyproject(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_public_has_license_in_pyproject(self, copier_defaults: dict, project_factory) -> None:
         """Public projects should have license metadata in pyproject.toml."""
         answers = {**copier_defaults, "project_visibility": "public"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "pyproject.toml").read_text()
         assert 'license = "MIT"' in content
         assert "license-files" in content
 
-    def test_internal_no_funding_url_in_pyproject(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_no_funding_url_in_pyproject(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects should not have Funding URL in pyproject.toml."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "pyproject.toml").read_text()
         assert "Funding" not in content
         assert "sponsors" not in content
 
-    def test_public_has_funding_url_in_pyproject(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_public_has_funding_url_in_pyproject(self, copier_defaults: dict, project_factory) -> None:
         """Public projects should have Funding URL in pyproject.toml."""
         answers = {**copier_defaults, "project_visibility": "public"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "pyproject.toml").read_text()
         assert "Funding" in content
 
     # -- mkdocs.yml nav --
 
-    def test_internal_mkdocs_no_community_nav(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_mkdocs_no_community_nav(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects mkdocs.yml should not have community pages in nav."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "mkdocs.yml").read_text()
         assert "License:" not in content
@@ -825,38 +767,38 @@ class TestProjectVisibility:
         assert "Code of Conduct:" not in content
         assert "copyright:" not in content.lower().split("nav")[0]  # no copyright line
 
-    def test_public_mkdocs_has_community_nav(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_public_mkdocs_has_community_nav(self, copier_defaults: dict, project_factory) -> None:
         """Public projects mkdocs.yml should have community pages in nav."""
         answers = {**copier_defaults, "project_visibility": "public"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "mkdocs.yml").read_text()
         assert "License: license.md" in content
         assert "Contributing: contributing.md" in content
         assert "Code of Conduct: code_of_conduct.md" in content
 
-    def test_internal_mkdocs_no_copyright(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_mkdocs_no_copyright(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects mkdocs.yml should not have copyright line."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "mkdocs.yml").read_text()
         assert "copyright:" not in content
 
-    def test_public_mkdocs_has_copyright(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_public_mkdocs_has_copyright(self, copier_defaults: dict, project_factory) -> None:
         """Public projects mkdocs.yml should have copyright line."""
         answers = {**copier_defaults, "project_visibility": "public"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "mkdocs.yml").read_text()
         assert "copyright:" in content
 
     # -- Core files still present for internal --
 
-    def test_internal_still_has_core_files(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_still_has_core_files(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects should still have core project files."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         assert (project / "pyproject.toml").exists()
         assert (project / "README.md").exists()
@@ -869,21 +811,21 @@ class TestProjectVisibility:
 
     # -- mkdocs.yml is valid YAML for both --
 
-    def test_internal_mkdocs_valid_yaml(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_mkdocs_valid_yaml(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects mkdocs.yml should be valid YAML."""
         import yaml
 
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "mkdocs.yml").read_text()
         data = yaml.compose(content)
         assert data is not None
 
-    def test_internal_pyproject_valid_toml(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_pyproject_valid_toml(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects pyproject.toml should be valid TOML."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         with (project / "pyproject.toml").open("rb") as f:
             data = tomllib.load(f)
@@ -891,26 +833,26 @@ class TestProjectVisibility:
 
     # -- Lychee config --
 
-    def test_internal_lychee_accepts_401(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_lychee_accepts_401(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects .lychee.toml should accept 401 for auth-gated URLs."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / ".lychee.toml").read_text()
         assert "401" in content
 
-    def test_public_lychee_no_401(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_public_lychee_no_401(self, copier_defaults: dict, project_factory) -> None:
         """Public projects .lychee.toml should not accept 401."""
         answers = {**copier_defaults, "project_visibility": "public"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / ".lychee.toml").read_text()
         assert "401" not in content
 
-    def test_internal_lychee_valid_toml(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_internal_lychee_valid_toml(self, copier_defaults: dict, project_factory) -> None:
         """Internal projects .lychee.toml should be valid TOML."""
         answers = {**copier_defaults, "project_visibility": "internal"}
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         with (project / ".lychee.toml").open("rb") as f:
             data = tomllib.load(f)
@@ -918,7 +860,7 @@ class TestProjectVisibility:
 
     # -- Self-hosted repository URLs --
 
-    def test_selfhosted_pyproject_urls(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_selfhosted_pyproject_urls(self, copier_defaults: dict, project_factory) -> None:
         """Self-hosted GitLab should use repository_host for URLs, no Pages pattern."""
         answers = {
             **copier_defaults,
@@ -926,7 +868,7 @@ class TestProjectVisibility:
             "repository_provider": "gitlab.com",
             "repository_host": "gitlab.company.com",
         }
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "pyproject.toml").read_text()
         assert "gitlab.company.com" in content
@@ -935,7 +877,7 @@ class TestProjectVisibility:
         # No Pages URL pattern for self-hosted
         assert ".gitlab.io" not in content
 
-    def test_selfhosted_mkdocs_urls(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_selfhosted_mkdocs_urls(self, copier_defaults: dict, project_factory) -> None:
         """Self-hosted GitLab should use repository_host in mkdocs.yml."""
         answers = {
             **copier_defaults,
@@ -943,16 +885,16 @@ class TestProjectVisibility:
             "repository_provider": "gitlab.com",
             "repository_host": "gitlab.company.com",
         }
-        project = generate_project(tmp_path, answers)
+        project = project_factory(answers)
 
         content = (project / "mkdocs.yml").read_text()
         assert "gitlab.company.com" in content
         # No Pages URL pattern for self-hosted
         assert ".gitlab.io" not in content
 
-    def test_standard_host_uses_pages_urls(self, tmp_path: Path, copier_defaults: dict) -> None:
+    def test_standard_host_uses_pages_urls(self, copier_defaults: dict, project_factory) -> None:
         """Standard github.com/gitlab.com should use Pages URL pattern."""
-        project = generate_project(tmp_path, copier_defaults)
+        project = project_factory(copier_defaults)
 
         content = (project / "pyproject.toml").read_text()
         assert ".github.io" in content


### PR DESCRIPTION
## Summary

Speed up the test suite from **258s → 53s** (5x) via module-scoped fixture caching and pytest-xdist parallel execution.

Closes #134

## Problem

All 82 tests spawned independent `copier copy` subprocesses (~3s each), even when many tests used identical answer sets. The "defaults" config alone was regenerated ~30 times.

## Solution

### 1. Module-scoped project factory (258s → 64s, 4x)

New `tests/conftest.py` with a `project_factory` fixture that caches copier generations by answer key. Tests sharing the same answers reuse a single generated project. All tests are read-only (file assertions only), so shared state is safe.

- 82 copier invocations → ~22 unique configurations
- `copier_defaults` fixture and `generate_project` moved to conftest
- `TestIntegration` keeps `tmp_path` since it mutates (git init, uv sync)

### 2. pytest-xdist parallel execution (64s → 53s, another 20%)

New `poe test-fast` task: `pytest -n auto --dist loadscope`
- `--dist loadscope` keeps same-class tests on the same worker → module-scoped cache is effective per-worker
- `poe test` remains sequential for debugging
- `pytest-xdist 3.8.0` was already installed

## Results

| Mode | Time | Speedup |
|---|---|---|
| Before (no caching) | 258s | baseline |
| `poe test` (caching) | 64s | **4x** |
| `poe test-fast` (caching + xdist) | 53s | **5x** |

## Files changed

- **`tests/conftest.py`** (new) — `copier_defaults`, `generate_project`, `project_factory` fixtures
- **`tests/test_template.py`** — all 80 non-integration tests migrated to `project_factory`
- **`pyproject.toml`** — new `poe test-fast` task