### PR TITLE
feat: add ci-pass gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,14 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
+
+  ci-pass:
+    if: always()
+    needs: [links, test-project]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check all jobs passed
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+      with:
+        allowed-skips: test-project
+        jobs: ${{ toJSON(needs) }}

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -227,3 +227,14 @@ jobs:
       with:
         token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
         fail_ci_if_error: false
+
+  ci-pass:
+    if: always()
+    needs: [links, quality, tests]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check all jobs passed
+      uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+      with:
+        allowed-skips: quality, tests
+        jobs: {% raw %}${{ toJSON(needs) }}{% endraw %}

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -20,3 +20,9 @@
 {%- endif %}
 
 {{ project_description }}
+{% if use_ci and repository_provider == "github.com" %}
+## Branch protection
+
+The CI workflow includes a `ci-pass` gate job that aggregates the status of all CI jobs.
+Add a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule) for `main` requiring the **`ci-pass`** status check to pass before merging.
+{% endif %}


### PR DESCRIPTION
## Summary

Add a `ci-pass` gate job to CI workflows using [re-actors/alls-green](https://github.com/re-actors/alls-green) for branch protection.

## Problem

Discovered in surfmon — an entire 8-PR stack merged with CI failing because no branch protection rule blocked it. Individual job names change as the CI matrix evolves, making manual branch protection maintenance fragile.

## Solution

Add a single `ci-pass` job that aggregates all CI job results via `re-actors/alls-green` (used by aiohttp, cryptography, pytest, pip-tools, setuptools). Repos only need to require `ci-pass` in branch protection settings — no maintenance when the CI matrix changes.

## Changes

- **`project/.github/workflows/ci.yml.jinja`** — added `ci-pass` job with `allowed-skips: quality, tests` (they can be skipped by the changes filter)
- **`.github/workflows/ci.yml`** — added `ci-pass` to the template project's own CI with SHA-pinned action
- **`project/README.md.jinja`** — added branch protection setup note (gated behind `use_ci` and GitHub)

Closes #218