### PR TITLE
fix: default use_ci to false for internal projects

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -192,7 +192,7 @@ cli_framework:
 use_ci:
   type: bool
   help: "Enable CI workflow? (testing, linting, type checking)"
-  default: true
+  default: "{{ project_visibility == 'public' }}"
 
 use_semantic_release:
   type: bool


### PR DESCRIPTION
## Summary
Default `use_ci` to `false` for internal/corporate projects.

Closes #228

## Problem
Corporate CI environments are too varied — different Docker registries, proxy setups, shared CI components, and versioning pipelines. The template's generated CI config (GitHub Actions, GitLab CI) causes immediate failures on first push for internal projects.

## Solution
Change `use_ci` default from `true` to `{{ project_visibility == 'public' }}`. Internal projects get no CI files by default. Users can still opt in by setting `use_ci: true`.

The existing cascade handles the rest: `use_ci=false` → `use_semantic_release` hidden → `publish_to_pypi` hidden. The `_exclude` rules already gate CI files on `use_ci`.

## Changes
- `copier.yml`: Change `use_ci` default to be visibility-aware