### PR TITLE
fix: minor template polish — provider-neutral badge text and stale coverage omit

### DIFF
--- a/project/README_TEMPLATE.md.jinja
+++ b/project/README_TEMPLATE.md.jinja
@@ -5,7 +5,7 @@ and kept up to date on every `copier update`. Your project README lives in `READ
 
 ## Badges
 
-Copy these into your `README.md` to show project status on GitHub:
+Copy these into your `README.md` to show project status:
 
 ```markdown
 {% if repository_provider == "github.com" -%}

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -217,7 +217,7 @@ source = ["src/"]
 
 [tool.coverage.report]
 precision = 2
-omit = ["src/*/__init__.py", "tests/__init__.py"]
+omit = ["src/*/__init__.py"]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING", "if __name__ == .__main__.:"]
 
 [tool.coverage.json]


### PR DESCRIPTION
## Summary
Fix two cosmetic issues in the generated template output.

Closes #226

## Problem
1. **README_TEMPLATE.md** says "show project status on GitHub" but badges are provider-conditional (GitHub/GitLab)
2. **coverage.report.omit** includes `tests/__init__.py` but the template doesn't generate that file

Note: Item 1 from #226 (`custom_dir: docs/.overrides`) is **not a bug** — the directory exists with `comments.html.jinja` and `path-item.html` (git-tracked dotfiles).

## Changes
- `project/README_TEMPLATE.md.jinja`: Make badge text provider-neutral
- `project/pyproject.toml.jinja`: Remove stale `tests/__init__.py` from coverage omit