### PR TITLE
fix: update test for unified update notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
+        ref: main
         fetch-depth: 0
         fetch-tags: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ See the original repository for historical changes before version 2.0.0.
   ([#246](https://github.com/detailobsessed/copier-uv-bleeding/pull/246),
   [`5d7441d`](https://github.com/detailobsessed/copier-uv-bleeding/commit/5d7441db45237bbf6f7b2d15e5434d1ab3554555))
 
-
 ## v0.29.3 (2026-02-18)
 
 ### Documentation

--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -28,6 +28,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
       with:
+        ref: main
         fetch-depth: 0
         fetch-tags: true
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -226,6 +226,14 @@ class TestCIWorkflows:
         content = release_yml.read_text()
         assert "semantic-release" in content
 
+    def test_release_checks_out_main(self, copier_defaults: dict, project_factory) -> None:
+        """Release workflow should checkout main explicitly (workflow_run defaults to PR branch)."""
+        answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True}
+        project = project_factory(answers)
+
+        content = (project / ".github" / "workflows" / "release.yml").read_text()
+        assert "ref: main" in content
+
     def test_release_has_uv_publish(self, copier_defaults: dict, project_factory) -> None:
         """Release workflow should use uv publish in separate pypi-publish job."""
         answers = {**copier_defaults, "use_ci": True, "use_semantic_release": True, "publish_to_pypi": True}
@@ -853,11 +861,10 @@ class TestTemplateUpdateNotification:
         assert "1.2.3" in result.stdout
 
     def test_notification_includes_update_commands(self, tmp_path: Path) -> None:
-        """Notification shows both copier and poe update commands."""
+        """Notification shows poe update-template command."""
         project = self._setup(tmp_path)
         self._cleanup_cache(project)
         result = self._run(project)
-        assert "copier update" in result.stdout
         assert "poe update-template" in result.stdout
 
     def test_silent_when_up_to_date(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #249 — release workflow checks out PR branch instead of main under `workflow_run` trigger, so `semantic-release` never sees merged commits.

Also fixes the test + CHANGELOG breakage from PR #247.

## Changes

- **`.github/workflows/release.yml`**: Added `ref: main` to checkout step
- **`project/.github/workflows/release.yml.jinja`**: Same fix for generated projects
- **`tests/test_template.py`**: Added `test_release_checks_out_main` regression test; fixed `test_notification_includes_update_commands` (no longer asserts bare `copier update`)
- **`CHANGELOG.md`**: Markdownlint auto-fix (extra blank line)