### PR TITLE
fix: tell python where .venv is explicitly to help code editors resolve modules

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -191,6 +191,7 @@ output = "htmlcov/coverage.json"
 
 [tool.ty.environment]
 python-version = "3.14"
+python = ".venv"
 
 [tool.poe.tasks]
 # Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ watch = "gh run watch"
 
 [tool.ty.environment]
 python-version = "3.14"
+python = ".venv"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Description

Adds `python = ".venv"` to the `[tool.ty.environment]` config in both the template and the repo's own `pyproject.toml`.

**Problem:** When `ty` runs inside an IDE (not via `uv run`), `VIRTUAL_ENV` isn't set and `ty` can't resolve third-party imports like `rich`, `typer`, `psutil`, etc. This produces noisy `unresolved-import` errors in the editor despite the packages being installed.

**Fix:** Explicitly point `ty` to `.venv` so it can find `site-packages` regardless of how it's invoked. Per the [ty docs](https://docs.astral.sh/ty/reference/configuration/#python), this is the recommended approach when `VIRTUAL_ENV` isn't reliably available.

## Checklist

- [x] Template updated (`pyproject.toml.jinja`)
- [x] Repo's own `pyproject.toml` updated
- [x] `uv run ty check .` passes