### PR TITLE
ci: add prek-action job to CI workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a bug report to help us improve.
 title: "bug: "
 labels: bug
-assignees: [ichoosetoaccept]
+assignees: [detailobsessed]
 ---
 
 ### Description of the bug

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project.
 title: "feature: "
 labels: enhancement
-assignees: [ichoosetoaccept]
+assignees: [detailobsessed]
 ---
 
 ### Is your feature request related to a problem? Please describe

--- a/.github/ISSUE_TEMPLATE/3-docs.md
+++ b/.github/ISSUE_TEMPLATE/3-docs.md
@@ -3,7 +3,7 @@ name: Documentation update
 about: Point at unclear, missing or outdated documentation.
 title: "docs: "
 labels: documentation
-assignees: [ichoosetoaccept]
+assignees: [detailobsessed]
 ---
 
 ### Is something unclear, missing or outdated in our documentation?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,21 @@ jobs:
         fail: true
         args: --config .lychee.toml --no-progress .
 
+  prek:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+      with:
+        python-version: "3.14"
+        enable-cache: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
+      env:
+        SKIP: pytest-testmon
+      with:
+        extra-args: '--all-files'
+
   test-project:
     needs: changes
     if: ${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}
@@ -73,7 +88,7 @@ jobs:
     - name: Configure Git
       run: |
         git config --global init.defaultBranch main
-        git config --global user.email "dev@ichoosetoaccept.com"
+        git config --global user.email "dev@detailobsessed.com"
         git config --global user.name "I Choose to Accept"
 
     - name: Setup uv and Python
