### PR TITLE
fix: unblock .env.example.jinja from .gitignore and mark network-dependent tests as slow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 .env
 .env.*
 !.env.example
+!.env.example.jinja
 
 # tools
 .coverage*

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -613,6 +613,7 @@ class TestTemplateUpdateCheck:
         assert rev, "Lychee rev should be pinned, not empty"
         assert rev.startswith("lychee-v"), f"Lychee rev should be a versioned tag, got: {rev}"
 
+    @pytest.mark.slow
     def test_script_exits_cleanly_without_answers_file(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should exit 0 when .copier-answers.yml is missing."""
         project = tmp_path / "project"
@@ -625,6 +626,7 @@ class TestTemplateUpdateCheck:
         assert result.returncode == 0
         assert result.stdout == ""
 
+    @pytest.mark.slow
     def test_script_exits_cleanly_for_gitlab_source(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should exit 0 silently for non-GitHub templates."""
         project = tmp_path / "project"
@@ -637,6 +639,7 @@ class TestTemplateUpdateCheck:
         assert result.returncode == 0
         assert result.stdout == ""
 
+    @pytest.mark.slow
     def test_script_handles_gh_shorthand(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should accept gh: shorthand and attempt API call."""
         project = tmp_path / "project"
@@ -652,6 +655,7 @@ class TestTemplateUpdateCheck:
             return
         assert "Template update available" in result.stdout
 
+    @pytest.mark.slow
     def test_script_handles_https_github_url(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should accept full https://github.com/ URLs."""
         project = tmp_path / "project"
@@ -667,6 +671,7 @@ class TestTemplateUpdateCheck:
             return
         assert "Template update available" in result.stdout
 
+    @pytest.mark.slow
     def test_script_silent_when_up_to_date(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
         """Script should produce no output when local version matches latest."""
         project = tmp_path / "project"


### PR DESCRIPTION
## Changes

1. **Fix .env.example not generated** — `.gitignore` had `.env.*` which matched `project/.env.example.jinja` but the negation `!.env.example` didn't cover the `.jinja` suffix. Copier's dirty-overlay file discovery excluded it, so generated projects were missing `.env.example`.

2. **Mark network-dependent tests as slow** — 5 `TestTemplateUpdateCheck` script tests that `shutil.copytree` + run bash scripts with `curl` to GitHub API (4-7s each) are now marked `@pytest.mark.slow`. `poe test` drops from ~70s to ~41s.

Closes #148