### PR TITLE
chore(prek): collapse autoupdate workaround to single --repo-exclude-tag pass (DOT-540)

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -1,7 +1,7 @@
-"$schema" = "https://raw.githubusercontent.com/j178/prek/v0.3.8/prek.schema.json"
+"$schema" = "https://raw.githubusercontent.com/j178/prek/v0.3.11/prek.schema.json"
 default_stages = ["pre-commit"]
 # Minimum prek version for builtin hooks and TOML config support
-minimum_prek_version = "0.3.8"
+minimum_prek_version = "0.3.11"  # 0.3.11 introduced --repo-exclude-tag (project/scripts/prek-autoupdate.sh)
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
 default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post-rewrite", "pre-commit", "pre-push"]
 
@@ -71,7 +71,7 @@ hooks = [{ id = "shellcheck", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = "0.11.6"
+rev = "0.11.11"
 hooks = [
   { id = "uv-lock", priority = 1 },
   { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 1 },
@@ -84,7 +84,7 @@ hooks = [{ id = "actionlint", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
-rev = "v1.45.0"
+rev = "v1.46.0"
 hooks = [{ id = "typos", priority = 1 }]
 
 [[repos]]
@@ -94,7 +94,7 @@ hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], pr
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.23.0"  # use bash project/scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
+rev = "lychee-v0.24.2"  # use bash project/scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -1,6 +1,6 @@
-"$schema" = "https://raw.githubusercontent.com/j178/prek/v0.3.8/prek.schema.json"
+"$schema" = "https://raw.githubusercontent.com/j178/prek/v0.3.11/prek.schema.json"
 default_stages = ["pre-commit"]
-minimum_prek_version = "0.3.8"
+minimum_prek_version = "0.3.11"  # 0.3.11 introduced --repo-exclude-tag (scripts/prek-autoupdate.sh)
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
 default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post-rewrite", "pre-commit", "pre-push"]
 
@@ -74,7 +74,7 @@ hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], pr
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.23.0"  # use scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
+rev = "lychee-v0.24.2"  # use scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -72,7 +72,7 @@ ci = [
 ]
 dev = []
 local = [
-    "prek>=0.3.8",
+    "prek>=0.3.11",
     "pytest-testmon>=2.2",
 ]
 docs = [

--- a/project/scripts/prek-autoupdate.sh
+++ b/project/scripts/prek-autoupdate.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Wraps `uv run prek autoupdate` with a workaround for lychee marking `nightly` as
-# their GitHub "Latest" release (DOT-492). The second pass with --cooldown-days 7
-# reverts lychee's `rev` from `nightly` back to the most recent versioned tag.
-# Remove once lychee stops marking nightly as Latest (DOT-504).
+# Wraps `uv run prek autoupdate` with a workaround for lychee tagging `nightly`
+# as their GitHub "Latest" release (lycheeverse/lychee#1601). The
+# --repo-exclude-tag flag (prek 0.3.11+) keeps lychee on its real latest
+# versioned tag instead of flipping to `nightly`. Remove the flag when upstream
+# closes lycheeverse/lychee#1601 (DOT-504).
 set -eu
-uv run prek autoupdate "$@"
-uv run prek autoupdate --repo https://github.com/lycheeverse/lychee --cooldown-days 7 "$@"
+uv run prek autoupdate --repo-exclude-tag https://github.com/lycheeverse/lychee=nightly "$@"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -142,12 +142,12 @@ class TestPreCommitConfig:
     """Test pre-commit configuration."""
 
     def test_prek_version(self, copier_defaults: dict, project_factory) -> None:
-        """Pre-commit config should have correct prek version."""
+        """Pre-commit config should pin prek to 0.3.11+ (provides --repo-exclude-tag)."""
         project = project_factory(copier_defaults)
 
         config = project / "prek.toml"
         content = config.read_text()
-        assert 'minimum_prek_version = "0.3.8"' in content
+        assert 'minimum_prek_version = "0.3.11"' in content
 
     def test_has_betterleaks(self, copier_defaults: dict, project_factory) -> None:
         """Pre-commit config should have betterleaks."""
@@ -195,12 +195,12 @@ class TestDependencies:
         assert "tomli" not in content
 
     def test_prek_version_updated(self, copier_defaults: dict, project_factory) -> None:
-        """prek dependency should be >= 0.3.8."""
+        """prek dependency should be >= 0.3.11 (introduces --repo-exclude-tag, used by scripts/prek-autoupdate.sh)."""
         project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
-        assert '"prek>=0.3.8"' in content
+        assert '"prek>=0.3.11"' in content
 
 
 class TestCIWorkflows:
@@ -694,11 +694,11 @@ class TestTemplateUpdateCheck:
         assert rev.startswith("lychee-v"), f"Lychee rev should be a versioned tag, got: {rev}"
 
     def test_prek_autoupdate_script_has_lychee_workaround(self, copier_defaults: dict, project_factory) -> None:
-        """scripts/prek-autoupdate.sh wraps `prek autoupdate` with the lychee `nightly` workaround (DOT-492).
+        """scripts/prek-autoupdate.sh wraps `prek autoupdate` with the lychee `nightly` workaround (DOT-492, DOT-540).
 
-        Verifies the script exists, is executable, calls plain `prek autoupdate` once, and
-        follows up with a lychee-scoped pass using --cooldown-days 7. Without the second pass,
-        lychee's `rev` flips to `nightly` and lychee's own hook then rejects the next commit.
+        Verifies the script exists, is executable, and uses prek 0.3.11+ `--repo-exclude-tag` to
+        prevent lychee's `rev` from flipping to `nightly` (which lychee's own hook then rejects).
+        Tracks lycheeverse/lychee#1601 — remove the flag once upstream closes that issue (DOT-504).
         """
         project = project_factory(copier_defaults)
 
@@ -708,8 +708,9 @@ class TestTemplateUpdateCheck:
 
         body = script.read_text()
         assert "prek autoupdate" in body, "script must invoke `prek autoupdate`"
-        assert "--repo https://github.com/lycheeverse/lychee" in body, "script must scope the second pass to the lychee repo"
-        assert "--cooldown-days 7" in body, "script must use --cooldown-days 7 so prek skips the daily-republished `nightly` tag"
+        assert "--repo-exclude-tag https://github.com/lycheeverse/lychee=nightly" in body, (
+            "script must exclude the lychee `nightly` tag so prek picks the latest versioned tag"
+        )
 
 
 class TestTemplateUpdateNotification:


### PR DESCRIPTION
Closes DOT-540
Refs DOT-492
Refs DOT-504

Linear: https://linear.app/ismar/issue/DOT-540/simplify-prek-autoupdatesh-using-prek-0311-repo-exclude-tag

## Summary

- `project/scripts/prek-autoupdate.sh` collapses from two `prek autoupdate` passes to a single `prek autoupdate --repo-exclude-tag https://github.com/lycheeverse/lychee=nightly` call.
- `prek` minimum bumped 0.3.8 → 0.3.11 (the version that introduced `--repo-exclude-tag`):
  - `project/pyproject.toml.jinja`: `prek>=0.3.8` → `prek>=0.3.11`
  - `prek.toml` and `project/prek.toml.jinja`: `minimum_prek_version = "0.3.11"` + matching `\$schema` URL
- Hook bumps discovered while validating the new flow (free perks): `uv-pre-commit` 0.11.6 → 0.11.11, `typos` v1.45.0 → v1.46.0, `lychee` `lychee-v0.23.0` → `lychee-v0.24.2` (also bumped in `project/prek.toml.jinja`).
- `tests/test_template.py` assertions updated for the new pin and the new flag form.

## Why

The previous wrapper ran `prek autoupdate` twice — once normally, then again scoped to lychee with `--cooldown-days 7` to walk back the `nightly` flip caused by [lycheeverse/lychee#1601](https://github.com/lycheeverse/lychee/issues/1601). That cooldown approach is **racy**: if lychee shipped a real versioned tag in the last 7 days, the cooldown filter would also skip the legitimate update, leaving the rev stale.

prek 0.3.11 (2026-04-27) added per-repo tag-exclusion flags, which lets us name the problem directly:

\`\`\`sh
uv run prek autoupdate --repo-exclude-tag https://github.com/lycheeverse/lychee=nightly
\`\`\`

Surgical: only the `nightly` tag is excluded, only for the lychee repo. All other hooks autoupdate normally, no cooldowns anywhere.

This **does not close DOT-504** — that ticket is about removing the workaround entirely once lycheeverse/lychee#1601 is fixed. Comment on DOT-504 confirms upstream is still open as of 2026-05-08.

## Test plan

- [x] `poe check` — ruff + ty clean
- [x] `poe test` — 128 passed, 3 deselected (slow), 0 failures
- [x] Manual probe: `uv run prek autoupdate --repo-exclude-tag https://github.com/lycheeverse/lychee=nightly` correctly bumped lychee `lychee-v0.23.0` → `lychee-v0.24.2` (the real latest versioned tag, not `nightly`)
- [ ] CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace two-pass lychee autoupdate workaround with single `--repo-exclude-tag` pass
> - Replaces the two-step `prek autoupdate` workaround in [prek-autoupdate.sh](https://github.com/detailobsessed/copier-uv-bleeding/pull/313/files#diff-d6d43a47daaa77e4ca5cc6c8dcd2d2d5db375895b720b0c4607e3d718b544f07) with a single invocation using `--repo-exclude-tag https://github.com/lycheeverse/lychee=nightly`, preventing lychee's rev from flipping to `nightly`.
> - The previous cooldown-based second pass could incorrectly filter legitimate versioned lychee releases published within 7 days.
> - Bumps `minimum_prek_version` to `0.3.11` in [prek.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/313/files#diff-72359463e1c50ddcb8dfabe900898a8f1d92416bbe6754f2e497f62d96232021) and [project/prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/313/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c), and updates the scaffolded `prek>=0.3.11` requirement in [project/pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/313/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3).
> - Also picks up hook updates from running the simplified autoupdate: `uv-pre-commit` 0.11.6→0.11.11, `typos` v1.45.0→v1.46.0, `lychee` v0.23.0→v0.24.2.
>
> #### 🖇️ Linked Issues
> Closes [DOT-540](https://linear.app/ismar/issue/DOT-540), which tracked simplifying `prek-autoupdate.sh` using the new `--repo-exclude-tag` flag added in prek v0.3.11.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized daf82d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->