### PR TITLE
build: add pyrightconfig.json for pyright LSP + uv compatibility

### DIFF
--- a/project/pyrightconfig.json.jinja
+++ b/project/pyrightconfig.json.jinja
@@ -1,0 +1,4 @@
+{
+  "venvPath": ".",
+  "venv": ".venv"
+}

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -11,6 +11,7 @@ Tests two properties:
 from __future__ import annotations
 
 import ast
+import json
 import re
 import tomllib
 from datetime import UTC, datetime
@@ -127,10 +128,19 @@ def _validate_python(content: str) -> str | None:
     return None
 
 
+def _validate_json(content: str) -> str | None:
+    try:
+        json.loads(content)
+    except json.JSONDecodeError as exc:
+        return f"Invalid JSON: {exc}"
+    return None
+
+
 _VALIDATORS = {
     ".toml": _validate_toml,
     ".yml": _validate_yaml,
     ".yaml": _validate_yaml,
+    ".json": _validate_json,
     ".md": _validate_markdown,
     ".py": _validate_python,
 }


### PR DESCRIPTION
Pyright LSP is not uv-aware. Without explicit config, editors using
pyright can't resolve imports from the uv-managed .venv. Adds a
minimal config to both this repo and the template so generated
projects work out of the box with pyright-based editors.

<!-- Closes #, Related to # -->

## Why

<!-- What problem does this solve, or what improvement does it make? -->

## Notes for reviewer

<!-- Anything non-obvious: trade-offs made, things to look out for, follow-up work left. Delete if nothing to add. -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/copier-uv-bleeding/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
