### PR TITLE
ci: use allowed-failures for lychee and add token to template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Check links
       uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
-      continue-on-error: true
       with:
         fail: true
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -64,12 +63,12 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+    - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
         python-version: "3.14"
         enable-cache: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: j178/prek-action@0bb87d7f00b0c99306c8bcb8b8beba1eb581c037 # v1.1.1
+    - uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
       env:
         SKIP: no-commit-to-branch,pytest-cov,lychee
       with:
@@ -94,11 +93,12 @@ jobs:
         git config --global user.name "I Choose to Accept"
 
     - name: Setup uv and Python
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
         python-version: "3.14"
         enable-cache: true
         cache-dependency-glob: project/pyproject.toml.jinja
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install Copier
       env:
@@ -117,7 +117,7 @@ jobs:
       run: uv run pytest tests/test_template.py tests/test_template_lint.py -v --cov=tests --cov-report=term-missing
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
@@ -131,4 +131,5 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
       with:
         allowed-skips: test-project
+        allowed-failures: links
         jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,11 @@ jobs:
         fetch-tags: true
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
         python-version: "3.14"
         enable-cache: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install dependencies
       run: uv sync --group dev

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -62,10 +62,10 @@ jobs:
       uses: actions/checkout@v6
     - name: Check links
       uses: lycheeverse/lychee-action@v2
-      continue-on-error: true
       with:
         fail: true
         args: --config .lychee.toml --no-progress .
+        token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 
   prek:
 {%- if use_blacksmith_runners %}
@@ -227,4 +227,5 @@ jobs:
       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
       with:
         allowed-skips: quality, tests
+        allowed-failures: links
         jobs: {% raw %}${{ toJSON(needs) }}{% endraw %}


### PR DESCRIPTION
Replace continue-on-error with allowed-failures in alls-green so the
links job reports honestly. Add GITHUB_TOKEN to the template's lychee
step to avoid rate limits in generated projects.

Follows up on #295. Resolves DOT-450.

<!-- Closes #, Related to # -->

## Why

<!-- What problem does this solve, or what improvement does it make? -->

## Notes for reviewer

<!-- Anything non-obvious: trade-offs made, things to look out for, follow-up work left. Delete if nothing to add. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
