### PR TITLE
docs: add actionlint section to learning-tools.md

### DIFF
--- a/learning-tools.md
+++ b/learning-tools.md
@@ -95,6 +95,32 @@ python-version = "3.14"
 
 ---
 
+## actionlint (GitHub Actions linter)
+
+### Cross-repo reusable workflow limitations
+
+actionlint **cannot** validate permissions of cross-repo reusable workflows. It only checks local YAML syntax. If a reusable workflow requests `id-token: write` but the caller only grants `contents: write`, actionlint won't catch the mismatch. GitHub rejects this at parse time with:
+
+> The nested job 'release' is requesting 'id-token: write', but is only allowed 'id-token: none'
+
+### Script injection detection
+
+actionlint can detect some `${{ }}` expression injection in `run:` steps, but not all cases. Always use the env variable pattern:
+
+```yaml
+# Bad — shell injection risk:
+run: uv sync --group ${{ inputs.dependency-group }}
+
+# Good — safe:
+env:
+  DEP_GROUP: ${{ inputs.dependency-group }}
+run: uv sync --group "$DEP_GROUP"
+```
+
+Safe contexts (not shell): `with:`, `runs-on:`, `if:`
+
+---
+
 ## uv
 
 ### Trusted publishing caveat


### PR DESCRIPTION
## Summary
Add actionlint section to learning-tools.md documenting two key discoveries from the release workflow debugging session.

## Changes
- **Cross-repo reusable workflow limitations**: actionlint can't validate permissions of remote reusable workflows
- **Script injection prevention**: Always use env variables instead of direct `${{ }}` interpolation in `run:` steps