### PR TITLE
feat: add sync-with-uv hook to generated projects

### DIFF
--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -19,6 +19,11 @@ hooks = [
 ]
 
 [[repos]]
+repo = "https://github.com/detailobsessed/sync-with-uv"
+rev = ""  # prek autoupdate will fill this
+hooks = [{ id = "sync-with-uv", priority = 0 }]
+
+[[repos]]
 repo = "https://github.com/gitleaks/gitleaks"
 rev = ""  # prek autoupdate will fill this
 hooks = [{ id = "gitleaks", priority = 1 }]


### PR DESCRIPTION
## Summary

Add the `sync-with-uv` hook to the `prek.toml.jinja` template so that **generated projects** automatically get hook version syncing with `uv.lock`.

## Problem

The repo's own `prek.toml` was updated in PR #137 to use `sync-with-uv`, but the template was missing it — meaning newly generated projects wouldn't benefit from automatic hook version syncing.

## Fix

Add `sync-with-uv` (from our fork with prek.toml support) to `project/prek.toml.jinja` with `priority = 0` so it runs early, before other hooks.

## Notes

- Uses `detailobsessed/sync-with-uv` fork temporarily — will switch to `tsvikas/sync-with-uv` once [upstream PR #35](https://github.com/tsvikas/sync-with-uv/pull/35) is merged
- `rev` is empty (filled by `prek autoupdate`) consistent with other hooks in the template
- All 339 lint template checks pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
