### PR TITLE
test(scaffold): add full first-commit e2e regression test

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -22,6 +22,8 @@ _skip_if_exists:
 - CHANGELOG.md
 - README.md
 - "src/{{ python_package_import_name }}/__init__.py"
+- "tests/__init__.py"
+- "tests/test_{{ python_package_import_name }}.py"
 
 _exclude:
 - "{% if repository_provider != 'github.com' %}.github{% endif %}"

--- a/project/.lychee.toml.jinja
+++ b/project/.lychee.toml.jinja
@@ -13,6 +13,16 @@ exclude = [
     '^mailto:',
     # Localhost URLs (e.g. docs preview in CONTRIBUTING.md)
     '^http://localhost',
+    # Self-referential URLs to this repo and its GitHub Pages site.
+    # These don't exist on a fresh scaffold (before `gh repo create` / first CI run / docs deploy)
+    # and they're user-owned anyway -- lychee can't tell us anything we don't already know.
+    '^https?://{{ repository_host | replace(".", "\\.") }}/{{ repository_namespace }}/{{ repository_name }}(/|$)',
+{%- if repository_host in ['github.com', 'gitlab.com'] %}
+    '^https?://{{ repository_namespace }}\.{{ repository_host.rsplit(".", 1)[0] }}\.io/{{ repository_name }}(/|$)',
+{%- endif %}
+{%- if publish_to_pypi %}
+    '^https://pypi\.org/project/{{ python_package_distribution_name }}/?$',
+{%- endif %}
 ]
 
 # Exclude local/private addresses

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -24,5 +24,5 @@
 ## Branch protection
 
 The CI workflow includes a `ci-pass` gate job that aggregates the status of all CI jobs.
-Add a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule) for `main` requiring the **`ci-pass`** status check to pass before merging.
+Add a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) for `main` requiring the **`ci-pass`** status check to pass before merging.
 {%- endif %}

--- a/project/tests/test_{{python_package_import_name}}.py.jinja
+++ b/project/tests/test_{{python_package_import_name}}.py.jinja
@@ -1,0 +1,12 @@
+"""Placeholder smoke test for {{ project_name }}.
+
+Ensures pytest collects at least one test on a freshly scaffolded project so the
+pre-commit `pytest-testmon` hook does not exit with code 5 on the first commit.
+Replace with real tests as the project grows.
+"""
+
+import {{ python_package_import_name }}
+
+
+def test_package_importable() -> None:
+    assert {{ python_package_import_name }}.__name__ == "{{ python_package_import_name }}"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -71,10 +71,23 @@ class TestCoreFiles:
         project = project_factory(copier_defaults)
         assert (project / "src").is_dir()
 
-    def test_tests_directory_not_generated(self, copier_defaults: dict, project_factory) -> None:
-        """tests directory should not be generated (users create via uv init)."""
-        project = project_factory(copier_defaults)
-        assert not (project / "tests").is_dir()
+    def test_tests_directory_has_placeholder(self, copier_defaults: dict, project_factory) -> None:
+        """tests/ ships with a placeholder so the first commit doesn't fail on pytest exit 5.
+
+        Both `app` and `lib` project types must get the placeholder -- there's no
+        conditional `_exclude`, so a missing file in either would be a regression.
+        """
+        for project_type in ("app", "lib"):
+            project = project_factory(copier_defaults, project_type)
+            tests_dir = project / "tests"
+            assert tests_dir.is_dir(), f"tests/ missing for {project_type} project"
+            assert (tests_dir / "__init__.py").exists(), f"tests/__init__.py missing for {project_type}"
+            # python_package_import_name = "Test Project" | slugify("_") = "test_project"
+            placeholder = tests_dir / "test_test_project.py"
+            assert placeholder.exists(), f"placeholder test missing for {project_type}"
+            content = placeholder.read_text()
+            assert "import test_project" in content
+            assert "def test_" in content
 
 
 class TestCIConfiguration:
@@ -909,12 +922,16 @@ class TestCLIFramework:
     """Test app project type scaffolding."""
 
     def test_app_type_no_scaffold_code(self, copier_defaults: dict, project_factory) -> None:
-        """App type should not generate scaffold source files (users create their own via uv init)."""
+        """App type should not generate scaffold source files (users create their own via uv init).
+
+        Note: ``tests/__init__.py`` and ``tests/test_<package>.py`` ARE generated as
+        a placeholder so the first commit doesn't fail the pytest-testmon hook.
+        See test_tests_directory_has_placeholder.
+        """
         project = project_factory(copier_defaults, "app")
         assert not (project / "src" / "test_project" / "_internal").exists()
         assert not (project / "src" / "test_project" / "__main__.py").exists()
         assert not (project / "src" / "test_project" / "py.typed").exists()
