### PR TITLE
perf: skip CI matrix for workflow-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,27 @@ env:
 
 jobs:
 
+  changes:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          src:
+            - 'project/**'
+            - 'tests/**'
+            - 'scripts/**'
+            - 'copier.yml'
+            - 'extensions.py'
+            - 'pyproject.toml'
+            - 'uv.lock'
+            - 'docs/**'
+            - '*.md'
+
   links:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -36,6 +57,8 @@ jobs:
         args: --config .lychee.toml --no-progress .
 
   test-filenames:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
@@ -44,6 +67,8 @@ jobs:
       run: bash tests/test_filenames.sh
 
   test-funding:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
@@ -70,6 +95,8 @@ jobs:
       run: bash tests/test_funding.sh
 
   test-licenses:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
@@ -89,6 +116,8 @@ jobs:
       run: uv run --with jinja2 --with pyyaml --with reuse python tests/test_licenses.py
 
   test-project:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     strategy:
       matrix:
         python-version:

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -26,6 +26,29 @@ env:
 
 jobs:
 
+  changes:
+{%- if use_blacksmith_runners %}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+{%- else %}
+    runs-on: ubuntu-latest
+{%- endif %}
+    outputs:
+      src: {% raw %}${{ steps.filter.outputs.src }}{% endraw %}
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          src:
+            - 'src/**'
+            - 'tests/**'
+            - 'pyproject.toml'
+            - 'uv.lock'
+            - 'docs/**'
+            - 'mkdocs.yml'
+            - '*.md'
+
   links:
 {%- if use_blacksmith_runners %}
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -42,6 +65,8 @@ jobs:
         args: --no-progress .
 
   quality:
+    needs: changes
+    if: {% raw %}${{ needs.changes.outputs.src == 'true' }}{% endraw %}
 {%- if publish_to_pypi %}
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Add path-based filtering to CI so that workflow-only changes (e.g. editing `release.yml`) skip the expensive test matrix.

Closes #139.

## Problem

A PR that only changes `.github/workflows/*.yml` triggers the full CI matrix — up to 8 jobs for PyPI packages (3 OS × 2 resolution strategies + quality + links). This wastes CI minutes for YAML-only changes.

## Solution

Uses `dorny/paths-filter@v3` (Option 2 from the issue) with a `changes` job that detects source-relevant file changes.

### Template (`project/.github/workflows/ci.yml.jinja`)
- New `changes` job with `dorny/paths-filter@v3`
- `quality` gated on `needs.changes.outputs.src == 'true'`
- `tests` cascades from `quality` (skipped when quality is skipped)
- `links` stays unconditional (cheap, always useful)

**Paths that trigger full CI:** `src/**`, `tests/**`, `pyproject.toml`, `uv.lock`, `docs/**`, `mkdocs.yml`, `*.md`

### This repo (`.github/workflows/ci.yml`)
- Same `changes` job pattern
- All 4 test jobs gated: `test-filenames`, `test-funding`, `test-licenses`, `test-project`
- `links` stays unconditional

**Paths that trigger full CI:** `project/**`, `tests/**`, `scripts/**`, `copier.yml`, `pyproject.toml`, `uv.lock`, `docs/**`, `*.md`

## Result

| Change type | Before | After |
|---|---|---|
| Workflow-only | 8 jobs | 2 jobs (changes + links) |
| Code/docs | 8 jobs | 8 jobs (unchanged) |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
