### PR TITLE
fix: stage CHANGELOG.md in semantic-release build_command

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -278,7 +278,7 @@ version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 build_command = """
 uv lock --upgrade-package "$PACKAGE_NAME"
-git add uv.lock
+git add uv.lock CHANGELOG.md
 uv build
 """
 commit_message = "chore(release): {version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 build_command = """
 uv lock --upgrade-package "$PACKAGE_NAME"
-git add uv.lock
+git add uv.lock CHANGELOG.md
 """
 commit_message = "chore(release): {version}"
 tag_format = "{version}"


### PR DESCRIPTION
Closes DOT-393

## Summary

- Add `CHANGELOG.md` to `git add` in the semantic-release `build_command` in both `pyproject.toml` and `project/pyproject.toml.jinja`

## Problem

`build_command` only staged `uv.lock`, so `CHANGELOG.md` was never included in the release commit despite `mode = "update"` being configured. GitHub Releases were unaffected (generated separately), but the committed CHANGELOG.md stayed empty across releases.