### PR TITLE
fix: CI path filter safety + pin lychee to stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
   test-filenames:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
@@ -68,7 +68,7 @@ jobs:
 
   test-funding:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
@@ -96,7 +96,7 @@ jobs:
 
   test-licenses:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
@@ -117,7 +117,7 @@ jobs:
 
   test-project:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}
     strategy:
       matrix:
         python-version:

--- a/prek.toml
+++ b/prek.toml
@@ -83,7 +83,7 @@ rev = "v0.47.0"
 hooks = [{ id = "markdownlint", args = ["--fix"], priority = 1 }]
 
 [[repos]]
-repo = "https://github.com/lycheeverse/lychee.git"
+repo = "https://github.com/lycheeverse/lychee"
 rev = "lychee-v0.22.0"
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1 }]
 

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -66,7 +66,7 @@ jobs:
 
   quality:
     needs: changes
-    if: {% raw %}${{ needs.changes.outputs.src == 'true' }}{% endraw %}
+    if: {% raw %}${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}{% endraw %}
 {%- if publish_to_pypi %}
     strategy:
       matrix:

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -64,8 +64,8 @@ rev = ""  # prek autoupdate will fill this
 hooks = [{ id = "markdownlint", args = ["--fix"], priority = 1 }]
 
 [[repos]]
-repo = "https://github.com/lycheeverse/lychee.git"
-rev = ""  # prek autoupdate will fill this
+repo = "https://github.com/lycheeverse/lychee"
+rev = "lychee-v0.22.0"
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1 }]
 
 [[repos]]


### PR DESCRIPTION
CI path filter (#145):
- Always run quality/test jobs on push to main (event_name == 'push')
- Only skip on PRs when no source files changed
- Prevents untested releases via semantic-release

Lychee hook (#146):
- Pin to lychee-v0.22.0 instead of mutable 'nightly' tag
- Remove .git suffix from repo URL

Closes #145 Closes #146

## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
