### PR TITLE
fix: correct except syntax in check-pathlib-encoding and align setup-uv tags

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -102,7 +102,7 @@ jobs:
         fetch-tags: true
 
     - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7.1.5
+      uses: astral-sh/setup-uv@v7
       with:
 {%- if publish_to_pypi %}
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
@@ -187,7 +187,7 @@ jobs:
         fetch-tags: true
 
     - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7.1.5
+      uses: astral-sh/setup-uv@v7
       with:
 {%- if publish_to_pypi %}
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}


### PR DESCRIPTION
## Description

Updates the `astral-sh/setup-uv` GitHub Action from pinned version `v7.1.5` to major version `v7` in the CI workflow template. This change allows the workflow to automatically use the latest minor and patch versions within the v7 release line.
