### PR TITLE
fix: add --no-cov to poe test-affected task

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -203,7 +203,7 @@ typecheck = "ty check ."
 
 # Testing
 test = "pytest -m 'not slow'"
-test-affected = "pytest --testmon"
+test-affected = "pytest --testmon --no-cov"
 test-all = "pytest"
 test-cov = "pytest --cov --cov-report=term-missing --cov-report=html"
 


### PR DESCRIPTION
## Problem

The `poe test-affected` task runs `pytest --testmon` but picks up `--cov` from `addopts` in `pyproject.toml`. testmon crashes when branch coverage is enabled:

```
TestmonException: testmon doesn't support simultaneous run with pytest-cov when branch coverage is on.
```

The prek hook at `prek.toml` already had `--no-cov` (added in #200), but the poe task was missed. Caught by Devin review on codereviewbuddy PR detailobsessed/codereviewbuddy#122.

## Fix

Add `--no-cov` to the `test-affected` poe task definition in `project/pyproject.toml.jinja`.

## Checklist

- [x] `poe lint-templates` passes (344 checks)
- [x] Commit follows conventional commits
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
