### PR TITLE
fix: include tests in ruff lint/format targets for generated projects

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -197,8 +197,8 @@ python-version = "3.14"
 setup = "uv sync"
 
 # Quality checks
-lint = "ruff check src"
-format = "ruff format src"
+lint = "ruff check ."
+format = "ruff format ."
 typecheck = "ty check src"
 
 # Testing


### PR DESCRIPTION
## Summary
Fix ruff lint/format poe tasks in generated projects to include test files.

## Problem
The template's poe tasks only targeted `src` for ruff lint/format, meaning test files were never linted or formatted. This was a regression.

## Solution
Changed `ruff check src` → `ruff check .` and `ruff format src` → `ruff format .` in the template's poe tasks. This:
- Includes `tests/` (and any other Python files) in linting/formatting
- Doesn't error if `tests/` doesn't exist yet (unlike `src tests` which would fail)
- Matches the template repo's own convention
- Ruff's default excludes already handle `.venv`, `__pycache__`, etc.

## Changes
- `project/pyproject.toml.jinja`: update `lint` and `format` poe tasks to use `.`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
