### PR TITLE
refactor: collapse project_type to 2 choices and add cli_framework

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -51,11 +51,10 @@ project_description:
 project_type:
   type: str
   help: What type of project is this?
-  default: package
+  default: app
   choices:
-    Application (standalone script, no CLI entry point): app
-    Library (importable package, no CLI): lib
-    Package (installable with CLI entry point): package
+    Application (with CLI entry point — uv init --app): app
+    Library (importable package, no CLI — uv init --lib): lib
 
 project_visibility:
   type: str
@@ -180,11 +179,15 @@ python_package_command_line_name:
   default: "{{ project_name | slugify }}"
   when: false
 
-# Typer is always used for packages - no argparse option
-use_typer:
-  type: bool
-  default: true
-  when: false
+cli_framework:
+  type: str
+  help: CLI framework
+  default: typer
+  when: "{{ project_type == 'app' }}"
+  choices:
+    "Typer (https://typer.tiangolo.com/)": typer
+    "Cyclopts (https://cyclopts.readthedocs.io/)": cyclopts
+    "None (no framework)": none
 
 use_ci:
   type: bool

--- a/project/CONTRIBUTING.md.jinja
+++ b/project/CONTRIBUTING.md.jinja
@@ -13,7 +13,7 @@ uv sync
 
 This installs all dependencies including dev tools. If `uv` is not installed, see the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
-{% if project_type == 'package' -%}
+{% if project_type == 'app' -%}
 Run the CLI with `uv run {{ python_package_command_line_name }} [ARGS...]`.
 
 {% endif -%}

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -31,8 +31,10 @@ classifiers = [
 ]
 {%- endif %}
 dependencies = [
-{%- if project_type == 'package' and use_typer %}
-    "typer>=0.21",
+{%- if project_type == 'app' and cli_framework == 'typer' %}
+    "typer>=0.23",
+{%- elif project_type == 'app' and cli_framework == 'cyclopts' %}
+    "cyclopts>=4.5",
 {%- endif %}
 ]
 
@@ -55,7 +57,7 @@ Discussions = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repos
 Funding = "https://{{ repository_host }}/sponsors/{{ author_username }}"
 {%- endif %}
 
-{% if project_type == 'package' -%}
+{% if project_type == 'app' -%}
 [project.scripts]
 {{ python_package_command_line_name }} = "{{ python_package_import_name }}.cli:main"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def copier_defaults() -> dict:
 def generate_project(
     tmp_path: Path,
     answers: dict,
-    project_type: str = "package",
+    project_type: str = "app",
 ) -> Path:
     """Generate a project using copier.
 
@@ -85,7 +85,7 @@ def project_factory(tmp_path_factory: pytest.TempPathFactory):
     """
     cache: dict[str, Path] = {}
 
-    def _generate(answers: dict, project_type: str = "package") -> Path:
+    def _generate(answers: dict, project_type: str = "app") -> Path:
         key = _cache_key(answers, project_type)
         if key not in cache:
             path = tmp_path_factory.mktemp("project")

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -17,11 +17,11 @@ if TYPE_CHECKING:
 
 
 class TestProjectTypes:
-    """Test different project types generate correctly."""
+    """Test project types (app = CLI, lib = no CLI)."""
 
-    def test_package_type_has_cli(self, copier_defaults: dict, project_factory) -> None:
-        """Package type should have CLI entry point."""
-        project = project_factory(copier_defaults, "package")
+    def test_app_type_has_cli(self, copier_defaults: dict, project_factory) -> None:
+        """App type should have CLI entry point."""
+        project = project_factory(copier_defaults, "app")
 
         pyproject = project / "pyproject.toml"
         assert pyproject.exists()
@@ -38,16 +38,11 @@ class TestProjectTypes:
         content = pyproject.read_text()
         assert "[project.scripts]" not in content
 
-    def test_app_type_no_main_py(self, copier_defaults: dict, project_factory) -> None:
-        """App type should NOT generate main.py (users create their own)."""
-        project = project_factory(copier_defaults, "app")
-        assert not (project / "main.py").exists()
-
-    def test_app_type_no_cli_entry_point(self, copier_defaults: dict, project_factory) -> None:
-        """App type should not have [project.scripts] section."""
-        project = project_factory(copier_defaults, "app")
-        content = (project / "pyproject.toml").read_text()
-        assert "[project.scripts]" not in content
+    def test_no_main_py(self, copier_defaults: dict, project_factory) -> None:
+        """Neither type should generate main.py (users create their own)."""
+        for project_type in ("app", "lib"):
+            project = project_factory(copier_defaults, project_type)
+            assert not (project / "main.py").exists()
 
 
 class TestCoreFiles:
@@ -1104,30 +1099,47 @@ class TestGitLabSupport:
         assert not (project / ".gitlab-ci.yml").exists()
 
 
-class TestTyperOption:
-    """Test typer CLI option."""
+class TestCLIFramework:
+    """Test cli_framework question (typer, cyclopts, none)."""
 
-    def test_typer_enabled_has_typer_dependency(self, copier_defaults: dict, project_factory) -> None:
-        """Typer enabled should add typer dependency."""
-        answers = {**copier_defaults, "use_typer": True}
-        project = project_factory(answers, "package")
+    def test_typer_has_dependency(self, copier_defaults: dict, project_factory) -> None:
+        """Typer framework should add typer dependency."""
+        answers = {**copier_defaults, "cli_framework": "typer"}
+        project = project_factory(answers, "app")
 
