### PR TITLE
fix: use --only-group maintain in release job to minimize attack surface

### DIFF
--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -38,7 +38,7 @@ jobs:
         enable-cache: true
 
     - name: Install dependencies
-      run: uv sync --group maintain
+      run: uv sync --only-group maintain
 
     - name: Semantic Release
       id: release


### PR DESCRIPTION
## Description

Updates the `uv sync` command in the release workflow to use `--only-group` instead of `--group` flag when installing dependencies.