### PR TITLE
fix: switch template update hook from post-merge to post-checkout and add check-template task

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -19,6 +19,7 @@ _jinja_extensions:
 # copier performs a 3-way merge that preserves user customizations.
 # Only truly user-owned files (README, CHANGELOG, source code) should be skipped.
 _skip_if_exists:
+- .envrc
 - CHANGELOG.md
 - README.md
 - "src/{{ python_package_import_name }}/__init__.py"

--- a/project/.envrc.jinja
+++ b/project/.envrc.jinja
@@ -2,3 +2,6 @@
 # Requires: https://github.com/direnv/direnv
 export VIRTUAL_ENV="$(pwd)/.venv"
 export PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# How often the post-checkout hook checks for template updates (seconds)
+# export COPIER_CHECK_INTERVAL=86400  # default: 24h

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -1,7 +1,7 @@
 default_stages = ["pre-commit"]
 minimum_prek_version = "0.3.2"
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
-default_install_hook_types = ["commit-msg", "post-merge", "pre-commit", "pre-push"]
+default_install_hook_types = ["commit-msg", "post-checkout", "pre-commit", "pre-push"]
 
 [[repos]]
 repo = "builtin"
@@ -118,7 +118,7 @@ entry = "bash scripts/check-template-update.sh"
 language = "system"
 always_run = true
 pass_filenames = false
-stages = ["post-merge"]
+stages = ["post-checkout"]
 
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -227,6 +227,7 @@ verify-scaffold = "bash scripts/verify-scaffold.sh"
 {%- endif %}
 
 # Template utilities
+check-template = "bash scripts/check-template-update.sh"
 update-template = "copier update --trust . --skip-answered"
 
 # Git utilities

--- a/project/scripts/check-template-update.sh
+++ b/project/scripts/check-template-update.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 # Check if a newer version of the copier template is available.
-# Runs as a post-merge hook — informational only, never blocks.
+# Runs as a post-checkout hook — informational only, never blocks.
+# Set COPIER_CHECK_INTERVAL=900 in .envrc for 15-min checks (default: 86400 = 24h).
 set -euo pipefail
