### PR TITLE
feat: run delete-branch-on-merge setup on copier update too

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -211,9 +211,8 @@ _tasks:
   # Update only — reinstall hooks (fresh copy has no .git yet)
   - command: "if [ -d .git ]; then uv run prek install; fi"
     when: "{{ _copier_operation in ('update', 'recopy') }}"
-  # Copy only — one-time GitHub repo setup
+  # GitHub repo settings — idempotent, runs on copy and update
   - command: "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge --enable-auto-merge && echo '✓ Enabled delete-branch-on-merge and auto-merge' || true"
-    when: "{{ _copier_operation == 'copy' }}"
   # Copy — setup instructions
   - command: "printf '\\n🎉 Project created!\\n\\n  ✓ Dependencies installed\\n\\nTo finish setup:\\n  git init && uv run prek install && uv run prek autoupdate\\n  Create your source files in src/ and tests/\\n'"
     when: "{{ _copier_operation == 'copy' }}"


### PR DESCRIPTION
The gh repo edit task that enables delete-branch-on-merge and
auto-merge was copy-only. Projects created before this task was
added never got the setting. Now runs on every copier operation
since it's idempotent and fails silently.

Resolves DOT-480

Closes #

<!-- Replace # with the issue this PR closes (e.g., "Closes #123" or "Closes PROJ-123").
     Use "Ref" to link without closing. Delete the line for PRs with no issue. -->
