### PR TITLE
feat: add custom PyPI index support without default=true

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -189,6 +189,11 @@ cli_framework:
     "Cyclopts (https://cyclopts.readthedocs.io/)": cyclopts
     "None (no framework)": none
 
+custom_pypi_index_url:
+  type: str
+  help: "Custom PyPI index URL (e.g. Artifactory, Nexus). Leave empty for public PyPI only."
+  default: ""
+
 use_ci:
   type: bool
   help: "Enable CI workflow? (testing, linting, type checking)"

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -98,6 +98,11 @@ docs = [
 
 [tool.uv]
 default-groups = [{% if use_semantic_release %}"maintain", {% endif %}"ci", "docs", "local"]
+{%- if custom_pypi_index_url %}
+
+[[tool.uv.index]]
+url = "{{ custom_pypi_index_url }}"
+{%- endif %}
 
 [tool.ruff]
 target-version = "py314"

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -77,6 +77,7 @@ def _build_context(overrides: dict) -> dict:
         "use_blacksmith_runners": False,
         "project_visibility": "public",
         "use_polar": False,
+        "custom_pypi_index_url": "",
         "include_template_dev_scripts": False,
         "current_year": datetime.now(UTC).year,
         "giscus_repo_id": "PLACEHOLDER_REPO_ID",
@@ -275,6 +276,13 @@ CONTEXT_VARIANTS: dict[str, dict] = {
         "publish_to_pypi": False,
         "use_polar": False,
         "use_blacksmith_runners": False,
+    }),
+    # Custom PyPI index (corporate Artifactory/Nexus)
+    "custom-pypi-index": _build_context({
+        "project_visibility": "internal",
+        "custom_pypi_index_url": "https://artifactory.company.com/api/pypi/python-virtual/simple",
+        "publish_to_pypi": False,
+        "use_polar": False,
     }),
 }
 


### PR DESCRIPTION
## Summary
Add support for custom PyPI index URLs (e.g. Artifactory, Nexus) without replacing public PyPI.

Closes #229

## Problem
Corporate environments often use internal PyPI mirrors. If configured with `default = true`, the custom index **replaces** public PyPI entirely — packages not yet mirrored (like `uv-build`) fail to resolve with no fallback.

## Solution
Add a `custom_pypi_index_url` copier question. When set, generates a `[[tool.uv.index]]` section **without** `default = true`, making it supplemental so public PyPI remains as fallback.

```toml
[[tool.uv.index]]
url = "https://artifactory.company.com/api/pypi/python-virtual/simple"
```

## Changes
- `copier.yml`: Add `custom_pypi_index_url` question (empty string default)
- `project/pyproject.toml.jinja`: Conditionally render `[[tool.uv.index]]` section
- `tests/test_template_lint.py`: Add `custom_pypi_index_url` to base context + new `custom-pypi-index` test variant