### PR TITLE
fix: add id-token: write permission to release workflow for reusable workflow compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ name: release
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 htmlcov/
 .env
 !.env.example
+
+# Stakpak session files
+.stakpak/session*

--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -9,6 +9,7 @@ name: release
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
Fix release workflow failing with 'id-token: write not allowed' when calling reusable semantic-release workflow.

## Problem
The release workflow sets explicit `permissions: contents: write`, which implicitly sets all other permissions to `none`. The reusable `semantic-release-uv.yml` workflow in ci-components requests `id-token: write` in its job, causing GitHub to reject it:

> Error calling workflow. The nested job 'release' is requesting 'id-token: write', but is only allowed 'id-token: none'.

This broke all releases after the stack merge.

## Root Cause
actionlint (our workflow linter) cannot validate permissions of cross-repo reusable workflows — it only checks local syntax. This is a known limitation.

## Solution
Add `id-token: write` to the calling workflow's top-level permissions in both:
- `.github/workflows/release.yml` (this repo)
- `project/.github/workflows/release.yml.jinja` (template for generated projects)

Also adds `poe checks` task (`gh pr checks --watch`) — unrelated but included in this branch.

## Changes
- `.github/workflows/release.yml`: add `id-token: write` permission
- `project/.github/workflows/release.yml.jinja`: same fix for generated projects
- `pyproject.toml` + `project/pyproject.toml.jinja`: add `checks` poe task