### PR TITLE
feat: auto-create needs-triage label in issue triage workflow

### DIFF
--- a/project/.github/workflows/issue-triage.yml.jinja
+++ b/project/.github/workflows/issue-triage.yml.jinja
@@ -16,6 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 {%- endif %}
     steps:
+    - name: Ensure needs-triage label exists
+      run: gh label create "needs-triage" --description "Issue needs triage" --color "FBCA04" || true
+      env:
+        GH_REPO: {% raw %}${{ github.repository }}{% endraw %}
+        GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
     - name: Add needs-triage label
       run: gh issue edit "$NUMBER" --add-label "needs-triage"
       env:


### PR DESCRIPTION
## Summary

Auto-create the `needs-triage` label in the issue triage workflow so it works on fresh repos without manual setup.

Closes #190

## Changes

- **issue-triage.yml.jinja**: Added `gh label create` step before adding the label to the issue. Uses `|| true` to handle the idempotent case (label already exists).