### PR TITLE
fix: detect table-style poe tasks and fix issue triage workflow

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -15,5 +15,6 @@ jobs:
     - name: Add needs-triage label
       run: gh issue edit "$NUMBER" --add-label "needs-triage"
       env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NUMBER: ${{ github.event.issue.number }}

--- a/project/.github/workflows/issue-triage.yml.jinja
+++ b/project/.github/workflows/issue-triage.yml.jinja
@@ -19,5 +19,6 @@ jobs:
     - name: Add needs-triage label
       run: gh issue edit "$NUMBER" --add-label "needs-triage"
       env:
+        GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
         GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
         NUMBER: {% raw %}${{ github.event.issue.number }}{% endraw %}

--- a/project/scripts/verify-scaffold.sh
+++ b/project/scripts/verify-scaffold.sh
@@ -27,11 +27,11 @@ for f in pyproject.toml README.md LICENSE CHANGELOG.md CONTRIBUTING.md \
     if [[ -f "$f" ]]; then pass "$f exists"; else fail "$f missing"; fi
 done
 
-# Source package marker (__init__.py in any src/ subpackage)
+# Source package marker (__init__.py required for editable installs)
 if compgen -G "src/*/__init__.py" > /dev/null 2>&1; then
     pass "src/*/__init__.py exists"
 else
-    fail "src/*/__init__.py missing"
+    fail "src/*/__init__.py missing (required for uv sync / editable installs)"
 fi
 
 # Read copier answers for conditional checks
@@ -257,7 +257,7 @@ section "Poe Tasks"
 
 for task in setup lint format typecheck test test-all test-cov check fix \
             docs docs-build prek; do
-    if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml; then
+    if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
         pass "Poe task: $task"
     else
         fail "Poe task missing: $task"


### PR DESCRIPTION
## Changes

- **verify-scaffold.sh**: Add detection of TOML table-style poe task definitions (fixes #152)
- **issue-triage.yml**: Add `GH_REPO` env var so `gh` CLI works without a checkout step (fixes issue triage workflow failures)
- **issue-triage.yml.jinja**: Same fix applied to the template for generated projects

### Re: #153 (copier update deletes test files)
Migration approach was explored but removed — too much complexity for a one-time transition. Users upgrading from pre-0.20.0 should back up their `tests/` directory before running `copier update`.

## Closes
- Closes #152
- Closes #153