### PR TITLE
feat: adopt poethepoet 0.38-0.41 features — parallel check task

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -74,7 +74,7 @@ ci = [
     "pytest-cov>=6",
     "pytest-randomly>=3.15",
     "ty>=0.0.14",
-    "poethepoet>=0.32",
+    "poethepoet>=0.41",
 ]
 local = [
     "prek>=0.3.1",
@@ -206,7 +206,8 @@ test-all = "pytest"
 test-cov = "pytest --cov=src/{{ python_package_import_name }} --cov-report=term-missing --cov-report=html"
 
 # Combined tasks
-check = ["lint", "typecheck"]
+check.parallel = ["lint", "typecheck"]
+check.ignore_fail = "return_non_zero"
 fix = ["lint --fix", "format"]
 
 # Documentation

--- a/project/scripts/verify-scaffold.sh
+++ b/project/scripts/verify-scaffold.sh
@@ -257,7 +257,7 @@ section "Poe Tasks"
 
 for task in setup lint format typecheck test test-all test-cov check fix \
             docs docs-build prek; do
-    if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
+    if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "^$task\." pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
         pass "Poe task: $task"
     else
         fail "Poe task missing: $task"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,8 @@ setup = "uv sync"
 format = "ruff format ."
 lint = "ruff check ."
 typecheck = "ty check ."
-check = ["lint", "typecheck"]
+check.parallel = ["lint", "typecheck"]
+check.ignore_fail = "return_non_zero"
 fix = ["lint --fix", "format"]
 
 # Testing

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -215,8 +215,8 @@ class TestCIWorkflows:
         # Verify each task exists in pyproject.toml
         for task in poe_tasks:
             assert "[tool.poe.tasks]" in pyproject_content, "pyproject.toml should have poe tasks"
-            # Check task is defined (either as string or table)
-            assert f"{task} = " in pyproject_content or f"{task} = [" in pyproject_content, (
+            # Check task is defined (as string, array, or dotted table like check.parallel)
+            assert f"{task} = " in pyproject_content or f"{task} = [" in pyproject_content or f"{task}." in pyproject_content, (
                 f"poe task '{task}' referenced in CI but not defined in pyproject.toml"
             )
 


### PR DESCRIPTION
## Summary

Adopts poethepoet 0.38–0.41 features for faster CI feedback and better DX.

Closes #172

## Changes

- **Bump `poethepoet>=0.32` → `>=0.41`** in rendered project dev dependencies
- **Switch `check` from sequential to parallel**: `check.parallel = ["lint", "typecheck"]` with `ignore_fail = "return_non_zero"` so both always run
- **Mirror in template repo** `pyproject.toml` for consistency
- **Update `verify-scaffold.sh`** and test to detect dotted-table task definitions (`check.parallel`)

## What's NOT included (and why)

- **`choices`** (0.40): No tasks with constrained params currently
- **Shell completions** (0.41): User-side setup, no template change needed
- **`fix` → parallel**: Order-dependent (`lint --fix` then `format`), must stay sequential
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
