### PR TITLE
fix: chmod scripts in _tasks to ensure executable bits after copier update

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -225,6 +225,7 @@ include_template_dev_scripts:
 # TASKS --------------------------------
 _tasks:
   # Always run
+  - "chmod +x scripts/*.sh scripts/*.py 2>/dev/null || true"
   - "uv sync --upgrade"
   # Update only — reinstall hooks (fresh copy has no .git yet)
   - command: "if [ -d .git ]; then uv run prek install; fi"


### PR DESCRIPTION
## Summary

Copier doesn't preserve executable bits during `copier update` (despite docs claiming it does). This causes `check-template-update.sh` and other scripts to be non-executable after template updates, requiring manual `chmod +x`.

### Fix

Added `chmod +x scripts/*.sh scripts/*.py` as the first `_tasks` entry in `copier.yml`. Runs on both `copy` and `update` operations — belt-and-suspenders approach that works regardless of copier's permission handling.

## Checklist
- [x] All hooks pass
- [x] Conventional commit