### PR TITLE
ci: skip no-commit-to-branch hook in CI prek job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
       env:
-        SKIP: pytest-cov,lychee
+        SKIP: no-commit-to-branch,pytest-cov,lychee
       with:
         extra-args: '--all-files'
 

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -81,7 +81,7 @@ jobs:
         github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
     - uses: j178/prek-action@v1
       env:
-        SKIP: pytest-testmon,lychee
+        SKIP: no-commit-to-branch,pytest-testmon,lychee
       with:
         extra-args: '--all-files'
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -267,13 +267,13 @@ class TestCIWorkflows:
         content = (project / ".github" / "workflows" / "ci.yml").read_text()
         assert "j178/prek-action" in content
 
-    def test_ci_prek_skips_testmon(self, copier_defaults: dict, project_factory) -> None:
-        """CI prek job should skip pytest-testmon (redundant with tests job)."""
+    def test_ci_prek_skips_redundant_hooks(self, copier_defaults: dict, project_factory) -> None:
+        """CI prek job should skip hooks redundant with dedicated CI jobs."""
         answers = {**copier_defaults, "use_ci": True}
         project = project_factory(answers)
 
         content = (project / ".github" / "workflows" / "ci.yml").read_text()
-        assert "SKIP: pytest-testmon" in content
+        assert "SKIP: no-commit-to-branch,pytest-testmon,lychee" in content
 
     def test_pyproject_has_build_system(self, copier_defaults: dict, project_factory) -> None:
         """pyproject.toml should have build-system section."""


### PR DESCRIPTION
## Summary

The `no-commit-to-branch` prek hook prevents direct commits to `main` — a useful local dev guard. But in CI, the push-to-main event checks out `main`, so the hook trips and fails the prek job on every merge.

## Fix

Add `no-commit-to-branch` to the `SKIP` env var in the prek CI job for both the main repo and the template.

## Changes

- **`.github/workflows/ci.yml`**: `SKIP: no-commit-to-branch,pytest-cov,lychee`
- **`project/.github/workflows/ci.yml.jinja`**: `SKIP: no-commit-to-branch,pytest-testmon,lychee`