### PR TITLE
fix: scaffolded files end with single trailing newline

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -31,6 +31,7 @@ _exclude:
 - "{% if not use_ci %}.gitlab-ci.yml{% endif %}"
 - "{% if not use_semantic_release %}.github/workflows/release.yml{% endif %}"
 - "{% if not publish_to_mcp_registry %}.github/workflows/mcp-registry-publish.yml{% endif %}"
+- "{% if not use_blacksmith_runners %}.github/actionlint.yaml{% endif %}"
 - "{% if project_visibility == 'internal' %}CODE_OF_CONDUCT.md{% endif %}"
 - "{% if project_visibility == 'internal' %}CONTRIBUTING.md{% endif %}"
 - "{% if project_visibility == 'internal' %}SECURITY.md{% endif %}"

--- a/project/.github/actionlint.yaml.jinja
+++ b/project/.github/actionlint.yaml.jinja
@@ -1,4 +1,4 @@
-{%- if use_blacksmith_runners %}
+{%- if use_blacksmith_runners -%}
 self-hosted-runner:
   labels:
     - blacksmith-2vcpu-ubuntu-2404

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -25,4 +25,4 @@
 
 The CI workflow includes a `ci-pass` gate job that aggregates the status of all CI jobs.
 Add a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule) for `main` requiring the **`ci-pass`** status check to pass before merging.
-{% endif %}
+{%- endif %}

--- a/project/{{_copier_conf.answers_file}}.jinja
+++ b/project/{{_copier_conf.answers_file}}.jinja
@@ -1,2 +1,2 @@
 # Changes here will be overwritten by Copier.
-{{_copier_answers|to_nice_yaml}}
+{{_copier_answers|to_nice_yaml -}}


### PR DESCRIPTION
## Summary
- Strip a redundant blank line from `project/README.md.jinja`, `project/.github/actionlint.yaml.jinja` and `project/{{_copier_conf.answers_file}}.jinja` so the rendered files end with a single trailing newline (matches `end-of-file-fixer`).
- Exclude the empty `actionlint.yaml` from the scaffold when `use_blacksmith_runners` is false.

## Why
Without these fixes, the `end-of-file-fixer` prek hook auto-rewrites scaffolded files on the very first commit, which forces an extra `git add && git commit` cycle for every new project. Surfaces as part of the broader DOT-491 fresh-scaffold investigation but warrants its own PR.

## Test plan
- [x] `poe test` — green
- [x] Generate fresh project, confirm no files are touched by `end-of-file-fixer` on first commit