### PR TITLE
fix(prek): keep lychee on a versioned tag after autoupdate (DOT-492)

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -215,7 +215,7 @@ _tasks:
   # GitHub repo settings — idempotent, runs on copy and update
   - command: "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge --enable-auto-merge && echo '✓ Enabled delete-branch-on-merge and auto-merge' || true"
   # Copy — setup instructions
-  - command: "printf '\\n🎉 Project created!\\n\\n  ✓ Dependencies installed\\n\\nTo finish setup:\\n  git init && uv run prek install && uv run prek autoupdate\\n  Create your source files in src/ and tests/\\n'"
+  - command: "printf '\\n🎉 Project created!\\n\\n  ✓ Dependencies installed\\n\\nTo finish setup:\\n  git init && uv run prek install && bash scripts/prek-autoupdate.sh\\n  Create your source files in src/ and tests/\\n'"
     when: "{{ _copier_operation == 'copy' }}"
   # Update — minimal output (poe update-template handles prek autoupdate)
   - command: "printf '\\n🎉 Template updated!\\n\\n  ✓ Dependencies synced\\n  ✓ Git hooks reinstalled\\n'"

--- a/docs/update.md
+++ b/docs/update.md
@@ -61,7 +61,7 @@ This runs:
 
 1. `copier update --trust . --skip-answered --defaults` — pull template changes without prompting
 2. `uv sync --upgrade` — upgrade all dependencies
-3. `prek autoupdate` — update hook versions
+3. `bash scripts/prek-autoupdate.sh` — update hook versions (wraps `prek autoupdate` with a lychee `nightly` workaround; see `scripts/prek-autoupdate.sh`)
 
 Since we are generally using Git in our projects,
 my recommendation is to not think at all

--- a/prek.toml
+++ b/prek.toml
@@ -94,7 +94,7 @@ hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], pr
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.23.0"  # lychee tags nightly as latest; prek autoupdate may switch to it
+rev = "lychee-v0.23.0"  # use bash project/scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -74,7 +74,7 @@ hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], pr
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.23.0"  # lychee tags nightly as latest; prek autoupdate may switch to it
+rev = "lychee-v0.23.0"  # use scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -256,7 +256,7 @@ prek = "prek run --all-files"
 
 # Template utilities
 check-template = { shell = "copier check-update || true" }
-update-template = { shell = "copier update --trust . --skip-answered --defaults && uv sync --upgrade && prek autoupdate && echo '  ✓ Dependencies upgraded and hook versions updated'{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
+update-template = { shell = "copier update --trust . --skip-answered --defaults && uv sync --upgrade && bash scripts/prek-autoupdate.sh && echo '  ✓ Dependencies upgraded and hook versions updated'{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/project/scripts/prek-autoupdate.sh
+++ b/project/scripts/prek-autoupdate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wraps `uv run prek autoupdate` with a workaround for lychee marking `nightly` as
+# their GitHub "Latest" release (DOT-492). The second pass with --cooldown-days 7
+# reverts lychee's `rev` from `nightly` back to the most recent versioned tag.
+# Remove once lychee stops marking nightly as Latest (DOT-504).
+set -eu
+uv run prek autoupdate "$@"
+uv run prek autoupdate --repo https://github.com/lycheeverse/lychee --cooldown-days 7 "$@"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -673,7 +673,8 @@ class TestTemplateUpdateCheck:
         assert "copier update" in content
         assert "--defaults" in content
         assert "uv sync --upgrade" in content
-        assert "prek autoupdate" in content
+        assert "scripts/prek-autoupdate.sh" in content
+        assert (project / "scripts" / "prek-autoupdate.sh").exists()
 
     def test_lychee_rev_is_pinned_not_empty(self, copier_defaults: dict, project_factory) -> None:
         """Lychee should have a pinned rev (not empty) since its 'nightly' tag is mutable."""
@@ -686,6 +687,24 @@ class TestTemplateUpdateCheck:
         rev = lychee_repos[0]["rev"]
         assert rev, "Lychee rev should be pinned, not empty"
         assert rev.startswith("lychee-v"), f"Lychee rev should be a versioned tag, got: {rev}"
+
+    def test_prek_autoupdate_script_has_lychee_workaround(self, copier_defaults: dict, project_factory) -> None:
+        """scripts/prek-autoupdate.sh wraps `prek autoupdate` with the lychee `nightly` workaround (DOT-492).
+
+        Verifies the script exists, is executable, calls plain `prek autoupdate` once, and
+        follows up with a lychee-scoped pass using --cooldown-days 7. Without the second pass,
+        lychee's `rev` flips to `nightly` and lychee's own hook then rejects the next commit.
+        """
+        project = project_factory(copier_defaults)
+
+        script = project / "scripts" / "prek-autoupdate.sh"
+        assert script.exists(), "prek-autoupdate.sh must ship in the scaffolded project"
+        assert os.access(script, os.X_OK), "prek-autoupdate.sh must be executable"
+
+        body = script.read_text()
+        assert "prek autoupdate" in body, "script must invoke `prek autoupdate`"
+        assert "--repo https://github.com/lycheeverse/lychee" in body, "script must scope the second pass to the lychee repo"
+        assert "--cooldown-days 7" in body, "script must use --cooldown-days 7 so prek skips the daily-republished `nightly` tag"
 
 
 class TestTemplateUpdateNotification:


### PR DESCRIPTION
Closes [DOT-492](https://linear.app/ismar/issue/DOT-492/prek-autoupdate-sets-lychee-rev-to-nightly-which-lychees-own-hook)
Refs [DOT-504](https://linear.app/ismar/issue/DOT-504/remove-lychee-nightly-autoupdate-workaround-once-upstream-fixes-it) (follow-up: remove the workaround once upstream fixes the nightly tagging)

## Summary
- Add `project/scripts/prek-autoupdate.sh` wrapper that runs `prek autoupdate`, then runs it again with `--repo lychee --cooldown-days 7`. The cooldown filter makes prek skip the daily-republished `nightly` and fall back to the most recent versioned tag.
- Wire the wrapper into the post-copy setup message, the `update-template` poe task, and `docs/update.md`.
- Pin the lychee `rev` in `prek.toml` and `project/prek.toml.jinja` to `lychee-v0.23.0` with a comment pointing future readers at the wrapper.

## Why
`prek autoupdate` flips lychee's `rev` to `nightly` because lychee tags their nightly build as the GitHub "Latest" release. Lychee's own pre-commit hook then rejects anything that isn't a versioned tag, breaking the first commit on every fresh scaffold.

We wanted a fix scoped to lychee specifically — a global `--cooldown-days` would defeat the whole point of a "bleeding" template.

## Test plan
- [x] `poe test` — green
- [x] `bash scripts/prek-autoupdate.sh` end-to-end on a freshly scaffolded project — lychee `rev` lands on `lychee-v0.23.0`, not `nightly`
- [x] Covered by the DOT-491 e2e test in #310