### PR TITLE
fix: add --defaults to copier update in update-template poe task

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -265,7 +265,7 @@ prek = "prek run --all-files"
 
 # Template utilities
 check-template = "bash scripts/check-template-update.sh"
-update-template = { shell = "copier update --trust . --skip-answered && uv sync --upgrade && prek autoupdate && echo '  ✓ Dependencies upgraded and hook versions updated'" }
+update-template = { shell = "copier update --trust . --skip-answered --defaults && uv sync --upgrade && prek autoupdate && echo '  ✓ Dependencies upgraded and hook versions updated'" }
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -594,6 +594,7 @@ class TestTemplateUpdateCheck:
         content = pyproject.read_text()
         assert "update-template" in content
         assert "copier update" in content
+        assert "--defaults" in content
         assert "uv sync --upgrade" in content
         assert "prek autoupdate" in content
 
@@ -1411,7 +1412,7 @@ class TestSkipIfExists:
 
         # Re-apply template
         result = subprocess.run(
-            ["copier", "recopy", "--trust", "-r", "HEAD", "--skip-answered", "--overwrite"],
+            ["copier", "recopy", "--trust", "-r", "HEAD", "--skip-answered", "--defaults", "--overwrite"],
             cwd=project,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Description

<!-- Brief description of what this PR does -->

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)
- [ ] `poe check` passes
- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)

## Related Issues

<!-- Link related issues: Fixes #123, Related to #456 -->
