### PR TITLE
fix: use uv run for pathlib encoding check hook

### DIFF
--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -86,7 +86,7 @@ priority = 0
 [[repos.hooks]]
 id = "check-pathlib-encoding"
 name = "pathlib encoding check"
-entry = "python scripts/check-pathlib-encoding.py"
+entry = "uv run scripts/check-pathlib-encoding.py"
 language = "system"
 types = ["python"]
 priority = 1


### PR DESCRIPTION
## Summary

Fixes the `check-pathlib-encoding` pre-commit hook introduced in v0.27.1:

1. **Python 2 except syntax bug** — `except SyntaxError, UnicodeDecodeError:` silently assigns the exception to `UnicodeDecodeError` instead of catching both types. Fixed to `except (SyntaxError, UnicodeDecodeError):`
2. **`python`** **→** **`uv run`** — `python` isn't on PATH in all environments (macOS ships `python3`, not `python`). Using `uv run` is consistent with other hooks (`ty`, `pytest`).

## Checklist

- [x] Template linting passes
- [x] Conventional commit