### PR TITLE
feat: improve template update reliability + add pathlib encoding hook

### DIFF
--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -84,6 +84,16 @@ stages = ["pre-push"]
 priority = 0
 
 [[repos.hooks]]
+id = "check-pathlib-encoding"
+name = "pathlib encoding check"
+entry = "python scripts/check-pathlib-encoding.py"
+language = "system"
+types = ["python"]
+priority = 1
+# Workaround for ruff PLW1514 false negatives on indirect Path objects.
+# Remove when https://github.com/astral-sh/ruff/issues/19294 is fixed.
+
+[[repos.hooks]]
 id = "ty"
 name = "ty type checker"
 entry = "uv run ty check"
@@ -95,7 +105,7 @@ priority = 1
 [[repos.hooks]]
 id = "pytest-testmon"
 name = "pytest affected tests"
-entry = "uv run pytest --testmon"
+entry = "uv run pytest --testmon --no-cov"
 language = "system"
 types = ["python"]
 pass_filenames = false

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -230,7 +230,7 @@ verify-scaffold = "bash scripts/verify-scaffold.sh"
 
 # Template utilities
 check-template = "bash scripts/check-template-update.sh"
-update-template = { shell = "copier update --trust . --skip-answered && prek autoupdate && echo '  ✓ Hook versions updated'" }
+update-template = { shell = "copier update --trust . --skip-answered && uv sync --upgrade && prek autoupdate && echo '  ✓ Dependencies upgraded and hook versions updated'" }
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/project/scripts/check-pathlib-encoding.py
+++ b/project/scripts/check-pathlib-encoding.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Check that pathlib .read_text() / .write_text() calls specify encoding=.
+
+Workaround for ruff PLW1514 false negatives on indirect Path objects.
+See: https://github.com/astral-sh/ruff/issues/19294
+
+Remove this hook once ruff handles indirect pathlib paths.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+METHODS = {"read_text", "write_text"}
+
+
+def check_file(path: Path) -> list[str]:
+    """Return list of error messages for the given file."""
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError, UnicodeDecodeError:
+        return []
+
+    errors: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr not in METHODS:
+            continue
+        # Check if encoding= is among keyword arguments
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+        errors.append(f"{path}:{node.lineno}: `{func.attr}` without explicit `encoding` argument")
+    return errors
+
+
+def main() -> int:
+    files = [Path(f) for f in sys.argv[1:] if f.endswith(".py")]
+    exit_code = 0
+    for path in files:
+        for error in check_file(path):
+            sys.stderr.write(error + "\n")
+            exit_code = 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -591,13 +591,14 @@ class TestTemplateUpdateCheck:
         assert 'check-template = "bash scripts/check-template-update.sh"' in content
 
     def test_update_template_poe_task(self, copier_defaults: dict, project_factory) -> None:
-        """Rendered projects should have update-template poe task that chains prek autoupdate."""
+        """Rendered projects should have update-template poe task that chains uv sync --upgrade and prek autoupdate."""
         project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
         assert "update-template" in content
         assert "copier update" in content
+        assert "uv sync --upgrade" in content
         assert "prek autoupdate" in content
 
     def test_lychee_rev_is_pinned_not_empty(self, copier_defaults: dict, project_factory) -> None:


### PR DESCRIPTION
## Problem

Three issues discovered while real-world testing `copier update` on downstream projects (codereviewbuddy, surfmon):

1. **`uv sync --upgrade` partially reverted** — Same root cause as the `prek autoupdate` fix in #198: copier's diff re-application (step 5) overwrites upgrades done by `uv sync --upgrade` in `_tasks` (step 4). Users had to manually re-run `uv sync --upgrade` after every template update.

2. **ruff PLW1514 false negatives on indirect `Path` objects** — `Path.write_text()` / `.read_text()` without `encoding=` aren't caught when the path comes from a variable (e.g. `tmp_path / "file"`). This is a [known ruff limitation](https://github.com/astral-sh/ruff/issues/19294). We only caught it at CI time via `filterwarnings = ["error"]`, wasting a round-trip.

3. **testmon + pytest-cov conflict** — The new `pytest-testmon` hook crashes when `branch = true` is set in coverage config: `testmon doesn't support simultaneous run with pytest-cov when branch coverage is on`.

## Solution

- **Chain `uv sync --upgrade`** in the `poe update-template` task, after `copier update` completes (same pattern as `prek autoupdate`)
- **Ship `scripts/check-pathlib-encoding.py`** — a small AST-based hook that catches `.write_text()` / `.read_text()` without `encoding=` on any object. Registered as a local prek hook. Tracked in #201 for removal when ruff fixes #19294.
- **Add `--no-cov`** to the testmon hook entry to prevent the conflict

## Files changed

- `project/pyproject.toml.jinja` — updated `update-template` poe task chain
- `project/prek.toml.jinja` — added encoding hook + `--no-cov` on testmon
- `project/scripts/check-pathlib-encoding.py` — new AST checker (54 lines)
- `tests/test_template.py` — added `uv sync --upgrade` assertion to update-template test

## Checklist

- [x] Tests added/updated
- [x] `poe lint-templates` passes (344 checks)
- [x] Commit messages follow conventional commits

## Related Issues

- Fixes partially: real-world update issues found in codereviewbuddy and surfmon
- Tracking: #201 (remove encoding hook when astral-sh/ruff#19294 is fixed)
- Related: #199 (.env.example cosmetic fix)