### PR TITLE
fix: add github-token to setup-uv steps in CI and release workflows

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -111,6 +111,7 @@ jobs:
 {%- endif %}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
+        github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 
     - name: Install dependencies
       run: uv run poe setup
@@ -195,6 +196,7 @@ jobs:
 {%- endif %}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
+        github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 {%- if publish_to_pypi %}
         cache-suffix: {% raw %}${{ matrix.resolution }}{% endraw %}
 {%- endif %}

--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -36,6 +36,7 @@ jobs:
       with:
         python-version: "3.14"
         enable-cache: true
+        github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 
     - name: Install dependencies
       run: uv sync --only-group maintain
@@ -85,6 +86,7 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.14"
+        github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 
     - name: Build and publish
       run: |

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -235,6 +235,22 @@ class TestCIWorkflows:
         content = release_yml.read_text()
         assert "uv publish" in content
 
+    def test_release_setup_uv_has_github_token(self, copier_defaults: dict, project_factory) -> None:
+        """Release workflow setup-uv steps should have github-token to avoid rate limiting (#237)."""
+        answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True, "publish_to_pypi": True}
+        project = project_factory(answers)
+
+        content = (project / ".github" / "workflows" / "release.yml").read_text()
+        assert "github-token:" in content
+
+    def test_ci_setup_uv_has_github_token(self, copier_defaults: dict, project_factory) -> None:
+        """CI workflow setup-uv steps should have github-token to avoid rate limiting (#237)."""
+        answers = {**copier_defaults, "use_ci": True}
+        project = project_factory(answers)
+
+        content = (project / ".github" / "workflows" / "ci.yml").read_text()
+        assert "github-token:" in content
+
     def test_pyproject_has_build_system(self, copier_defaults: dict, project_factory) -> None:
         """pyproject.toml should have build-system section."""
         project = project_factory(copier_defaults)


### PR DESCRIPTION
## Summary
Add `github-token` to all `setup-uv` steps in CI and release workflow templates to prevent GitHub API rate limiting.

## Problem
`setup-uv` resolves the latest uv version via anonymous GitHub API calls, which get rate-limited on shared runners. This broke the codereviewbuddy release workflow.

Closes #237

## Solution
Pass `github-token: ${{ secrets.GITHUB_TOKEN }}` to every `setup-uv` step so API calls are authenticated and not rate-limited.

## Changes
- `project/.github/workflows/release.yml.jinja`: Add `github-token` to both setup-uv steps (release + pypi-publish jobs)
- `project/.github/workflows/ci.yml.jinja`: Add `github-token` to both setup-uv steps (quality + test jobs)
- `tests/test_template.py`: 2 new tests verifying `github-token` presence in rendered workflows