### PR TITLE
refactor: add strict pylint and modern ruff rules to template

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import subprocess
 import unicodedata
-from datetime import date
+from datetime import UTC, datetime
 
 from copier_templates_extensions import ContextHook
 from jinja2.ext import Extension
@@ -39,7 +39,7 @@ class SlugifyExtension(Extension):
 class CurrentYearExtension(Extension):
     def __init__(self, environment):
         super().__init__(environment)
-        environment.globals["current_year"] = date.today().year
+        environment.globals["current_year"] = datetime.now(UTC).year
 
 
 class GitHubIDsforGiscusExtension(ContextHook):

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -114,11 +114,13 @@ select = [
     "I",    # isort - import sorting
 
     # Code quality
+    "A",    # flake8-builtins - prevent shadowing builtins (id, type, list, etc.)
     "B",    # flake8-bugbear - common bugs and design issues
     "SIM",  # flake8-simplify - simplify code
     "C4",   # flake8-comprehensions - better comprehensions
     "PIE",  # flake8-pie - misc improvements
     "RET",  # flake8-return - return statement issues
+    "RSE",  # flake8-raise - raise best practices
     "RUF",  # Ruff-specific rules
     "FA",   # flake8-future-annotations
     "ISC",  # flake8-implicit-str-concat - catch missing commas
@@ -127,6 +129,22 @@ select = [
     "TC",   # flake8-type-checking - TYPE_CHECKING imports
     "PTH",  # flake8-use-pathlib - prefer pathlib over os.path
     "FURB", # refurb - modernize and simplify code
+    "FLY",  # flynt - prefer f-strings over .format() and %
+
+    # Naming
+    # "N",  # pep8-naming - PEP 8 naming conventions (enable when ready)
+
+    # Datetime
+    "DTZ",  # flake8-datetimez - enforce timezone-aware datetimes
+
+    # Error messages
+    "EM",   # flake8-errmsg - no string literals in exceptions
+
+    # Pylint
+    "PLC",  # pylint conventions
+    "PLE",  # pylint errors
+    "PLR",  # pylint refactor (too-many-args, too-many-branches, etc.)
+    "PLW",  # pylint warnings
 
     # Performance
     "PERF", # Perflint - performance anti-patterns
@@ -147,13 +165,23 @@ select = [
 
     # Print statements (use logging instead)
     "T20",  # flake8-print
-
-    # Encoding
-    "PLW1514",  # unspecified-encoding - require encoding in open()
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101", "S603", "S607", "S701", "T201"]  # Allow assert, subprocess, jinja2, print in tests
+"tests/**" = [
+    "S101", "S603", "S607", "S701",  # Allow assert, subprocess, jinja2 in tests
+    "T201",       # Allow print in tests
+    "PLR6301",    # Test methods don't use self (pytest classes)
+    "PLR2004",    # Magic values in assertions are fine
+    "PLC0415",    # Lazy imports in test functions are idiomatic
+    "PLC2701",    # Private name imports for testing internals
+    "ARG002",     # Unused method arguments (fixtures)
+    "DTZ005",     # Naive datetime in tests is fine
+    "PLR0904",    # Test classes naturally have many test methods
+]
+
+[tool.ruff.lint.pylint]
+# All values are pylint defaults — do not inflate to hide violations.
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,13 @@ select = [
     "I",    # isort - import sorting
 
     # Code quality
+    "A",    # flake8-builtins - prevent shadowing builtins (id, type, list, etc.)
     "B",    # flake8-bugbear - common bugs and design issues
     "SIM",  # flake8-simplify - simplify code
     "C4",   # flake8-comprehensions - better comprehensions
     "PIE",  # flake8-pie - misc improvements
     "RET",  # flake8-return - return statement issues
+    "RSE",  # flake8-raise - raise best practices
     "RUF",  # Ruff-specific rules
     "FA",   # flake8-future-annotations
     "ISC",  # flake8-implicit-str-concat - catch missing commas
@@ -88,6 +90,22 @@ select = [
     "TC",   # flake8-type-checking - TYPE_CHECKING imports
     "PTH",  # flake8-use-pathlib - prefer pathlib over os.path
     "FURB", # refurb - modernize and simplify code
+    "FLY",  # flynt - prefer f-strings over .format() and %
+
+    # Naming
+    # "N",  # pep8-naming - PEP 8 naming conventions (enable when ready)
+
+    # Datetime
+    "DTZ",  # flake8-datetimez - enforce timezone-aware datetimes
+
+    # Error messages
+    "EM",   # flake8-errmsg - no string literals in exceptions
+
+    # Pylint
+    "PLC",  # pylint conventions
+    "PLE",  # pylint errors
+    "PLR",  # pylint refactor (too-many-args, too-many-branches, etc.)
+    "PLW",  # pylint warnings
 
     # Performance
     "PERF", # Perflint - performance anti-patterns
@@ -108,16 +126,23 @@ select = [
 
     # Print statements (use logging instead)
     "T20",  # flake8-print
-
-    # Encoding
-    "PLW1514",  # unspecified-encoding - require encoding in open()
 ]
 
 [tool.ruff.lint.isort]
 known-first-party = ["tests", "scripts"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["S101", "S404", "S603", "S607", "S701", "T201"]  # Allow assert, subprocess, jinja2, print in tests
+"tests/**" = [
+    "S101", "S404", "S603", "S607", "S701",  # Allow assert, subprocess, jinja2 in tests
+    "T201",       # Allow print in tests
+    "PLR6301",    # Test methods don't use self (pytest classes)
+    "PLR2004",    # Magic values in assertions are fine
+    "PLC0415",    # Lazy imports in test functions are idiomatic
+    "PLC2701",    # Private name imports for testing internals
+    "ARG002",     # Unused method arguments (fixtures)
+    "DTZ005",     # Naive datetime in tests is fine
+    "PLR0904",    # Test classes naturally have many test methods
+]
 "extensions.py" = ["S404", "S602", "S605", "S607"]  # Template extensions use subprocess for git commands
 "scripts/**" = ["T201"]  # CLI scripts need print
 

--- a/scripts/lint_templates.py
+++ b/scripts/lint_templates.py
@@ -22,7 +22,7 @@ import re
 import sys
 import tomllib
 import unicodedata
-from datetime import date
+from datetime import UTC, datetime
 from pathlib import Path
 
 import yaml
@@ -48,7 +48,7 @@ def slugify(value: str, separator: str = "-") -> str:
 # ---------------------------------------------------------------------------
 
 _COMMON = {
-    "current_year": date.today().year,
+    "current_year": datetime.now(UTC).year,
     "giscus_repo_id": "PLACEHOLDER_REPO_ID",
     "giscus_discussion_category_id": "PLACEHOLDER_CATEGORY_ID",
 }
@@ -69,7 +69,7 @@ def _build_context(overrides: dict) -> dict:
         "repository_name": "my-test-project",
         "copyright_holder": "Test Author",
         "copyright_holder_email": "test@example.com",
-        "copyright_date": str(date.today().year),
+        "copyright_date": str(datetime.now(UTC).year),
         "copyright_license": "MIT",
         "python_package_distribution_name": "my-test-project",
         "python_package_import_name": "my_test_project",
@@ -263,6 +263,33 @@ def render_template(env: Environment, template_path: Path, context: dict) -> str
 # ---------------------------------------------------------------------------
 
 
+def _should_skip_template(rel_str: str, context: dict) -> bool:
+    """Return True if this template/variant combination should be skipped."""
+    provider = context.get("repository_provider", "github.com")
+
+    # Skip GitHub-only files for GitLab variants and vice versa
+    if rel_str.startswith(".github") and provider != "github.com":
+        return True
+    if "gitlab-ci" in rel_str and provider != "gitlab.com":
+        return True
+    # Skip CI files when CI is disabled
+    ci_files = ("ci.yml", "release.yml", "copier-update.yml", "gitlab-ci")
+    if not context.get("use_ci") and any(x in rel_str for x in ci_files):
+        return True
+    # Skip community/open-source files for internal projects
+    community_files = (
+        "CODE_OF_CONDUCT",
+        "CONTRIBUTING",
+        "SECURITY",
+        "LICENSE",
+        "license.md",
+        "contributing.md",
+        "code_of_conduct.md",
+        "FUNDING",
+    )
+    return context.get("project_visibility") == "internal" and any(x in rel_str for x in community_files)
+
+
 def lint_templates(verbose: bool = False) -> int:
     """Lint all templates. Returns exit code (0=ok, 1=errors)."""
     env = Environment(
@@ -283,33 +310,7 @@ def lint_templates(verbose: bool = False) -> int:
         validator = VALIDATORS.get(ext)
 
         for variant_name, context in CONTEXT_VARIANTS.items():
-            # Skip GitHub-only files for GitLab variants and vice versa
-            rel_str = str(rel)
-            is_github_file = rel_str.startswith(".github")
-            is_gitlab_file = "gitlab-ci" in rel_str
-            provider = context.get("repository_provider", "github.com")
-
-            if is_github_file and provider != "github.com":
-                continue
-            if is_gitlab_file and provider != "gitlab.com":
-                continue
-            # Skip CI files when CI is disabled
-            if not context.get("use_ci") and any(x in rel_str for x in ["ci.yml", "release.yml", "copier-update.yml", "gitlab-ci"]):
-                continue
-            # Skip community/open-source files for internal projects
-            if context.get("project_visibility") == "internal" and any(
-                x in rel_str
-                for x in [
-                    "CODE_OF_CONDUCT",
-                    "CONTRIBUTING",
-                    "SECURITY",
-                    "LICENSE",
-                    "license.md",
-                    "contributing.md",
-                    "code_of_conduct.md",
-                    "FUNDING",
-                ]
-            ):
+            if _should_skip_template(str(rel), context):
                 continue
 
             total_checks += 1

--- a/tests/test_licenses.py
+++ b/tests/test_licenses.py
@@ -29,15 +29,15 @@ env = Environment()
 template = env.from_string(Path("project/LICENSE.jinja").read_text(encoding="utf-8"))
 
 
-for license in licenses:
-    print(f"Testing license: {license}")
+for license_id in licenses:
+    print(f"Testing license: {license_id}")
     rendered = template.render(
         project_name="Test Project",
         project_description="Testing this great template",
         author_fullname="Jane Doe",
         author_username="janedoe",
         author_email="jane@example.com",
-        copyright_license=license,
+        copyright_license=license_id,
         copyright_holder="Jane Doe",
         copyright_date="2024",
     )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -622,9 +622,9 @@ class TestTemplateUpdateCheck:
         # Remove answers file to simulate missing
         (project / ".copier-answers.yml").unlink(missing_ok=True)
         env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env, check=False)
         assert result.returncode == 0
-        assert result.stdout == ""
+        assert not result.stdout
 
     @pytest.mark.slow
     def test_script_exits_cleanly_for_gitlab_source(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
@@ -635,9 +635,9 @@ class TestTemplateUpdateCheck:
         answers.write_text("_commit: 1.0.0\n_src_path: https://gitlab.com/org/repo\n")
         script = project / "scripts" / "check-template-update.sh"
         env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env, check=False)
         assert result.returncode == 0
-        assert result.stdout == ""
+        assert not result.stdout
 
     @pytest.mark.slow
     def test_script_handles_gh_shorthand(self, copier_defaults: dict, project_factory, tmp_path: Path) -> None:
@@ -648,7 +648,7 @@ class TestTemplateUpdateCheck:
         answers.write_text("_commit: 0.0.0\n_src_path: gh:detailobsessed/copier-uv-bleeding\n")
         script = project / "scripts" / "check-template-update.sh"
         env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env, check=False)
         assert result.returncode == 0
         # Skip assertion if API unavailable (rate-limited, offline)
         if not result.stdout.strip():
@@ -664,7 +664,7 @@ class TestTemplateUpdateCheck:
         answers.write_text("_commit: 0.0.0\n_src_path: https://github.com/detailobsessed/copier-uv-bleeding\n")
         script = project / "scripts" / "check-template-update.sh"
         env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env, check=False)
         assert result.returncode == 0
         # Skip assertion if API unavailable (rate-limited, offline)
         if not result.stdout.strip():
@@ -686,6 +686,7 @@ class TestTemplateUpdateCheck:
             ["bash", "-c", curl_cmd],
             capture_output=True,
             text=True,
+            check=False,
         )
         latest = result.stdout.strip()
         if not latest:
@@ -694,7 +695,7 @@ class TestTemplateUpdateCheck:
         answers.write_text(f"_commit: {latest}\n_src_path: gh:detailobsessed/copier-uv-bleeding\n")
         script = project / "scripts" / "check-template-update.sh"
         env = {**os.environ, "COPIER_CHECK_INTERVAL": "0"}
-        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env)
+        result = subprocess.run(["bash", str(script)], cwd=project, capture_output=True, text=True, env=env, check=False)
         assert result.returncode == 0
         assert "Template update available" not in result.stdout
 
@@ -1169,5 +1170,5 @@ class TestIntegration:
         self._init_git_repo(project)
 
         # Run uv sync
-        result = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True)
+        result = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True, check=False)
         assert result.returncode == 0, f"uv sync failed: {result.stderr}"


