### PR TITLE
fix: add semantic_release.remote config for GitLab projects

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -303,4 +303,12 @@ mode = "update"
 allowed_tags = ["build", "chore", "ci", "deps", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
+{%- if repository_provider == "gitlab.com" %}
+
+[tool.semantic_release.remote]
+type = "gitlab"
+{%- if repository_host != "gitlab.com" %}
+domain = "{{ repository_host }}"
+{%- endif %}
+{%- endif %}
 {%- endif %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1083,6 +1083,40 @@ class TestGitLabSupport:
         content = mkdocs.read_text()
         assert "-/edit/main/docs/" in content
 
+    def test_gitlab_semantic_release_remote(self, copier_defaults: dict, project_factory) -> None:
+        """GitLab projects should have [tool.semantic_release.remote] with type=gitlab (#236)."""
+        answers = {**copier_defaults, "repository_provider": "gitlab.com", "use_ci": True, "use_semantic_release": True}
+        project = project_factory(answers)
+
+        content = (project / "pyproject.toml").read_text()
+        assert "[tool.semantic_release.remote]" in content
+        assert 'type = "gitlab"' in content
+        assert "domain" not in content
+
+    def test_gitlab_selfhosted_semantic_release_remote_domain(self, copier_defaults: dict, project_factory) -> None:
+        """Self-hosted GitLab should include domain in semantic_release.remote (#236)."""
+        answers = {
+            **copier_defaults,
+            "repository_provider": "gitlab.com",
+            "repository_host": "gitlab.company.com",
+            "use_ci": True,
+            "use_semantic_release": True,
+        }
+        project = project_factory(answers)
+
+        content = (project / "pyproject.toml").read_text()
+        assert "[tool.semantic_release.remote]" in content
+        assert 'type = "gitlab"' in content
+        assert 'domain = "gitlab.company.com"' in content
+
+    def test_github_no_semantic_release_remote(self, copier_defaults: dict, project_factory) -> None:
+        """GitHub projects should NOT have [tool.semantic_release.remote] section."""
+        answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True}
+        project = project_factory(answers)
+
+        content = (project / "pyproject.toml").read_text()
+        assert "[tool.semantic_release.remote]" not in content
+
     def test_github_edit_uri_no_dash_prefix(self, copier_defaults: dict, project_factory) -> None:
         """GitHub projects should have plain edit/ in edit_uri (#164)."""
         project = project_factory(copier_defaults)


### PR DESCRIPTION
## Summary
Add `[tool.semantic_release.remote]` config for GitLab projects so semantic-release targets the correct VCS provider.

## Problem
When generating a project with `repository_provider=gitlab.com`, semantic-release defaults to GitHub API calls, causing release failures.

Closes #236

## Solution
Add conditional `[tool.semantic_release.remote]` section in `pyproject.toml.jinja`:
- `type = "gitlab"` for all GitLab projects
- `domain = "{{ repository_host }}"` for self-hosted GitLab instances (where host differs from `gitlab.com`)

## Changes
- `project/pyproject.toml.jinja`: Add `[tool.semantic_release.remote]` block inside `use_semantic_release` conditional
- `tests/test_template.py`: 3 new tests — GitLab remote, self-hosted domain, GitHub negative case