### PR TITLE
refactor: drop cli_framework question — users manage CLI deps themselves

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -180,17 +180,6 @@ python_package_command_line_name:
   default: "{{ project_name | slugify }}"
   when: false
 
-cli_framework:
-  type: str
-  help: CLI framework
-  default: typer
-  when: "{{ project_type == 'app' }}"
-  choices:
-    "Typer (https://typer.tiangolo.com/)": typer
-    "Cyclopts (https://cyclopts.readthedocs.io/)": cyclopts
-    "None (no framework)": none
-    "(legacy — equivalent to none)": ""
-
 custom_pypi_index_url:
   type: str
   help: "Custom PyPI index URL (e.g. Artifactory, Nexus). Leave empty for public PyPI only."

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -30,13 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 {%- endif %}
-dependencies = [
-{%- if project_type == 'app' and cli_framework == 'typer' %}
-    "typer>=0.23",
-{%- elif project_type == 'app' and cli_framework == 'cyclopts' %}
-    "cyclopts>=4.5",
-{%- endif %}
-]
+dependencies = []
 
 [project.urls]
 {%- if repository_host in ['github.com', 'gitlab.com'] %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1191,42 +1191,7 @@ class TestGitLabSupport:
 
 
 class TestCLIFramework:
-    """Test cli_framework question (typer, cyclopts, none)."""
-
-    def test_typer_has_dependency(self, copier_defaults: dict, project_factory) -> None:
-        """Typer framework should add typer dependency."""
-        answers = {**copier_defaults, "cli_framework": "typer"}
-        project = project_factory(answers, "app")
-
-        content = (project / "pyproject.toml").read_text()
-        assert '"typer>=' in content
-        assert "cyclopts" not in content
-
-    def test_cyclopts_has_dependency(self, copier_defaults: dict, project_factory) -> None:
-        """Cyclopts framework should add cyclopts dependency."""
-        answers = {**copier_defaults, "cli_framework": "cyclopts"}
-        project = project_factory(answers, "app")
-
-        content = (project / "pyproject.toml").read_text()
-        assert '"cyclopts>=' in content
-        assert "typer" not in content
-
-    def test_none_no_cli_dependency(self, copier_defaults: dict, project_factory) -> None:
-        """No framework should not add any CLI dependency."""
-        answers = {**copier_defaults, "cli_framework": "none"}
-        project = project_factory(answers, "app")
-
-        content = (project / "pyproject.toml").read_text()
-        assert "typer" not in content
-        assert "cyclopts" not in content
-
-    def test_none_still_has_scripts_entry(self, copier_defaults: dict, project_factory) -> None:
-        """App with no framework still gets [project.scripts] — user wires their own CLI."""
-        answers = {**copier_defaults, "cli_framework": "none"}
-        project = project_factory(answers, "app")
-
-        content = (project / "pyproject.toml").read_text()
-        assert "[project.scripts]" in content
+    """Test app project type scaffolding."""
 
     def test_app_type_no_scaffold_code(self, copier_defaults: dict, project_factory) -> None:
         """App type should not generate scaffold source files (users create their own via uv init)."""

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -70,7 +70,6 @@ def _build_context(overrides: dict) -> dict:
         "python_package_distribution_name": "my-test-project",
         "python_package_import_name": "my_test_project",
         "python_package_command_line_name": "my-test-project",
-        "cli_framework": "typer",
         "use_ci": True,
         "use_semantic_release": True,
         "publish_to_pypi": True,
@@ -249,9 +248,6 @@ CONTEXT_VARIANTS: dict[str, dict] = {
     }),
     # Project types
     "lib-type": _build_context({"project_type": "lib"}),
-    # CLI frameworks
-    "cyclopts": _build_context({"cli_framework": "cyclopts"}),
-    "no-cli-framework": _build_context({"cli_framework": "none"}),
     # Visibility
     "internal": _build_context({
         "project_visibility": "internal",


### PR DESCRIPTION
## Summary

Remove the `cli_framework` copier question. Adding a CLI dependency (`typer`, `cyclopts`, or anything else) is a one-liner edit in `pyproject.toml` — it doesn't warrant a scaffolding prompt.

## Changes

- **`copier.yml`**: Delete `cli_framework` question entirely
- **`project/pyproject.toml.jinja`**: Replace conditional dependency block with `dependencies = []`
- **`tests/test_template.py`**: Remove 4 tests from `TestCLIFramework` that tested the removed behaviour
- **`tests/test_template_lint.py`**: Remove `cli_framework` from base context and drop `cyclopts` / `no-cli-framework` lint variants

## Migration for existing projects

Existing projects with `cli_framework: typer` (or `cyclopts`/`none`) in `.copier-answers.yml` will upgrade cleanly — copier silently ignores keys in the answers file that have no corresponding question. No manual migration needed.

Any previously scaffolded CLI dependency (e.g. `typer>=0.23`) remains in `pyproject.toml` as-is; the template just stops managing it going forward.