@@ -110,7 +125,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [links, test-project]
+    needs: [links, prek, test-project]
     runs-on: ubuntu-latest
     steps:
     - name: Check all jobs passed

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -21,6 +21,10 @@ exclude = [
     '^https://pypi\.org/p/$',
     # Localhost URLs (e.g. docs preview in CONTRIBUTING.md)
     '^http://localhost',
+    # Copier template: CONTRIBUTING.md.jinja doesn't exist as plain .md in the template repo
+    '^file://.*CONTRIBUTING\.md',
+    # GitHub Pages site may not be deployed yet
+    '^https://detailobsessed\.github\.io/',
 ]
 
 # Exclude local/private addresses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#240](https://github.com/detailobsessed/copier-uv-bleeding/pull/240),
   [`f60913d`](https://github.com/detailobsessed/copier-uv-bleeding/commit/f60913dafacbab442b45d62d8114823b2bf078cb))
 
-
 ## v0.29.2 (2026-02-17)
 
 ### Bug Fixes
@@ -41,7 +40,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#238](https://github.com/detailobsessed/copier-uv-bleeding/pull/238),
   [`7c51d44`](https://github.com/detailobsessed/copier-uv-bleeding/commit/7c51d44ee276c8d6d83af10477d33cff4ebc91e9))
 
-
 ## v0.29.1 (2026-02-17)
 
 ### Bug Fixes
@@ -49,7 +47,6 @@ See the original repository for historical changes before version 2.0.0.
 - Add --defaults to copier update in update-template poe task
   ([#235](https://github.com/detailobsessed/copier-uv-bleeding/pull/235),
   [`e8e4db8`](https://github.com/detailobsessed/copier-uv-bleeding/commit/e8e4db84f7896076d26ad9e4b4f69703e1b3bb5d))
-
 
 ## v0.29.0 (2026-02-17)
 
@@ -61,7 +58,6 @@ See the original repository for historical changes before version 2.0.0.
 
 - Enable auto-merge on repos ([#234](https://github.com/detailobsessed/copier-uv-bleeding/pull/234),
   [`333396f`](https://github.com/detailobsessed/copier-uv-bleeding/commit/333396f594a8edc2984814fffba2ff3b1214b9a2))
-
 
 ## v0.28.5 (2026-02-17)
 
@@ -75,7 +71,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#230](https://github.com/detailobsessed/copier-uv-bleeding/pull/230),
   [`0848731`](https://github.com/detailobsessed/copier-uv-bleeding/commit/084873138c5943df5dec541e12b1e0a09286c38b))
 
-
 ## v0.28.4 (2026-02-15)
 
 ### Bug Fixes
@@ -83,7 +78,6 @@ See the original repository for historical changes before version 2.0.0.
 - Add -q flag to pytest hooks for quieter output
   ([#227](https://github.com/detailobsessed/copier-uv-bleeding/pull/227),
   [`27c32ab`](https://github.com/detailobsessed/copier-uv-bleeding/commit/27c32ab0ca0bd073597d0e422749ad7a1fc1428f))
-
 
 ## v0.28.3 (2026-02-13)
 
@@ -93,7 +87,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#225](https://github.com/detailobsessed/copier-uv-bleeding/pull/225),
   [`e1ff6d5`](https://github.com/detailobsessed/copier-uv-bleeding/commit/e1ff6d512596d6e8fe89056729c66f224b16da16))
 
-
 ## v0.28.2 (2026-02-13)
 
 ### Bug Fixes
@@ -102,7 +95,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#224](https://github.com/detailobsessed/copier-uv-bleeding/pull/224),
   [`3c5175a`](https://github.com/detailobsessed/copier-uv-bleeding/commit/3c5175a2935bc16fcebce96f05b630b80af26474))
 
-
 ## v0.28.1 (2026-02-13)
 
 ### Documentation
@@ -110,7 +102,6 @@ See the original repository for historical changes before version 2.0.0.
 - Refine ruff rules and rewrite CONTRIBUTING
   ([#223](https://github.com/detailobsessed/copier-uv-bleeding/pull/223),
   [`30cced6`](https://github.com/detailobsessed/copier-uv-bleeding/commit/30cced69e565b68b17369e0957ef7a30de596155))
-
 
 ## v0.28.0 (2026-02-13)
 
@@ -132,7 +123,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#220](https://github.com/detailobsessed/copier-uv-bleeding/pull/220),
   [`8dbde33`](https://github.com/detailobsessed/copier-uv-bleeding/commit/8dbde33adbb6d9a0bc8a79afee0501ccf482377d))
 
-
 ## v0.27.11 (2026-02-13)
 
 ### Bug Fixes
@@ -147,7 +137,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#215](https://github.com/detailobsessed/copier-uv-bleeding/pull/215),
   [`e815632`](https://github.com/detailobsessed/copier-uv-bleeding/commit/e8156327d61694329e96fc5d95c562848738773e))
 
-
 ## v0.27.10 (2026-02-12)
 
 ### Bug Fixes
@@ -155,7 +144,6 @@ See the original repository for historical changes before version 2.0.0.
 - Tell python where .venv is explicitly to help code editors resolve modules
   ([#214](https://github.com/detailobsessed/copier-uv-bleeding/pull/214),
   [`82c75c2`](https://github.com/detailobsessed/copier-uv-bleeding/commit/82c75c2ef6214a7ee845214df55126a0f5f11fae))
-
 
 ## v0.27.9 (2026-02-12)
 
@@ -165,7 +153,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#213](https://github.com/detailobsessed/copier-uv-bleeding/pull/213),
   [`00daf7f`](https://github.com/detailobsessed/copier-uv-bleeding/commit/00daf7fab7d921015ac4a8427c6cce3f1a649774))
 
-
 ## v0.27.8 (2026-02-12)
 
 ### Bug Fixes
@@ -173,7 +160,6 @@ See the original repository for historical changes before version 2.0.0.
 - Inline release logic, remove verify-scaffold.sh, fix CI continue-on-error, right-size triage
   runner ([#212](https://github.com/detailobsessed/copier-uv-bleeding/pull/212),
   [`421d227`](https://github.com/detailobsessed/copier-uv-bleeding/commit/421d227ca02aac39cb52525bc9ecebc4a66a28a9))
-
 
 ## v0.27.7 (2026-02-12)
 
@@ -183,7 +169,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#211](https://github.com/detailobsessed/copier-uv-bleeding/pull/211),
   [`ad7a752`](https://github.com/detailobsessed/copier-uv-bleeding/commit/ad7a75294abc3480e380aaea5641f562f52c1e1e))
 
-
 ## v0.27.6 (2026-02-12)
 
 ### Bug Fixes
@@ -191,7 +176,6 @@ See the original repository for historical changes before version 2.0.0.
 - Gitignore testmondata SQLite sidecar files
   ([#210](https://github.com/detailobsessed/copier-uv-bleeding/pull/210),
   [`5011a30`](https://github.com/detailobsessed/copier-uv-bleeding/commit/5011a30680d0e30ccd1065b245db3419932e78d8))
-
 
 ## v0.27.5 (2026-02-12)
 
@@ -217,7 +201,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#207](https://github.com/detailobsessed/copier-uv-bleeding/pull/207),
   [`140f950`](https://github.com/detailobsessed/copier-uv-bleeding/commit/140f9506363afd868a8c855f748d23f6e6df0dd6))
 
-
 ## v0.27.4 (2026-02-12)
 
 ### Bug Fixes
@@ -225,7 +208,6 @@ See the original repository for historical changes before version 2.0.0.
 - Chmod scripts in _tasks to ensure executable bits after copier update
   ([#205](https://github.com/detailobsessed/copier-uv-bleeding/pull/205),
   [`27d688c`](https://github.com/detailobsessed/copier-uv-bleeding/commit/27d688c44b57dbc7c13b57f4e11ae2c1efb3f4ab))
-
 
 ## v0.27.3 (2026-02-12)
 
@@ -235,7 +217,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#204](https://github.com/detailobsessed/copier-uv-bleeding/pull/204),
   [`4012488`](https://github.com/detailobsessed/copier-uv-bleeding/commit/4012488f43d7fc145eb06735e72686e15314e2d9))
 
-
 ## v0.27.2 (2026-02-12)
 
 ### Bug Fixes
@@ -243,7 +224,6 @@ See the original repository for historical changes before version 2.0.0.
 - Use uv run for pathlib encoding check hook
   ([#203](https://github.com/detailobsessed/copier-uv-bleeding/pull/203),
   [`8810014`](https://github.com/detailobsessed/copier-uv-bleeding/commit/8810014e8ec6bd561859c283c2ac1ca17f906bf2))
-
 
 ## v0.27.1 (2026-02-11)
 
@@ -253,7 +233,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#202](https://github.com/detailobsessed/copier-uv-bleeding/pull/202),
   [`e1eb54e`](https://github.com/detailobsessed/copier-uv-bleeding/commit/e1eb54e68a2279129a51f11695b97e040eaa8d89))
 
-
 ## v0.27.0 (2026-02-11)
 
 ### Features
@@ -261,7 +240,6 @@ See the original repository for historical changes before version 2.0.0.
 - Improve template update reliability + add pathlib encoding hook
   ([#200](https://github.com/detailobsessed/copier-uv-bleeding/pull/200),
   [`c917687`](https://github.com/detailobsessed/copier-uv-bleeding/commit/c9176876e4e98a51ad6031be0b0c74431a025800))
-
 
 ## v0.26.3 (2026-02-11)
 
@@ -271,15 +249,13 @@ See the original repository for historical changes before version 2.0.0.
   ([#198](https://github.com/detailobsessed/copier-uv-bleeding/pull/198),
   [`de1d588`](https://github.com/detailobsessed/copier-uv-bleeding/commit/de1d5880e68037d5bbdcd88c6d5c680979449597))
 
-
 ## v0.26.2 (2026-02-11)
 
 ### Bug Fixes
 
-- Modernize copier _tasks with _copier_operation and chain prek autoupdate
+- Modernize copier _tasks with_copier_operation and chain prek autoupdate
   ([#197](https://github.com/detailobsessed/copier-uv-bleeding/pull/197),
   [`1d50965`](https://github.com/detailobsessed/copier-uv-bleeding/commit/1d5096566e3a038c26823ec073c5c453b689c507))
-
 
 ## v0.26.1 (2026-02-11)
 
@@ -289,7 +265,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#195](https://github.com/detailobsessed/copier-uv-bleeding/pull/195),
   [`560f77c`](https://github.com/detailobsessed/copier-uv-bleeding/commit/560f77cc8d29582097f31bb5e11143401f53165f))
 
-
 ## v0.26.0 (2026-02-11)
 
 ### Features
@@ -297,7 +272,6 @@ See the original repository for historical changes before version 2.0.0.
 - Add PR description validation workflow and auto-create needs-triage label
   ([#194](https://github.com/detailobsessed/copier-uv-bleeding/pull/194),
   [`e35e840`](https://github.com/detailobsessed/copier-uv-bleeding/commit/e35e840949a727a93db5866f5c38cdf9fb3568aa))
-
 
 ## v0.25.0 (2026-02-11)
 
@@ -313,7 +287,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#193](https://github.com/detailobsessed/copier-uv-bleeding/pull/193),
   [`c19439b`](https://github.com/detailobsessed/copier-uv-bleeding/commit/c19439b681dd06b52a969458e079b9c3adfa5c94))
 
-
 ## v0.24.1 (2026-02-10)
 
 ### Bug Fixes
@@ -321,7 +294,6 @@ See the original repository for historical changes before version 2.0.0.
 - Coverage inflation, GitLab badge check, release tag format
   ([#189](https://github.com/detailobsessed/copier-uv-bleeding/pull/189),
   [`e6228ab`](https://github.com/detailobsessed/copier-uv-bleeding/commit/e6228aba25c9de249b44210459676a4bd524bf19))
-
 
 ## v0.24.0 (2026-02-10)
 
@@ -331,7 +303,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#187](https://github.com/detailobsessed/copier-uv-bleeding/pull/187),
   [`979ffcd`](https://github.com/detailobsessed/copier-uv-bleeding/commit/979ffcd9104f948590f6abbd7b4718963f3bed9a))
 
-
 ## v0.23.0 (2026-02-10)
 
 ### Features
@@ -339,7 +310,6 @@ See the original repository for historical changes before version 2.0.0.
 - Split README into user-owned starter + template-managed docs
   ([#182](https://github.com/detailobsessed/copier-uv-bleeding/pull/182),
   [`55e58aa`](https://github.com/detailobsessed/copier-uv-bleeding/commit/55e58aaa24979dbc785d95735994bc5a2065b70a))
-
 
 ## v0.22.1 (2026-02-10)
 
@@ -349,7 +319,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#179](https://github.com/detailobsessed/copier-uv-bleeding/pull/179),
   [`aaad053`](https://github.com/detailobsessed/copier-uv-bleeding/commit/aaad05329fea960d393c136f5c3e63e30d3df329))
 
-
 ## v0.22.0 (2026-02-10)
 
 ### Features
@@ -357,7 +326,6 @@ See the original repository for historical changes before version 2.0.0.
 - Adopt poethepoet 0.38-0.41 features — parallel check task
   ([#174](https://github.com/detailobsessed/copier-uv-bleeding/pull/174),
   [`347c903`](https://github.com/detailobsessed/copier-uv-bleeding/commit/347c903e712bbffae35d3cf4a307a82c43d6c0f1))
-
 
 ## v0.21.0 (2026-02-10)
 
@@ -367,12 +335,11 @@ See the original repository for historical changes before version 2.0.0.
   ([#171](https://github.com/detailobsessed/copier-uv-bleeding/pull/171),
   [`7349eb7`](https://github.com/detailobsessed/copier-uv-bleeding/commit/7349eb744067c5dac93efdf737ea9181858bb71b))
 
-
 ## v0.20.4 (2026-02-10)
 
 ### Bug Fixes
 
-- Gate PyPI links on publish_to_pypi, fix GitLab edit_uri, skip __init__.py on update, exclude
+- Gate PyPI links on publish_to_pypi, fix GitLab edit_uri, skip **init**.py on update, exclude
   overrides from lychee ([#169](https://github.com/detailobsessed/copier-uv-bleeding/pull/169),
   [`3170624`](https://github.com/detailobsessed/copier-uv-bleeding/commit/3170624c8d7bd589439214fc3c68a0ccf4cf89bd))
 
@@ -383,7 +350,6 @@ See the original repository for historical changes before version 2.0.0.
 - Trim default_install_hook_types to only hooks actually used
   ([#168](https://github.com/detailobsessed/copier-uv-bleeding/pull/168),
   [`64426d4`](https://github.com/detailobsessed/copier-uv-bleeding/commit/64426d477e76d2c46a6eb618ae6a042f55b2ed87))
-
 
 ## v0.20.3 (2026-02-08)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 ISC License
 
 Copyright (c) 2019, Timothée Mazzucotelli
-Copyright (c) 2026, ichoosetoaccept
+Copyright (c) 2026, detailobsessed
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in this project, please report it respo
 
 **Do NOT open a public issue.**
 
-Instead, please email [dev@ichoosetoaccept.com](mailto:dev@ichoosetoaccept.com) with:
+Instead, please email [dev@detailobsessed.com](mailto:dev@detailobsessed.com) with:
 
 - Description of the vulnerability
 - Steps to reproduce

--- a/docs/generate.md
+++ b/docs/generate.md
@@ -3,19 +3,19 @@
 To generate a project, run the following command:
 
 ```bash
-copier copy --trust "https://github.com/ichoosetoaccept/copier-uv-bleeding.git" /path/to/your/new/project
+copier copy --trust "https://github.com/detailobsessed/copier-uv-bleeding.git" /path/to/your/new/project
 ```
 
 Or with a shorter command:
 
 ```bash
-copier copy --trust "gh:ichoosetoaccept/copier-uv-bleeding" /path/to/your/new/project
+copier copy --trust "gh:detailobsessed/copier-uv-bleeding" /path/to/your/new/project
 ```
 
 You can even generate a project without installing Copier, using [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uvx --with copier-templates-extensions copier copy --trust "gh:ichoosetoaccept/copier-uv-bleeding" /path/to/your/new/project
+uvx --with copier-templates-extensions copier copy --trust "gh:detailobsessed/copier-uv-bleeding" /path/to/your/new/project
 ```
 
 ## Questions

--- a/docs/update.md
+++ b/docs/update.md
@@ -36,10 +36,10 @@ And the file looks like this:
 ```yaml
 # Changes here will be overwritten by Copier
 _commit: 0.1.10
-_src_path: gh:ichoosetoaccept/copier-uv-bleeding
+_src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismar@gmail.com
 author_fullname: Ismar Iljazovic
-author_username: ichoosetoaccept
+author_username: detailobsessed
 copyright_date: '2020'
 copyright_holder: Ismar Iljazovic
 copyright_holder_email: ismar@gmail.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: "Copier UV Bleeding"
 site_description: "Copier template for Python projects managed by uv (bleeding edge fork)"
-site_url: "https://ichoosetoaccept.github.io/copier-uv-bleeding"
-repo_url: "https://github.com/ichoosetoaccept/copier-uv-bleeding"
-repo_name: "ichoosetoaccept/copier-uv-bleeding"
+site_url: "https://detailobsessed.github.io/copier-uv-bleeding"
+repo_url: "https://github.com/detailobsessed/copier-uv-bleeding"
+repo_name: "detailobsessed/copier-uv-bleeding"
 
 validation:
   omitted_files: warn

--- a/project/.github/pull_request_template.md
+++ b/project/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 - [ ] Tests added/updated
 - [ ] Documentation updated (if applicable)
 - [ ] `poe check` passes
-- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-message-convention)
+- [ ] Commit messages follow [conventional commits](../CONTRIBUTING.md#commit-messages)
 
 ## Related Issues
 

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -66,29 +66,29 @@ jobs:
         fail: true
         args: --no-progress .
 
+  prek:
+{%- if use_blacksmith_runners %}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+{%- else %}
+    runs-on: ubuntu-latest
+{%- endif %}
+    steps:
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+      with:
+        python-version: "3.14"
+        enable-cache: true
+        github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+    - uses: j178/prek-action@v1
+      env:
+        SKIP: pytest-testmon
+      with:
+        extra-args: '--all-files'
+
   quality:
     needs: changes
     if: {% raw %}${{ github.event_name == 'push' || needs.changes.outputs.src == 'true' }}{% endraw %}
-{%- if publish_to_pypi %}
-    strategy:
-      matrix:
-        os:
 {%- if use_blacksmith_runners %}
-        - blacksmith-4vcpu-ubuntu-2404
-        - macos-latest
-        - blacksmith-4vcpu-windows-2025
-{%- else %}
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
-{%- endif %}
-        python-version:
-        - "3.14"
-{%- endif %}
-
-{%- if publish_to_pypi %}
-    runs-on: {% raw %}${{ matrix.os }}{% endraw %}
-{%- elif use_blacksmith_runners %}
     runs-on: blacksmith-4vcpu-ubuntu-2404
 {%- else %}
     runs-on: ubuntu-latest
@@ -104,11 +104,7 @@ jobs:
     - name: Setup uv and Python
       uses: astral-sh/setup-uv@v7
       with:
-{%- if publish_to_pypi %}
-        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
-{%- else %}
         python-version: "3.14"
-{%- endif %}
         enable-cache: true
         cache-dependency-glob: pyproject.toml
         github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
@@ -122,18 +118,8 @@ jobs:
         echo '<html><body>No coverage report yet</body></html>' > htmlcov/index.html
         uv run poe docs-build
 
-    - name: Check the code quality
-      run: uv run poe check
-
     - name: Store objects inventory for tests
       uses: actions/upload-artifact@v6
-{%- if publish_to_pypi %}
-{%- if use_blacksmith_runners %}
-      if: {% raw %}${{ matrix.os == 'blacksmith-4vcpu-ubuntu-2404' && matrix.python-version == '3.14' }}{% endraw %}
-{%- else %}
-      if: {% raw %}${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.14' }}{% endraw %}
-{%- endif %}
-{%- endif %}
       with:
         name: objects.inv
         path: site/objects.inv
@@ -141,6 +127,7 @@ jobs:
   tests:
 
     needs:
+    - prek
     - quality
 {%- if publish_to_pypi %}
     strategy:
@@ -232,7 +219,7 @@ jobs:
 
   ci-pass:
     if: always()
-    needs: [links, quality, tests]
+    needs: [links, prek, quality, tests]
     runs-on: ubuntu-latest
     steps:
     - name: Check all jobs passed

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -259,6 +259,22 @@ class TestCIWorkflows:
         content = (project / ".github" / "workflows" / "ci.yml").read_text()
         assert "github-token:" in content
 
+    def test_ci_has_prek_action(self, copier_defaults: dict, project_factory) -> None:
+        """CI workflow should use prek-action for comprehensive quality checks."""
+        answers = {**copier_defaults, "use_ci": True}
+        project = project_factory(answers)
+
+        content = (project / ".github" / "workflows" / "ci.yml").read_text()
+        assert "j178/prek-action" in content
+
+    def test_ci_prek_skips_testmon(self, copier_defaults: dict, project_factory) -> None:
+        """CI prek job should skip pytest-testmon (redundant with tests job)."""
+        answers = {**copier_defaults, "use_ci": True}
+        project = project_factory(answers)
+
+        content = (project / ".github" / "workflows" / "ci.yml").read_text()
+        assert "SKIP: pytest-testmon" in content
+
     def test_pyproject_has_build_system(self, copier_defaults: dict, project_factory) -> None:
         """pyproject.toml should have build-system section."""
         project = project_factory(copier_defaults)


### PR DESCRIPTION
## Summary

Use `j178/prek-action` for comprehensive CI quality checks instead of just `poe check` (ruff + ty).

## Problem

Generated projects only ran ruff + ty via `poe check` in CI, missing all the other prek hooks (gitleaks, shellcheck, actionlint, typos, markdownlint, etc.).

## Solution

Add a dedicated `prek` job using `j178/prek-action@v1` to both the template project CI and the generated project CI template.

## Changes

- **`.github/workflows/ci.yml`**: Added `prek` job (SHA-pinned `v1.1.1`), added to `ci-pass` needs
- **`project/.github/workflows/ci.yml.jinja`**: Added `prek` job with `SKIP: pytest-testmon` (redundant with tests job), removed multi-OS matrix from `quality` job (was only there for `poe check`), removed `poe check` step, simplified artifact upload conditionals, added `prek` to `tests` and `ci-pass` dependencies
- **`tests/test_template.py`**: Added `test_ci_has_prek_action` and `test_ci_prek_skips_testmon` tests