### PR TITLE
docs: unify update instructions to use poe update-template

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -54,9 +54,17 @@ repository_namespace: mkdocstrings
 repository_provider: github.com
 ```
 
-If you want to use all previous answers
-without copier prompting you for each answer,
-run `copier update --force`.
+Generated projects ship a `poe update-template` task that handles the full update flow:
+
+```bash
+poe update-template
+```
+
+This runs:
+
+1. `copier update --trust . --skip-answered --defaults` — pull template changes without prompting
+2. `uv sync --upgrade` — upgrade all dependencies
+3. `prek autoupdate` — update hook versions
 
 Since we are generally using Git in our projects,
 my recommendation is to not think at all

--- a/project/README_TEMPLATE.md.jinja
+++ b/project/README_TEMPLATE.md.jinja
@@ -49,8 +49,10 @@ This project was generated with [copier-uv-bleeding](https://github.com/detailob
 To pull the latest template changes (smart 3-way merge that respects your project changes):
 
 ```bash
-copier update --trust .
+poe update-template
 ```
+
+This runs `copier update --trust . --skip-answered --defaults` followed by `uv sync --upgrade` and `prek autoupdate` to keep dependencies and hooks current.
 
 To re-apply the template from scratch (ignores your project diff):
 

--- a/project/scripts/check-template-update.sh
+++ b/project/scripts/check-template-update.sh
@@ -53,7 +53,6 @@ if [[ "$local_version" != "$latest" ]]; then
   if (echo -n > /dev/tty) 2>/dev/null; then out="/dev/tty"; fi
   echo "" > "$out"
   echo -e "  ${cyan}ℹ️  Template update available:${reset} ${dim}${local_version}${reset} ${bold}→${reset} ${yellow}${latest}${reset}" > "$out"
-  echo -e "  ${dim}Run:${reset} copier update --trust . --skip-answered" > "$out"
-  echo -e "  ${dim}Or:${reset}  poe update-template" > "$out"
+  echo -e "  ${dim}Run:${reset} poe update-template" > "$out"
   echo "" > "$out"
 fi


### PR DESCRIPTION
## Summary

Unify all update instructions to point to `poe update-template` as the canonical command. Previously, different places suggested incomplete commands (`copier update --trust .`, `copier update --force`) that miss critical post-update steps.

## Problem

When template answers change, consumers running bare `copier update` break because they miss:
- `--skip-answered --defaults` — avoids re-prompting for changed questions
- `uv sync --upgrade` — picks up new/changed dependencies
- `prek autoupdate` — updates hook versions

## Changes

- **`project/scripts/check-template-update.sh`**: Simplified notification to just `poe update-template` (removed redundant bare copier command)
- **`project/README_TEMPLATE.md.jinja`**: Changed code block from `copier update --trust .` to `poe update-template` with explanation of what it does
- **`docs/update.md`**: Replaced outdated `copier update --force` with `poe update-template` and documented the 3-step flow