### PR TITLE
fix: add explicit --config flag to lychee-action in CI template

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -64,7 +64,7 @@ jobs:
       uses: lycheeverse/lychee-action@v2
       with:
         fail: true
-        args: --no-progress .
+        args: --config .lychee.toml --no-progress .
 
   prek:
 {%- if use_blacksmith_runners %}


### PR DESCRIPTION
## Summary

Fixes #243 — `lychee-action` v2.7.0 does not auto-discover `.lychee.toml` from the repo root, so all exclusion rules in the config file are silently ignored. This causes false-positive 404 errors in CI (e.g. GitHub Pages URLs that aren't deployed yet).

## Fix

Add `--config .lychee.toml` to the lychee args in the **template** CI workflow so generated projects pass the config explicitly:

```yaml
args: --config .lychee.toml --no-progress .
```

Confirmed on `detailobsessed/windsurf-teacher` — 0 errors with the explicit config path.

## Changes

- **`project/.github/workflows/ci.yml.jinja`**: Added `--config .lychee.toml` to lychee-action args