### PR TITLE
fix: point sync-with-uv at fork with prek.toml support

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -20,8 +20,8 @@ hooks = [
 ]
 
 [[repos]]
-repo = "https://github.com/tsvikas/sync-with-uv"
-rev = "v0.5.0"
+repo = "https://github.com/detailobsessed/sync-with-uv"
+rev = "v0.6.0-prek"
 hooks = [{ id = "sync-with-uv", priority = 0 }]
 
 [[repos]]


### PR DESCRIPTION
## Summary

Point the `sync-with-uv` pre-commit hook at [our fork](https://github.com/detailobsessed/sync-with-uv) which adds `prek.toml` support.

## Problem

After migrating from `.pre-commit-config.yaml` to `prek.toml`, the `sync-with-uv` hook fails with:

```
".pre-commit-config.yaml" does not exist.
```

Tracked in #135.

## Fix

- Forked `sync-with-uv` and added prek.toml support ([upstream PR](https://github.com/tsvikas/sync-with-uv/pull/35))
- Point `prek.toml` at `detailobsessed/sync-with-uv@v0.6.0-prek`
- **Temporary** — switch back to `tsvikas/sync-with-uv` once upstream merges and releases

## Verification

The `sync-with-uv` hook now passes during pre-commit.