### PR TITLE
fix: restore .git guard for prek install in copier _tasks

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -227,7 +227,7 @@ _tasks:
   # Always run
   - "uv sync --upgrade"
   # Update only — reinstall hooks (fresh copy has no .git yet)
-  - command: "uv run prek install"
+  - command: "if [ -d .git ]; then uv run prek install; fi"
     when: "{{ _copier_operation in ('update', 'recopy') }}"
   # Copy only — one-time GitHub repo setup
   - command: "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge && echo '✓ Enabled delete-branch-on-merge' || true"


### PR DESCRIPTION
## Summary

Restores the `test -d .git &&` guard on the `prek install` task in `copier.yml`. Without it, `prek install` fails with exit code 2 in copier's temp dirs (which have no `.git`) during `copier update`.

## Root cause

`copier update` runs `_tasks` in temp dirs for diff computation. The `when: _copier_operation in ('update', 'recopy')` condition correctly gates the operation type, but temp dirs don't have `.git`, so `prek install` fails. The old code used `test -d .git &&` to guard this — we accidentally dropped it when modernizing tasks in PR #197.

Stacks on #197.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
