### PR TITLE
chore: comment out COPIER_CHECK_INTERVAL in .env.example.jinja

### DIFF
--- a/project/.env.example.jinja
+++ b/project/.env.example.jinja
@@ -9,7 +9,7 @@
 
 # How often the post-checkout hook checks for template updates (seconds).
 # Set to 0 to check on every checkout, or comment out for the script default (24 h).
-COPIER_CHECK_INTERVAL=900  # 15 min (set via .envrc)
+# COPIER_CHECK_INTERVAL=900  # 15 min (set via .envrc)
 
 # --- Application secrets (add your own below) --------------------------------
 


### PR DESCRIPTION
Comment out `COPIER_CHECK_INTERVAL=900` in `.env.example.jinja` — it's a template of example values that should all be commented out. The active export lives in `.envrc`.

Closes #199