### PR TITLE
fix: add verbose=true to template update hook so prek shows the notice

### DIFF
--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -146,6 +146,7 @@ entry = "bash scripts/check-template-update.sh"
 language = "system"
 always_run = true
 pass_filenames = false
+verbose = true
 stages = ["post-checkout"]
 
 [[repos]]


### PR DESCRIPTION
prek captures hook stdout and only displays Passed/Failed. The `check-template-update` post-checkout hook prints a template update notice, but users never see it because prek swallows the output.

Adding `verbose = true` to the hook config makes prek pass through the hook's stdout, so the notice is visible on branch switch:

```
check for template updates...............................................Passed
- hook id: check-template-update
- duration: 0.25s

  ℹ️  Template update available: 0.27.9 → 0.27.10
    Run: copier update --trust . --skip-answered
    Or:  poe update-template
```

**Change:** One line added to `prek.toml.jinja` — `verbose = true` on the `check-template-update` hook.