### PR TITLE
fix(ci): refresh uv.lock before prek to fix stacked PR breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,11 @@ jobs:
         python-version: "3.14"
         enable-cache: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Refresh lockfile
+      run: uv lock
     - uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
       env:
-        SKIP: no-commit-to-branch,pytest-cov,lychee
+        SKIP: no-commit-to-branch,pytest-cov,lychee,uv-lock
       with:
         extra-args: '--all-files'
 

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -80,9 +80,11 @@ jobs:
         python-version: "3.14"
         enable-cache: true
         github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
+    - name: Refresh lockfile
+      run: uv lock
     - uses: j178/prek-action@v1
       env:
-        SKIP: no-commit-to-main,pytest-testmon,lychee
+        SKIP: no-commit-to-main,pytest-testmon,lychee,uv-lock
       with:
         extra-args: '--all-files'
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -290,7 +290,7 @@ class TestCIWorkflows:
         project = project_factory(answers)
 
         content = (project / ".github" / "workflows" / "ci.yml").read_text()
-        assert "SKIP: no-commit-to-main,pytest-testmon,lychee" in content
+        assert "SKIP: no-commit-to-main,pytest-testmon,lychee,uv-lock" in content
 
     def test_pyproject_has_build_system(self, copier_defaults: dict, project_factory) -> None:
         """pyproject.toml should have build-system section."""


### PR DESCRIPTION
After semantic-release bumps the version on main, remaining stacked
branches have a stale uv.lock. Add a uv lock step before prek in CI
and skip the redundant uv-lock hook to prevent false failures.

Resolves DOT-474

Closes #

<!-- Replace # with the issue this PR closes (e.g., "Closes #123" or "Closes PROJ-123").
     Use "Ref" to link without closing. Delete the line for PRs with no issue. -->