-        assert not (project / "tests" / "__init__.py").exists()
         assert not (project / "tests" / "test_cli.py").exists()
         assert not (project / "tests" / "test_api.py").exists()
         assert not (project / "tests" / "conftest.py").exists()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1279,3 +1279,76 @@ class TestIntegration:
         # Run uv sync
         result = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True, check=False)
         assert result.returncode == 0, f"uv sync failed: {result.stderr}"
+
+    @pytest.mark.slow
+    def test_first_commit_succeeds_with_prek_hooks(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """First `git commit` on a freshly scaffolded project must succeed.
+
+        Reproduces the exact user flow from a fresh folder:
+            copier copy ... && cd <dest>
+            uv sync
+            git init && uv run prek install && bash scripts/prek-autoupdate.sh
+            git add -A && git commit -m "feat: init commit"
+
+        Originally added as a regression test for DOT-491 (pytest-testmon hook exited 5
+        because the template shipped no tests/). Intentionally runs the FULL prek hook
+        chain with no SKIP -- if any hook fails on a freshly scaffolded project, the
+        template is broken from the user's perspective and we have work to do.
+        """
+        project = generate_project(tmp_path, copier_defaults)
+
+        sync = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True, check=False)
+        assert sync.returncode == 0, f"uv sync failed: {sync.stderr}"
+
+        git_env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@test.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@test.com",
+        }
+        # An ambient SKIP=... in the developer's shell or CI step would silently
+        # disable prek hooks and defeat the whole point of this regression test.
+        git_env.pop("SKIP", None)
+
+        subprocess.run(
+            ["git", "init", "--initial-branch=main"],
+            cwd=project,
+            check=True,
+            capture_output=True,
+        )
+        install = subprocess.run(
+            ["uv", "run", "prek", "install"],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert install.returncode == 0, f"prek install failed: {install.stderr}"
+        autoupdate = subprocess.run(
+            ["bash", "scripts/prek-autoupdate.sh"],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert autoupdate.returncode == 0, f"prek-autoupdate.sh failed: {autoupdate.stderr}"
+
+        # Mirror the real user flow: hooks may auto-fix files (formatters, lockfile sync)
+        # on the first run, abort the commit, and the user re-stages and retries.
+        # Allow up to 2 attempts; the second must succeed.
+        for attempt in (1, 2):
+            subprocess.run(["git", "add", "-A"], cwd=project, check=True, capture_output=True)
+            commit = subprocess.run(
+                ["git", "commit", "-m", "feat: init commit"],
+                cwd=project,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=git_env,
+            )
+            if commit.returncode == 0:
+                break
+            assert attempt == 1, (
+                f"first commit on freshly scaffolded project failed after re-stage:\nstdout:\n{commit.stdout}\nstderr:\n{commit.stderr}"
+            )


### PR DESCRIPTION
Refs [DOT-491](https://linear.app/ismar/issue/DOT-491/ship-placeholder-test-file-in-scaffold-first-commit-fails-on-fresh)
Refs [DOT-492](https://linear.app/ismar/issue/DOT-492/prek-autoupdate-sets-lychee-rev-to-nightly-which-lychees-own-hook)
Refs [DOT-493](https://linear.app/ismar/issue/DOT-493/post-scaffold-task-should-enable-github-discussions)
Refs [DOT-494](https://linear.app/ismar/issue/DOT-494/stale-docsgithubcom-branch-protection-url-in-readmemd-returns-404)

## Summary
- Add `test_first_commit_succeeds_with_prek_hooks` to `tests/test_template.py`. Generates a fresh project, runs `uv sync`, `git init`, `prek install`, `bash scripts/prek-autoupdate.sh`, then attempts the first commit.
- Mirrors the real user flow: prek hooks may auto-fix files (formatters, lockfile sync) on the first run, abort the commit, and the user re-stages and retries. The test allows up to 2 attempts; the second must succeed.

## Why
This is the single regression test that guards every fresh-scaffold bug we've fixed in this stack. Without it, future template changes can silently re-break the first-commit experience and we'd never know until a user complains.

Runs with no `SKIP=` — every prek hook on every freshly scaffolded file. Marked `@pytest.mark.slow` so it only runs in `poe test-all` / `poe test-cov`, not the fast loop.

## Test plan
- [x] Test passes locally on top of the full stack (#306, #307, #308, #309)
- [x] Test fails on `main` — confirmed each fix is load-bearing