### PR TITLE
fix: use uv sync --upgrade in post-copy tasks, add test-affected to scaffold check, mark slow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ copier adopt --trust --conflict inline https://github.com/detailobsessed/copier-
 
 To update the fork later, re-run the install command with `--force`.
 
-The template automatically runs `uv sync` and `prek install` after scaffolding.
+The template automatically runs `uv sync --upgrade` and `prek install` after scaffolding.
 Create your source files in `src/<package_name>/` and tests in `tests/`.
 
 ## Automatic Template Update Checking

--- a/copier.yml
+++ b/copier.yml
@@ -223,7 +223,7 @@ include_template_dev_scripts:
 
 # TASKS --------------------------------
 _tasks:
-  - "uv sync"
+  - "uv sync --upgrade"
   - "test -d .git && uv run prek install || true"
   - "test -d .git && uv run prek autoupdate || true"
   - "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge && echo '✓ Enabled delete-branch-on-merge' || true"

--- a/project/scripts/verify-scaffold.sh
+++ b/project/scripts/verify-scaffold.sh
@@ -270,7 +270,7 @@ if grep -q 'git-revision-date' mkdocs.yml; then pass "Git revision date plugin";
 section "Poe Tasks"
 # ---------------------------------------------------------------------------
 
-for task in setup lint format typecheck test test-all test-cov check fix \
+for task in setup lint format typecheck test test-affected test-all test-cov check fix \
             docs docs-build prek check-template update-template; do
     if grep -q "^$task " pyproject.toml || grep -q "^$task = " pyproject.toml || grep -q "^$task\." pyproject.toml || grep -q "\[tool\.poe\.tasks\.$task\]" pyproject.toml; then
         pass "Poe task: $task"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1096,6 +1096,7 @@ class TestSkipIfExists:
     (no 3-way merge), so if _skip_if_exists works here, it works everywhere.
     """
 
+    @pytest.mark.slow
     def test_recopy_preserves_modified_readme(self, tmp_path: Path, copier_defaults: dict) -> None:
         """User-modified README.md should not be overwritten (core _skip_if_exists file)."""
         project = generate_project(tmp_path, copier_defaults)
@@ -1142,6 +1143,7 @@ class TestIntegration:
             },
         )
 
+    @pytest.mark.slow
     def test_uv_sync_succeeds(self, tmp_path: Path, copier_defaults: dict) -> None:
         """Generated project should successfully run uv sync."""
         project = generate_project(tmp_path, copier_defaults)


### PR DESCRIPTION
## Summary

Small improvements: upgrade deps on scaffold, verify test-affected poe task, mark slow tests.

## Changes

- **copier.yml**: `uv sync` → `uv sync --upgrade` in post-copy tasks so new projects get latest dep versions
- **verify-scaffold.sh**: Added `test-affected` to the poe tasks checklist (matches `pyproject.toml.jinja`)
- **test_template.py**: Marked `test_recopy_preserves_modified_readme` and `test_uv_sync_succeeds` as `@pytest.mark.slow` (both invoke copier/uv)