+
+# Skip file-level restores (arg 3 = 0); runs on branch switch, pull, rebase, clone
+[[ "${3:-1}" == "0" ]] && exit 0
+
+# Cooldown: throttle when called as a git hook (3 args); always run for manual poe invocation (0 args)
+check_interval="${COPIER_CHECK_INTERVAL:-86400}"
+cache_dir="/tmp"
+cache_file="${cache_dir}/.copier-template-check-$(echo "$PWD" | (sha1sum 2>/dev/null || shasum) | cut -c1-8)"
+if [[ $# -gt 0 && -f "$cache_file" ]]; then
+  last_check=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  (( now - last_check < check_interval )) && exit 0
+fi
 
 answers=".copier-answers.yml"
 [[ -f "$answers" ]] || exit 0
@@ -27,6 +41,9 @@ latest=$(curl -s --connect-timeout 3 --max-time 5 \
   | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//') || true
 
 [[ -z "$latest" ]] && exit 0
+
+# Update cooldown cache after successful API check
+touch "$cache_file"
 
 if [[ "$local_version" != "$latest" ]]; then
   cyan='\033[0;36m'; yellow='\033[1;33m'; dim='\033[2m'; bold='\033[1m'; reset='\033[0m'

--- a/project/scripts/verify-scaffold.sh
+++ b/project/scripts/verify-scaffold.sh
@@ -256,7 +256,7 @@ section "Poe Tasks"
 # ---------------------------------------------------------------------------
 
 for task in setup lint format typecheck test test-all test-cov check fix \
-            docs docs-build prek; do
+            docs docs-build prek check-template update-template; do
     if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "^$task\." pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
         pass "Poe task: $task"
     else

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import tomllib
 from typing import TYPE_CHECKING, ClassVar
@@ -564,14 +565,14 @@ class TestTemplateUpdateCheck:
         assert "copier-answers.yml" in content
         assert "curl" in content
 
-    def test_post_merge_in_hook_types(self, copier_defaults: dict, project_factory) -> None:
-        """prek.toml should install post-merge hooks."""
+    def test_post_checkout_in_hook_types(self, copier_defaults: dict, project_factory) -> None:
+        """prek.toml should install post-checkout hooks."""
         project = project_factory(copier_defaults)
 
         config = project / "prek.toml"
         with config.open("rb") as f:
             data = tomllib.load(f)
-        assert "post-merge" in data["default_install_hook_types"]
+        assert "post-checkout" in data["default_install_hook_types"]
 
     def test_check_template_update_hook_exists(self, copier_defaults: dict, project_factory) -> None:
         """prek.toml should have check-template-update hook."""
@@ -580,6 +581,14 @@ class TestTemplateUpdateCheck:
         config = project / "prek.toml"
         content = config.read_text()
         assert "check-template-update" in content
+
+    def test_check_template_poe_task(self, copier_defaults: dict, project_factory) -> None:
+        """Rendered projects should have check-template poe task."""
+        project = project_factory(copier_defaults)
+
+        pyproject = project / "pyproject.toml"
+        content = pyproject.read_text()
+        assert 'check-template = "bash scripts/check-template-update.sh"' in content
 
     def test_update_template_poe_task(self, copier_defaults: dict, project_factory) -> None:
         """Rendered projects should have update-template poe task."""
@@ -590,55 +599,64 @@ class TestTemplateUpdateCheck:
         assert "update-template" in content
         assert "copier update" in content
 
-    def test_script_exits_cleanly_without_answers_file(self, copier_defaults: dict, project_factory) -> None:
+    def test_script_exits_cleanly_without_answers_file(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should exit 0 when .copier-answers.yml is missing."""
-        project = project_factory(copier_defaults)
+        project = tmp_path / "project"
+        shutil.copytree(project_factory(copier_defaults), project)
         script = project / "scripts" / "check-template-update.sh"
         # Remove answers file to simulate missing
         (project / ".copier-answers.yml").unlink(missing_ok=True)
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True)
+        env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
         assert result.returncode == 0
         assert result.stdout == ""
 
-    def test_script_exits_cleanly_for_gitlab_source(self, copier_defaults: dict, project_factory) -> None:
+    def test_script_exits_cleanly_for_gitlab_source(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should exit 0 silently for non-GitHub templates."""
-        project = project_factory(copier_defaults)
+        project = tmp_path / "project"
+        shutil.copytree(project_factory(copier_defaults), project)
         answers = project / ".copier-answers.yml"
         answers.write_text("_commit: 1.0.0\n_src_path: https://gitlab.com/org/repo\n")
         script = project / "scripts" / "check-template-update.sh"
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True)
+        env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
         assert result.returncode == 0
         assert result.stdout == ""
 
-    def test_script_handles_gh_shorthand(self, copier_defaults: dict, project_factory) -> None:
+    def test_script_handles_gh_shorthand(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should accept gh: shorthand and attempt API call."""
-        project = project_factory(copier_defaults)
+        project = tmp_path / "project"
+        shutil.copytree(project_factory(copier_defaults), project)
         answers = project / ".copier-answers.yml"
         answers.write_text("_commit: 0.0.0\n_src_path: gh:detailobsessed/copier-uv-bleeding\n")
         script = project / "scripts" / "check-template-update.sh"
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True)
+        env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
         assert result.returncode == 0
         # Skip assertion if API unavailable (rate-limited, offline)
         if not result.stdout.strip():
             return
         assert "Template update available" in result.stdout
 
-    def test_script_handles_https_github_url(self, copier_defaults: dict, project_factory) -> None:
+    def test_script_handles_https_github_url(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should accept full https://github.com/ URLs."""
-        project = project_factory(copier_defaults)
+        project = tmp_path / "project"
+        shutil.copytree(project_factory(copier_defaults), project)
         answers = project / ".copier-answers.yml"
         answers.write_text("_commit: 0.0.0\n_src_path: https://github.com/detailobsessed/copier-uv-bleeding\n")
         script = project / "scripts" / "check-template-update.sh"
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True)
+        env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
         assert result.returncode == 0
         # Skip assertion if API unavailable (rate-limited, offline)
         if not result.stdout.strip():
             return
         assert "Template update available" in result.stdout
 
-    def test_script_silent_when_up_to_date(self, copier_defaults: dict, project_factory) -> None:
+    def test_script_silent_when_up_to_date(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should produce no output when local version matches latest."""
-        project = project_factory(copier_defaults)
+        project = tmp_path / "project"
+        shutil.copytree(project_factory(copier_defaults), project)
         # First, get the actual latest version
         curl_cmd = (
             "curl -s --connect-timeout 3 --max-time 5 "
@@ -656,7 +674,8 @@ class TestTemplateUpdateCheck:
         answers = project / ".copier-answers.yml"
         answers.write_text(f"_commit: {latest}\n_src_path: gh:detailobsessed/copier-uv-bleeding\n")
         script = project / "scripts" / "check-template-update.sh"
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True)
+        env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
         assert result.returncode == 0
         assert "Template update available" not in result.stdout
 


### PR DESCRIPTION
## Summary

Fixes the template update check hook so it actually fires in common developer workflows, and adds a manual `poe check-template` task.

Closes #177
Closes #178

## Problem

The `post-merge` git hook only fires on local `git merge` / `git pull` with merge strategy. It does **not** fire for:
- GitHub PR merges pulled locally
- `git pull --rebase` or `pull.rebase = true`
- Graphite `gt sync` (uses rebase)
- `git fetch && git rebase origin/main`

This means the template update check from PR #171 essentially never ran for most developers.

## Changes

- **Switch hook stage**: `post-merge` → `post-checkout` in `project/prek.toml.jinja`
  - Fires on: `git pull`, `git checkout`, `git switch`, `gt sync`, `git clone`
- **Add `poe check-template` task** in `project/pyproject.toml.jinja` — manual fallback to check for updates without applying them
- **Update `verify-scaffold.sh`** — add `check-template` and `update-template` to verified poe tasks
- **Update tests** — `post-checkout` hook type assertion, new `check-template` poe task test