### PR TITLE
feat: add PR description validation workflow and auto-create needs-triage label

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -12,6 +12,11 @@ jobs:
     if: join(github.event.issue.labels.*.name) == ''
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+    - name: Ensure needs-triage label exists
+      run: gh label create "needs-triage" --description "Issue needs triage" --color "FBCA04" || true
+      env:
+        GH_REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Add needs-triage label
       run: gh issue edit "$NUMBER" --add-label "needs-triage"
       env:

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,29 @@
+name: PR Description
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions: {}
+
+jobs:
+  check:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+    - name: Validate PR description
+      env:
+        BODY: ${{ github.event.pull_request.body }}
+      run: |
+        if [ -z "$BODY" ]; then
+          echo "::error::PR description is empty"
+          exit 1
+        fi
+
+        # Check that ## Description section has real content (not just the placeholder comment)
+        desc=$(printf '%s\n' "$BODY" | tr -d '\r' | sed -n '/^## Description/,/^## /{ /^## /d; p; }' | sed '/^<!--.*-->$/d' | tr -d '[:space:]')
+        if [ -z "$desc" ]; then
+          echo "::error::## Description section is missing, empty, or contains only placeholder text. Use the PR template."
+          exit 1
+        fi
+
+        echo "✓ PR description looks good"

--- a/.windsurf/lifeguard.yaml
+++ b/.windsurf/lifeguard.yaml
@@ -1,0 +1,7 @@
+rules: []
+memories:
+  - title: PR description check warns for GitLab projects incorrectly
+    description: The new pr-description.yml check always warns when the file is missing, but this is incorrect for GitLab projects. The .github folder is completely excluded for GitLab (copier.yml line 27), so this check will always produce a false warning 'PR description check workflow missing' for GitLab projects. The script already reads `repo_provider` from `.copier-answers.yml` and uses it for other conditional checks, but this new check is missing that condition.
+    file: /Users/ismar/repos/copier-uv-bleeding/project/scripts/verify-scaffold.sh
+    line: 245
+    comment: Not legit. Same claim as before — the script has no repo_provider variable and no .copier-answers.yml parsing. Lifeguard is hallucinating. The script is GitHub-only, and for GitLab projects the entire .github directory (including this script's caller context) is excluded by copier.

--- a/copier.yml
+++ b/copier.yml
@@ -28,6 +28,7 @@ _exclude:
 - "{% if repository_provider != 'gitlab.com' %}.gitlab-ci.yml{% endif %}"
 - "{% if not use_ci %}.github/workflows/ci.yml{% endif %}"
 - "{% if not use_ci %}.github/workflows/copier-update.yml{% endif %}"
+- "{% if not use_ci %}.github/workflows/pr-description.yml{% endif %}"
 - "{% if not use_ci %}.gitlab-ci.yml{% endif %}"
 - "{% if not use_semantic_release %}.github/workflows/release.yml{% endif %}"
 - "{% if not include_template_dev_scripts %}scripts/verify-scaffold.sh{% endif %}"

--- a/project/.github/workflows/pr-description.yml.jinja
+++ b/project/.github/workflows/pr-description.yml.jinja
@@ -1,0 +1,33 @@
+name: PR Description
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions: {}
+
+jobs:
+  check:
+{%- if use_blacksmith_runners %}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+{%- else %}
+    runs-on: ubuntu-latest
+{%- endif %}
+    steps:
+    - name: Validate PR description
+      env:
+        BODY: {% raw %}${{ github.event.pull_request.body }}{% endraw %}
+      run: |
+        if [ -z "$BODY" ]; then
+          echo "::error::PR description is empty"
+          exit 1
+        fi
+
+        # Check that ## Description section has real content (not just the placeholder comment)
+        desc=$(printf '%s\n' "$BODY" | tr -d '\r' | sed -n '/^## Description/,/^## /{ /^## /d; p; }' | sed '/^<!--.*-->$/d' | tr -d '[:space:]')
+        if [ -z "$desc" ]; then
+          echo "::error::## Description section is missing, empty, or contains only placeholder text. Use the PR template."
+          exit 1
+        fi
+
+        echo "✓ PR description looks good"

--- a/project/scripts/verify-scaffold.sh
+++ b/project/scripts/verify-scaffold.sh
@@ -242,6 +242,13 @@ else
     warn "CI: no CI workflow found"
 fi
 
+prd=".github/workflows/pr-description.yml"
+if [ -f "$prd" ]; then
+    pass "PR description check workflow present"
+elif [ -d ".github" ]; then
+    warn "PR description check workflow missing"
+fi
+
 rel=".github/workflows/release.yml"
 if [ -f "$rel" ]; then
     if grep -q 'semantic-release' "$rel"; then


### PR DESCRIPTION
## Summary

Add a lightweight CI workflow that validates PR descriptions have real content in the `## Description` section, blocking merge on empty/placeholder-only descriptions. Also applies the needs-triage label fix and PR description workflow to the template project itself.

Closes #191

## Changes

- **pr-description.yml.jinja**: New workflow triggered on `pull_request: [opened, edited]`. Checks PR body is non-empty and the `## Description` section has content beyond HTML comments.
- **copier.yml**: Added exclude pattern to gate workflow behind `use_ci`
- **verify-scaffold.sh**: Added check for `pr-description.yml` presence
- **.github/workflows/pr-description.yml**: Same workflow for the template project itself
- **.github/workflows/issue-triage.yml**: Applied the needs-triage label auto-create fix to the template project