### PR TITLE
feat: enable auto-merge on repos

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -233,7 +233,7 @@ _tasks:
   - command: "if [ -d .git ]; then uv run prek install; fi"
     when: "{{ _copier_operation in ('update', 'recopy') }}"
   # Copy only — one-time GitHub repo setup
-  - command: "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge && echo '✓ Enabled delete-branch-on-merge' || true"
+  - command: "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge --enable-auto-merge && echo '✓ Enabled delete-branch-on-merge and auto-merge' || true"
     when: "{{ _copier_operation == 'copy' }}"
   # Copy — setup instructions
   - command: "printf '\\n🎉 Project created!\\n\\n  ✓ Dependencies installed\\n\\nTo finish setup:\\n  git init && uv run prek install && uv run prek autoupdate\\n  Create your source files in src/ and tests/\\n'"


### PR DESCRIPTION
## Summary
Enable auto-merge on repos so PRs can be merged without manually waiting for CI.

Closes #233

## Changes
- **Template repo**: Enabled `allow_auto_merge` via `gh repo edit --enable-auto-merge`
- **Rendered projects**: Extended the existing `gh repo edit` copier task to also pass `--enable-auto-merge` during `copier copy`