### PR TITLE
fix: add post-rebase uv-sync hook to prevent stale uv.lock after restack

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -3,7 +3,7 @@ default_stages = ["pre-commit"]
 # Minimum prek version for builtin hooks and TOML config support
 minimum_prek_version = "0.3.8"
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
-default_install_hook_types = ["commit-msg", "pre-commit", "pre-push"]
+default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post-rewrite", "pre-commit", "pre-push"]
 
 [[repos]]
 repo = "builtin"
@@ -72,7 +72,10 @@ hooks = [{ id = "shellcheck", priority = 1 }]
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
 rev = "0.11.6"
-hooks = [{ id = "uv-lock", priority = 1 }]
+hooks = [
+  { id = "uv-lock", priority = 1 },
+  { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 1 },
+]
 
 [[repos]]
 repo = "https://github.com/rhysd/actionlint"

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -2,7 +2,7 @@
 default_stages = ["pre-commit"]
 minimum_prek_version = "0.3.8"
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
-default_install_hook_types = ["commit-msg", "post-checkout", "pre-commit", "pre-push"]
+default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post-rewrite", "pre-commit", "pre-push"]
 
 [[repos]]
 repo = "builtin"
@@ -45,7 +45,10 @@ hooks = [
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
 rev = ""  # prek autoupdate will fill this
-hooks = [{ id = "uv-lock", priority = 1 }]
+hooks = [
+  { id = "uv-lock", priority = 1 },
+  { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 1 },
+]
 
 [[repos]]
 repo = "https://github.com/shellcheck-py/shellcheck-py"


### PR DESCRIPTION
Closes DOT-471

## Summary

- Add `uv-sync` hook on `post-checkout`, `post-merge`, and `post-rewrite` stages to both `prek.toml` and the generated template (`project/prek.toml.jinja`)
- Add `post-checkout`, `post-merge`, `post-rewrite` to `default_install_hook_types` so prek wires up the git hook shims

## Problem

When a stacked branch is restacked onto a base that changed `pyproject.toml` (e.g. version bump), `uv.lock` becomes stale. The `uv-lock` pre-commit hook only fires when `pyproject.toml` or `uv.lock` are in the changeset — so after rebase it skips and CI fails with a version mismatch.

## Note

Users of the template need to re-run `prek install` after pulling this change to register the new git hook stages.