### PR TITLE
fix: pass dependency-group: dev to semantic-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,5 +17,6 @@ jobs:
     uses: detailobsessed/ci-components/.github/workflows/semantic-release-uv.yml@main
     with:
       python-version: "3.14"
+      dependency-group: dev
       pypi-publish: "false"
     secrets: inherit


### PR DESCRIPTION
## Summary
Pass `dependency-group: dev` to the semantic-release reusable workflow.

## Problem
The release workflow failed with `error: Group 'maintain' is not defined` because the reusable workflow defaulted to `--group maintain`, but copier-uv-bleeding (the template repo itself) has `python-semantic-release` in the `dev` group, not `maintain`.

Generated projects use `maintain` (the default), so only the template repo needs this override.

## Solution
Pass `dependency-group: dev` to the reusable workflow call. This uses the new configurable input added in ci-components PR #20.

## Changes
- `.github/workflows/release.yml`: add `dependency-group: dev` to workflow inputs