### PR TITLE
fix: make PR description check heading-agnostic

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -19,10 +19,10 @@ jobs:
           exit 1
         fi
 
-        # Check that ## Description section has real content (not just the placeholder comment)
-        desc=$(printf '%s\n' "$BODY" | tr -d '\r' | sed -n '/^## Description/,/^## /{ /^## /d; p; }' | sed '/^<!--.*-->$/d' | tr -d '[:space:]')
-        if [ -z "$desc" ]; then
-          echo "::error::## Description section is missing, empty, or contains only placeholder text. Use the PR template."
+        # Strip HTML comments, headings, checklist lines, and whitespace — what remains is real content
+        content=$(printf '%s\n' "$BODY" | tr -d '\r' | sed '/^<!--.*-->$/d' | sed '/^## /d' | sed '/^- \[[ xX]\]/d' | tr -d '[:space:]')
+        if [ -z "$content" ]; then
+          echo "::error::PR description has no real content — just headings, placeholders, or checklists. Describe your changes."
           exit 1
         fi
 

--- a/project/.github/workflows/pr-description.yml.jinja
+++ b/project/.github/workflows/pr-description.yml.jinja
@@ -23,10 +23,10 @@ jobs:
           exit 1
         fi
 
-        # Check that ## Description section has real content (not just the placeholder comment)
-        desc=$(printf '%s\n' "$BODY" | tr -d '\r' | sed -n '/^## Description/,/^## /{ /^## /d; p; }' | sed '/^<!--.*-->$/d' | tr -d '[:space:]')
-        if [ -z "$desc" ]; then
-          echo "::error::## Description section is missing, empty, or contains only placeholder text. Use the PR template."
+        # Strip HTML comments, headings, checklist lines, and whitespace — what remains is real content
+        content=$(printf '%s\n' "$BODY" | tr -d '\r' | sed '/^<!--.*-->$/d' | sed '/^## /d' | sed '/^- \[[ xX]\]/d' | tr -d '[:space:]')
+        if [ -z "$content" ]; then
+          echo "::error::PR description has no real content — just headings, placeholders, or checklists. Describe your changes."
           exit 1
         fi
 


### PR DESCRIPTION
## Description

The PR description validation workflow checked for a specific `## Description` heading, but our PRs (created via Graphite) use `## Summary`. This caused the workflow to always fail.

## Solution

Made the check heading-agnostic: instead of looking for content under `## Description`, strip all HTML comments, `##` headings, checklist items, and whitespace from the entire body. If nothing remains, the PR is just template boilerplate.

## Changes

- **pr-description.yml**: Replaced heading-specific sed with generic content extraction
- **pr-description.yml.jinja**: Same fix for generated projects