### PR TITLE
fix(template): drop --defaults, use --conflict rej, guard .rej commits (DOT-542)

### DIFF
--- a/docs/update.md
+++ b/docs/update.md
@@ -59,17 +59,15 @@ poe update-template
 
 This runs:
 
-1. `copier update --trust . --skip-answered --defaults` — pull template changes without prompting
+1. `copier update --trust . --skip-answered --conflict rej` — pull template changes; previously-answered questions are kept, new questions are surfaced interactively, conflicts produce `.rej` files instead of inline conflict markers
 2. `uv sync --upgrade` — upgrade all dependencies
 3. `bash scripts/prek-autoupdate.sh` — update hook versions (wraps `prek autoupdate` with a lychee `nightly` workaround; see `scripts/prek-autoupdate.sh`)
 
-Since we are generally using Git in our projects,
-my recommendation is to not think at all
-and blindly apply every change Copier proposes.
-Indeed, you'll be able to see the diff with `git diff`,
-un-apply changes on whole files with `git checkout -- FILE`
-if they are not relevant,
-or do partial, interactive commits with `git add -p`
-or within your IDE interface
-(PyCharm and VSCode have good support and UX
-for selecting and committing changes).
+## Handling conflicts
+
+`copier update` may produce two kinds of artefacts you need to handle before committing:
+
+1. **`.rej` files** — wherever the template's diff couldn't be applied cleanly, Copier writes the rejected hunk to `<file>.rej` alongside the original. The original file keeps your working content; the `.rej` file holds the change the template wanted. Review each `.rej`, apply what's useful by hand, then delete it. A pre-commit hook (`no-copier-rej-files`) refuses to commit while `.rej` files exist.
+2. **Re-rendered templated values** — fields rendered from `.copier-answers.yml` (e.g. `[project.urls]`, `[project.scripts]`, repository paths) are recomputed on every update. If you manually edited those without bumping the matching answer, the update will reset them. Fix the answer in `.copier-answers.yml` instead of editing the rendered file.
+
+Since we use Git, run `git status` and `git diff` after `poe update-template` and review the changes before committing. Use `git checkout -- FILE` to drop unwanted changes, or `git add -p` for partial commits.

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -13,7 +13,7 @@ hooks = [
   { id = "check-toml", priority = 0 },
   { id = "check-json", priority = 0 },
   { id = "check-added-large-files", priority = 0 },
-  { id = "check-merge-conflict", priority = 0 },
+  { id = "check-merge-conflict", args = ["--assume-in-merge"], priority = 0 },  # --assume-in-merge catches markers from `copier update --conflict inline` (no .git/MERGE_MSG)
   { id = "check-case-conflict", priority = 0 },
   { id = "check-symlinks", priority = 0 },
   { id = "check-executables-have-shebangs", priority = 0 },
@@ -88,6 +88,16 @@ language = "system"
 always_run = true
 pass_filenames = false
 stages = ["pre-push"]
+priority = 0
+
+# Block commits containing .rej files produced by `copier update --conflict rej` (DOT-542).
+# https://copier.readthedocs.io/en/stable/updating/#tips-and-tricks
+[[repos.hooks]]
+id = "no-copier-rej-files"
+name = "block copier .rej files"
+entry = "Found copier update rejection files (.rej). Review the diff, apply changes manually, delete the .rej file, then commit."
+language = "fail"
+files = "\\.rej$"
 priority = 0
 
 [[repos.hooks]]

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -271,7 +271,7 @@ prek = "prek run --all-files"
 
 # Template utilities
 check-template = { shell = "copier check-update || true" }
-update-template = { shell = "copier update --trust . --skip-answered --defaults && uv sync --upgrade && bash scripts/prek-autoupdate.sh && echo '  ✓ Dependencies upgraded and hook versions updated'{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
+update-template = { shell = "copier update --trust . --skip-answered --conflict rej && uv sync --upgrade && bash scripts/prek-autoupdate.sh && echo '  ✓ Dependencies upgraded and hook versions updated' && { ls -1 -- **/*.rej *.rej 2>/dev/null | head -1 >/dev/null && echo '  ⚠ Copier produced .rej files — review the diffs, apply manually, and delete the .rej files before committing.' || true; }{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -676,7 +676,11 @@ class TestTemplateUpdateCheck:
         content = pyproject.read_text()
         assert "update-template" in content
         assert "copier update" in content
-        assert "--defaults" in content
+        # DOT-542: update-template must NOT pass --defaults (silently picks template
+        # defaults for new questions) and MUST pass --conflict rej (separate .rej
+        # files instead of inline conflict markers in working files).
+        assert "--defaults" not in content
+        assert "--conflict rej" in content
         assert "uv sync --upgrade" in content
         assert "scripts/prek-autoupdate.sh" in content
         assert (project / "scripts" / "prek-autoupdate.sh").exists()
@@ -711,6 +715,43 @@ class TestTemplateUpdateCheck:
         assert "--repo-exclude-tag https://github.com/lycheeverse/lychee=nightly" in body, (
             "script must exclude the lychee `nightly` tag so prek picks the latest versioned tag"
         )
+
+    def test_check_merge_conflict_has_assume_in_merge(self, copier_defaults: dict, project_factory) -> None:
+        """check-merge-conflict must pass --assume-in-merge so it catches markers from `copier update --conflict inline` (DOT-542).
+
+        Without --assume-in-merge, pre-commit-hooks' check-merge-conflict only fires when git
+        records a pending merge (.git/MERGE_MSG). `copier update` doesn't set that state, so the
+        default-args form silently misses inline conflict markers produced by Copier.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        builtin = next(r for r in data["repos"] if r.get("repo") == "builtin")
+        hook = next(h for h in builtin["hooks"] if h["id"] == "check-merge-conflict")
+        assert hook.get("args") == ["--assume-in-merge"], (
+            f"check-merge-conflict must pass --assume-in-merge for copier update conflicts; got {hook.get('args')!r}"
+        )
+
+    def test_no_copier_rej_files_hook(self, copier_defaults: dict, project_factory) -> None:
+        """A local prek hook must block commits containing copier update .rej files (DOT-542).
+
+        Since `update-template` now uses `--conflict rej`, an unresolved conflict produces a
+        `<file>.rej` artifact. Committing those would leave the project half-merged. This hook
+        enforces manual review by failing on any staged path matching `\\.rej$`.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        local_repos = [r for r in data["repos"] if r.get("repo") == "local"]
+        hooks = [h for repo in local_repos for h in repo.get("hooks", [])]
+        rej_hook = next((h for h in hooks if h["id"] == "no-copier-rej-files"), None)
+        assert rej_hook is not None, "Expected a local 'no-copier-rej-files' hook in prek.toml"
+        assert rej_hook["language"] == "fail", "Hook must use language='fail' so any matching file fails the run"
+        assert rej_hook["files"] == r"\.rej$", f"Hook must target .rej files; got {rej_hook['files']!r}"
 
 
 class TestTemplateUpdateNotification:


### PR DESCRIPTION
## Summary

- `poe update-template` drops `--defaults` and adds `--conflict rej`, so new copier questions are surfaced instead of silently defaulted and conflicts produce reviewable `.rej` files instead of inline markers in working files.
- Two prek guards round-trip the new flow: `check-merge-conflict` now uses `--assume-in-merge` (catches inline markers from any `--conflict inline` run), and a new local `no-copier-rej-files` hook (`language = "fail"`, `files = "\.rej$"`) refuses to commit while `.rej` artifacts remain.
- `docs/update.md` rewritten with an explicit "Handling conflicts" section that explains the `.rej` workflow and the `.copier-answers.yml` drift mechanism (the latter is the real cause of the "wrong namespace in URLs" symptom reported in the issue).

## Why

DOT-542 reported that `copier update --trust . --skip-answered --defaults` wiped downstream pyproject.toml customizations on a real project (`exploring-step`). A controlled repro of the same customization shape on a clean scaffold did not reproduce the wipe — copier's 3-way merge actually preserves everything. The real failure modes are:

1. `--defaults` silently picking template values for any new question (here: `use_docs`, `configure_repo_settings`).
2. Inline conflict markers from `--conflict inline` (the copier default) being easy to overlook in working files, especially when running `git diff` after the update.
3. `.copier-answers.yml` drift — templated fields like `[project.urls]` are re-rendered on every update from stored answers; if a user edited the rendered URLs without updating the answer, copier correctly recomputes them and the user sees a "wipe" they actually caused themselves.

This PR addresses (1) and (2) directly with idiomatic copier mechanisms (per [copier's own docs](https://copier.readthedocs.io/en/stable/updating/)) and documents (3) so users have a model for it.

## Test plan

- [x] `poe check` — lint + typecheck green
- [x] `poe test` — 134 passed (incl. 2 new tests in `TestTemplateUpdateCheck` covering the new prek hooks and the updated `update-template` task assertions)
- [x] End-to-end repro: scaffold@0.34.3 with customizations (custom `dependencies`, `version = "0.6.1"`, two `[project.scripts]`, `[dependency-groups].mcp`, `[tool.uv].native-tls`, custom `[[tool.uv.index]]`) → `copier update -r HEAD --skip-answered --conflict rej` → all customizations preserved, 6 `.rej` files produced where conflicts couldn't apply cleanly, zero inline markers in working tree.
- [ ] Smoke test on a real downstream project after merge (e.g. update one project from current template HEAD using `poe update-template`).

Closes DOT-542

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `--defaults` with `--conflict rej` in `update-template` and guard `.rej` commits
> - Changes the `update-template` poe task in [pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/315/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3) to pass `--conflict rej` instead of `--defaults`, so Copier writes conflict files as `.rej` sidecars rather than silently overwriting customizations with template defaults.
> - Adds a post-run warning in `update-template` that lists any `.rej` files and prompts manual review before committing.
> - Adds a `no-copier-rej-files` pre-commit hook in [prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/315/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c) (language `fail`, matches `\.rej$`) to block commits that still contain unresolved `.rej` files.
> - Adds `--assume-in-merge` to the `check-merge-conflict` pre-commit hook so inline conflict markers are detected even outside an active Git merge.
> - Updates [docs/update.md](https://github.com/detailobsessed/copier-uv-bleeding/pull/315/files#diff-05ad2f061c8db8d1e79bff07c7103fd0ebc273efb5fe7443c3fd9a42e818cad3) with a new "Handling conflicts" section covering `.rej` file review, manual patching, and `.copier-answers.yml` adjustments.
>
> #### 🖇️ Linked Issues
> Addresses [DOT-542](https://linear.app/ismar/issue/DOT-542), where running `poe update-template` with `--defaults` silently wiped downstream project customizations (dependencies, scripts, indexes, etc.) by applying template defaults without prompting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c7b067.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->