### PR TITLE
fix: modernize copier _tasks with _copier_operation and chain prek autoupdate

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -224,14 +224,17 @@ include_template_dev_scripts:
 
 # TASKS --------------------------------
 _tasks:
+  # Always run
   - "uv sync --upgrade"
-  - "test -d .git && uv run prek install || true"
-  - "test -d .git && uv run prek autoupdate || true"
-  - "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge && echo '✓ Enabled delete-branch-on-merge' || true"
-  - "echo ''"
-  - "echo '🎉 Done!'"
-  - "echo ''"
-  - "echo '  ✓ Dependencies installed'"
-  - "test -d .git && echo '  ✓ Git hooks installed and synced' || true"
-  - "echo ''"
-  - "test ! -d .git && echo 'To finish setup:' && echo '  git init && uv run prek install && uv run prek autoupdate' && echo '  Create your source files in src/ and tests/' || true"
+  # Update only — reinstall hooks (fresh copy has no .git yet)
+  - command: "uv run prek install"
+    when: "{{ _copier_operation in ('update', 'recopy') }}"
+  # Copy only — one-time GitHub repo setup
+  - command: "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge && echo '✓ Enabled delete-branch-on-merge' || true"
+    when: "{{ _copier_operation == 'copy' }}"
+  # Copy — setup instructions
+  - command: "printf '\\n🎉 Project created!\\n\\n  ✓ Dependencies installed\\n\\nTo finish setup:\\n  git init && uv run prek install && uv run prek autoupdate\\n  Create your source files in src/ and tests/\\n'"
+    when: "{{ _copier_operation == 'copy' }}"
+  # Update — minimal output (poe update-template handles prek autoupdate)
+  - command: "printf '\\n🎉 Template updated!\\n\\n  ✓ Dependencies synced\\n  ✓ Git hooks reinstalled\\n'"
+    when: "{{ _copier_operation in ('update', 'recopy') }}"

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -67,7 +67,7 @@ hooks = [{ id = "markdownlint", args = ["--fix"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.22.0"  # pinned: 'nightly' tag is mutable, update manually
+rev = "lychee-v0.22.0"  # lychee tags nightly as latest; prek autoupdate may switch to it
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -230,7 +230,7 @@ verify-scaffold = "bash scripts/verify-scaffold.sh"
 
 # Template utilities
 check-template = "bash scripts/check-template-update.sh"
-update-template = "copier update --trust . --skip-answered"
+update-template = { shell = "copier update --trust . --skip-answered && prek autoupdate && echo '  ✓ Hook versions updated'" }
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -591,13 +591,26 @@ class TestTemplateUpdateCheck:
         assert 'check-template = "bash scripts/check-template-update.sh"' in content
 
     def test_update_template_poe_task(self, copier_defaults: dict, project_factory) -> None:
-        """Rendered projects should have update-template poe task."""
+        """Rendered projects should have update-template poe task that chains prek autoupdate."""
         project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "update-template" in content
         assert "copier update" in content
+        assert "prek autoupdate" in content
+
+    def test_lychee_rev_is_pinned_not_empty(self, copier_defaults: dict, project_factory) -> None:
+        """Lychee should have a pinned rev (not empty) since its 'nightly' tag is mutable."""
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+        lychee_repos = [r for r in data["repos"] if r.get("repo", "").endswith("/lychee")]
+        assert len(lychee_repos) == 1, "Expected exactly one lychee repo entry"
+        rev = lychee_repos[0]["rev"]
+        assert rev, "Lychee rev should be pinned, not empty"
+        assert rev.startswith("lychee-v"), f"Lychee rev should be a versioned tag, got: {rev}"
 
     def test_script_exits_cleanly_without_answers_file(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should exit 0 when .copier-answers.yml is missing."""


### PR DESCRIPTION
## Summary

Modernizes copier `_tasks` using `_copier_operation` and `when` conditions to properly differentiate between `copier copy` (fresh project) and `copier update` (template upgrade). Also chains `prek autoupdate` into `poe update-template` so hook versions stay current after template updates.

## Changes

- **`copier.yml`**: Replace flat string tasks with structured `when`-gated tasks:
  - `prek install` only on `update` (fresh copy has no `.git`)
  - `gh repo edit --delete-branch-on-merge` only on `copy` (one-time setup)
  - Separate output messages for copy ("Project created!") vs update ("Template updated!")
  - **Remove** `prek autoupdate` from `_tasks` — wasted work (results overwritten by 3-way merge during update, skipped on fresh copy due to no `.git`)
- **`project/pyproject.toml.jinja`**: Chain `prek autoupdate` after copier update in the `poe update-template` task
- **`project/prek.toml.jinja`**: Remove misleading `# pinned:` comment from lychee — accept whatever `prek autoupdate` gives us (lychee's nightly tag issue is upstream)

## Context

Discovered while running `poe update-template` on codereviewbuddy (upgrading 0.22.1 → 0.26.1):
- `prek autoupdate` in `_tasks` ran in temp dirs during update, results got overwritten by copier's 3-way merge
- Output messages didn't differentiate copy vs update ("git init" shown during updates)
- `prek autoupdate` wasn't chained after copier update, so hook versions stayed stale

Closes #196
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