### PR DESCRIPTION
## Summary
Adds strict pylint rules and modern ruff rule categories to both the template and the repo's own config.

## Problem
The template was missing several useful ruff rule categories (pylint subcategories, DTZ, EM, A, PLR0904) and the repo's own per-file-ignores were out of sync with the template's test suppressions.

## Solution
- Add PLC, PLE, PLR, PLW (pylint subcategories), DTZ, EM, A rule categories to both configs
- Add empty `[tool.ruff.lint.pylint]` section as documentation guard rail (pylint defaults, don't inflate)
- Sync repo's own per-file-ignores with template: PLR6301, PLR2004, PLC0415, PLC2701, ARG002, DTZ005, PLR0904
- Fix all 15 lint violations in repo's own code:
  - DTZ011: `date.today()` → `datetime.now(UTC)`
  - PLW1510: add explicit `check=False` to subprocess.run calls
  - PLC1901: simplify `== ""` to `not`
  - A001: rename `license` → `license_id` to avoid shadowing builtin
  - PLR0912: extract `_should_skip_template()` helper in lint_templates.py
  - PLR0904: config-level ignore for test classes (naturally many methods)

## Changes
- `pyproject.toml` — expanded select list, synced per-file-ignores
- `project/pyproject.toml.jinja` — same rule additions for generated projects
- `extensions.py` — DTZ011 fix
- `scripts/lint_templates.py` — DTZ011 fix, PLR0912 refactor
- `tests/test_licenses.py` — A001 fix
- `tests/test_template.py` — PLW1510, PLC1901 fixes