### PR TITLE
fix: add -q flag to pytest hooks for quieter output

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -114,7 +114,7 @@ priority = 1
 [[repos.hooks]]
 id = "pytest-cov"
 name = "pytest with coverage"
-entry = "uv run pytest --cov=tests --cov-fail-under=90 --cov-report=term-missing:skip-covered"
+entry = "uv run pytest -q --cov=tests --cov-fail-under=90 --cov-report=term-missing:skip-covered"
 language = "system"
 types = ["python"]
 pass_filenames = false

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -113,7 +113,7 @@ priority = 1
 [[repos.hooks]]
 id = "pytest-testmon"
 name = "pytest affected tests"
-entry = "uv run pytest --testmon --no-cov"
+entry = "uv run pytest -q --testmon --no-cov"
 language = "system"
 types = ["python"]
 pass_filenames = false
@@ -124,7 +124,7 @@ priority = 1
 [[repos.hooks]]
 id = "pytest-cov"
 name = "pytest with coverage"
-entry = "uv run pytest --cov --cov-fail-under=90 --cov-report=term-missing:skip-covered"
+entry = "uv run pytest -q --cov --cov-fail-under=90 --cov-report=term-missing:skip-covered"
 language = "system"
 types = ["python"]
 pass_filenames = false


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->
