### PR TITLE
fix: coverage inflation, GitLab badge check, release tag format

### DIFF
--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -38,7 +38,7 @@ jobs:
     - name: Checkout release tag
       uses: actions/checkout@v6
       with:
-        ref: {% raw %}${{ needs.release.outputs.version }}{% endraw %}
+        ref: {% raw %}${{ needs.release.outputs.tag }}{% endraw %}
     - name: Setup uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -95,7 +95,7 @@ priority = 1
 [[repos.hooks]]
 id = "pytest-testmon"
 name = "pytest affected tests"
-entry = "uv run pytest --testmon --no-cov"
+entry = "uv run pytest --testmon"
 language = "system"
 types = ["python"]
 pass_filenames = false
@@ -105,7 +105,7 @@ priority = 1
 [[repos.hooks]]
 id = "pytest-cov"
 name = "pytest with coverage"
-entry = "uv run pytest --cov=src/{{ python_package_import_name }} --cov-fail-under=90 --cov-report=term-missing:skip-covered"
+entry = "uv run pytest --cov --cov-fail-under=90 --cov-report=term-missing:skip-covered"
 language = "system"
 types = ["python"]
 pass_filenames = false

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -168,7 +168,7 @@ docstring-code-line-length = 100
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-v --cov"
+addopts = "-v"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
@@ -179,7 +179,7 @@ filterwarnings = [
 [tool.coverage.run]
 branch = true
 parallel = true
-source = ["src/", "tests/"]
+source = ["src/"]
 
 [tool.coverage.report]
 precision = 2
@@ -203,9 +203,9 @@ typecheck = "ty check ."
 
 # Testing
 test = "pytest -m 'not slow'"
-test-affected = "pytest --testmon --no-cov"
+test-affected = "pytest --testmon"
 test-all = "pytest"
-test-cov = "pytest --cov=src/{{ python_package_import_name }} --cov-report=term-missing --cov-report=html"
+test-cov = "pytest --cov --cov-report=term-missing --cov-report=html"
 
 # Combined tasks
 check.parallel = ["lint", "typecheck"]

--- a/project/scripts/verify-scaffold.sh
+++ b/project/scripts/verify-scaffold.sh
@@ -286,7 +286,7 @@ section "README Quality"
 if grep -q '\[!\[ci\]' README.md; then pass "CI badge present"; else warn "CI badge missing"; fi
 if grep -q '\[!\[release\]' README.md; then pass "Release badge present"; else warn "Release badge missing"; fi
 if grep -q '\[!\[documentation\]' README.md; then pass "Docs badge present"; else warn "Docs badge missing"; fi
-if grep -qi 'codecov\|coveralls\|coverage.*badge\|coverage.*img' README.md; then pass "Coverage badge present"; else fail "Coverage badge missing in README"; fi
+if grep -qi 'codecov\|coveralls\|coverage.*badge\|coverage.*img' README.md; then pass "Coverage badge present"; else warn "Coverage badge missing"; fi
 
 # Check for the known README formatting bug (#83)
 if grep -q '```##' README_TEMPLATE.md; then


### PR DESCRIPTION
## Summary

Fix three bugs: coverage inflation from implicit `--cov`, GitLab badge check failure, and release tag format fragility.

## Changes

### #188 — Coverage inflation (priority: high)

**Problem:** `addopts = "-v --cov"` injected `--cov` into every pytest run. Combined with `source = ["src/", "tests/"]`, this inflated coverage percentages (test files have high self-coverage), making the `--cov-fail-under=90` gate looser than intended.

**Fix:**
- Remove `--cov` from `addopts` → `addopts = "-v"`
- Remove `tests/` from `coverage.run.source` → `source = ["src/"]`
- Remove now-unnecessary `--no-cov` from testmon commands
- Simplify `--cov=src/pkg` to bare `--cov` (coverage.run.source already scopes it)

### #184 — GitLab coverage badge check

**Problem:** `verify-scaffold.sh` used `fail` severity for missing coverage badge, but the codecov badge is conditional on `repository_provider == "github.com"`. GitLab projects always failed this check.

**Fix:** Downgrade from `fail` to `warn`.

### #181 — Release tag format fragility

**Problem:** `release.yml` checked out `${{ needs.release.outputs.version }}` (e.g. `0.10.0`), which only works with `tag_format = "{version}"`. If changed to `v{version}`, checkout would fail.

**Fix:** Use `${{ needs.release.outputs.tag }}` which is the actual git tag name.

## Checklist

- [x] `poe lint-templates` passes (336 checks)
- [x] `poe test` passes (100 tests)
- [x] Commit message follows conventional commits

Closes #188, closes #184, closes #181