### PR TITLE
docs: link to ci-components workflow permissions guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ To update the fork later, re-run the install command with `--force`.
 The template automatically runs `uv sync --upgrade` and `prek install` after scaffolding.
 Create your source files in `src/<package_name>/` and tests in `tests/`.
 
+> **⚠️ Workflow permissions:** If semantic-release fails with 401 Unauthorized, your org or repo likely defaults `GITHUB_TOKEN` to read-only. See [Workflow Permissions](https://github.com/detailobsessed/ci-components#workflow-permissions) in ci-components for the fix.
+
 ## Automatic Template Update Checking
 
 Generated projects include a **post-checkout git hook** that automatically checks for template updates. When a newer version is available, you'll see a notification after `git checkout` / `git pull` / `git rebase`.


### PR DESCRIPTION
Adds a callout to the README linking to the [Workflow Permissions](https://github.com/detailobsessed/ci-components#workflow-permissions) guide in ci-components.

If semantic-release fails with 401 Unauthorized, the org or repo likely defaults `GITHUB_TOKEN` to read-only. The linked guide documents the `gh api` commands to diagnose and fix this at both org and repo level.