-        pyproject = project / "pyproject.toml"
-        content = pyproject.read_text()
+        content = (project / "pyproject.toml").read_text()
         assert '"typer>=' in content
+        assert "cyclopts" not in content
 
-    def test_typer_disabled_no_typer_dependency(self, copier_defaults: dict, project_factory) -> None:
-        """Typer disabled should not add typer dependency."""
-        answers = {**copier_defaults, "use_typer": False}
-        project = project_factory(answers, "package")
+    def test_cyclopts_has_dependency(self, copier_defaults: dict, project_factory) -> None:
+        """Cyclopts framework should add cyclopts dependency."""
+        answers = {**copier_defaults, "cli_framework": "cyclopts"}
+        project = project_factory(answers, "app")
 
-        pyproject = project / "pyproject.toml"
-        content = pyproject.read_text()
+        content = (project / "pyproject.toml").read_text()
+        assert '"cyclopts>=' in content
         assert "typer" not in content
 
-    def test_package_type_no_scaffold_code(self, copier_defaults: dict, project_factory) -> None:
-        """Package type should not generate scaffold source files (users create their own via uv init)."""
-        project = project_factory(copier_defaults, "package")
+    def test_none_no_cli_dependency(self, copier_defaults: dict, project_factory) -> None:
+        """No framework should not add any CLI dependency."""
+        answers = {**copier_defaults, "cli_framework": "none"}
+        project = project_factory(answers, "app")
+
+        content = (project / "pyproject.toml").read_text()
+        assert "typer" not in content
+        assert "cyclopts" not in content
+
+    def test_none_still_has_scripts_entry(self, copier_defaults: dict, project_factory) -> None:
+        """App with no framework still gets [project.scripts] — user wires their own CLI."""
+        answers = {**copier_defaults, "cli_framework": "none"}
+        project = project_factory(answers, "app")
+
+        content = (project / "pyproject.toml").read_text()
+        assert "[project.scripts]" in content
+
+    def test_app_type_no_scaffold_code(self, copier_defaults: dict, project_factory) -> None:
+        """App type should not generate scaffold source files (users create their own via uv init)."""
+        project = project_factory(copier_defaults, "app")
         assert not (project / "src" / "test_project" / "_internal").exists()
         assert not (project / "src" / "test_project" / "__main__.py").exists()
         assert not (project / "src" / "test_project" / "py.typed").exists()

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -55,7 +55,7 @@ def _build_context(overrides: dict) -> dict:
     base = {
         "project_name": "My Test Project",
         "project_description": "A test project",
-        "project_type": "package",
+        "project_type": "app",
         "author_fullname": "Test Author",
         "author_email": "test@example.com",
         "author_username": "testuser",
@@ -70,7 +70,7 @@ def _build_context(overrides: dict) -> dict:
         "python_package_distribution_name": "my-test-project",
         "python_package_import_name": "my_test_project",
         "python_package_command_line_name": "my-test-project",
-        "use_typer": True,
+        "cli_framework": "typer",
         "use_ci": True,
         "use_semantic_release": True,
         "publish_to_pypi": True,
@@ -248,10 +248,10 @@ CONTEXT_VARIANTS: dict[str, dict] = {
         "publish_to_pypi": True,
     }),
     # Project types
-    "app-type": _build_context({"project_type": "app"}),
     "lib-type": _build_context({"project_type": "lib"}),
-    # Typer disabled (previously untested — exercises argparse fallback)
-    "no-typer": _build_context({"use_typer": False}),
+    # CLI frameworks
+    "cyclopts": _build_context({"cli_framework": "cyclopts"}),
+    "no-cli-framework": _build_context({"cli_framework": "none"}),
     # Polar enabled (previously untested)
     "polar-enabled": _build_context({"use_polar": True}),
     # Visibility


### PR DESCRIPTION
## Description

Aligns `project_type` choices with `uv init` semantics and introduces a visible CLI framework selector.

### Breaking changes

- **`project_type: package` → `app`** — existing `.copier-answers.yml` files must update this value
- **`use_typer: true/false` → `cli_framework: typer/cyclopts/none`** — same migration needed

### What changed

**`copier.yml`**
- Collapsed 3 project types → 2: **app** (with CLI entry point — `uv init --app`) and **lib** (importable package, no CLI — `uv init --lib`)
- Replaced hidden `use_typer` bool with visible `cli_framework` choice: typer, cyclopts, or none — with docs links in the prompt
- Default changed from `package` to `app`

**Template files**
- `pyproject.toml.jinja`: updated conditionals from `project_type == 'package'` to `'app'`; dependency now handles typer, cyclopts, or no framework
- `CONTRIBUTING.md.jinja`: same conditional update for CLI run instructions

**Tests**
- `conftest.py`: default `project_type` parameter → `"app"`
- `test_template.py`: simplified `TestProjectTypes`, replaced `TestTyperOption` with `TestCLIFramework` covering all three framework options
- `test_template_lint.py`: updated base context and added `cyclopts` + `no-cli-framework` lint variants

### Why keep `[build-system]` in the template

Tests confirmed `uv init` refuses to run when `pyproject.toml` already exists (no `--force` flag), and `uv build` without `[build-system]` silently falls back to setuptools. Keeping the 3-line section in the template is the pragmatic choice until uv gains a way to patch existing projects.

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if applicable)
- [x] `poe check` passes
- [x] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

Related to #99