### PR TITLE
fix(template): bound uv_build version in build-system.requires

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["uv_build"]
+# uv warns on every `uv sync` / `uv build` if uv_build is unbounded — and a
+# breaking uv_build release would silently break sdist builds in every rendered
+# project. Pin to the current minor series and the next major. Bump the upper
+# bound when uv_build crosses 0.12+ (DOT-589).
+requires = ["uv_build>=0.9,<0.12"]
 build-backend = "uv_build"
 
 [project]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -324,6 +324,33 @@ class TestCIWorkflows:
         content = pyproject.read_text()
         assert "[build-system]" in content
 
+    def test_uv_build_has_upper_bound(self, copier_defaults: dict, project_factory) -> None:
+        """`build-system.requires` must pin `uv_build` with an upper bound (DOT-589).
+
+        An unbounded `uv_build` makes uv print a noisy warning on every `uv sync`
+        / `uv build` (drowns out real warnings) and risks silent sdist breakage
+        when `uv_build` ships a future major. The template ships with
+        `uv_build>=0.9,<0.12`; bump the upper bound when uv_build crosses 0.12+.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "pyproject.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        requires = data["build-system"]["requires"]
+        uv_build_specs = [r for r in requires if r.startswith(("uv_build", "uv-build"))]
+        assert uv_build_specs, f"build-system.requires must list uv_build; got {requires!r}"
+
+        spec = uv_build_specs[0]
+        # Reject bare "uv_build" or specs without an upper bound. The point of
+        # the pin is to keep a future breaking release from being auto-picked
+        # by the build frontend — so an upper bound (`<` or `<=`) is required.
+        assert "<" in spec, (
+            f"uv_build must have an upper version bound to avoid the uv warning and "
+            f"to prevent silent breakage on a future major release. Got {spec!r}; "
+            f"expected something like 'uv_build>=0.9,<0.12'."
+        )
+
     def test_pypi_false_excludes_classifiers_and_keywords(self, copier_defaults: dict, project_factory) -> None:
         """When publish_to_pypi is false, classifiers and keywords should not be in pyproject.toml."""
         answers = {**copier_defaults, "publish_to_pypi": False}


### PR DESCRIPTION
## Summary

- Pin `uv_build>=0.9,<0.12` in `project/pyproject.toml.jinja`'s `build-system.requires` instead of bare `uv_build`.
- Add `test_uv_build_has_upper_bound` to pin the upper-bound requirement.

## Why

uv complains on every `uv sync` / `uv build` when `build-system.requires` lists `uv_build` without an upper bound:

> warning: `build_system.requires = ["uv_build"]` is missing an upper bound on the `uv_build` version such as `<0.12`. Without bounding the `uv_build` version, the source distribution will break when a future, breaking version of `uv_build` is released.

During `poe update-template` the warning fires multiple times (once per copier render pass), drowning out real warnings. And the message isn't just noise — when `uv_build` ships a breaking change, every rendered project's sdist build would break with no upper-bound to fall back to. Bump the upper bound when `uv_build` crosses `0.12+`.

## Test plan

- [x] `poe test` (132 fast tests pass)
- [x] New `test_uv_build_has_upper_bound` passes; verified to **fail** against the unpinned form (`requires = ["uv_build"]`)
- [x] Smoke test: render template at HEAD into a fresh dir, run `uv sync`, no `build_system.requires.*uv_build.*missing` warning in output

Closes DOT-589

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound `uv_build` version in template `build-system.requires` to suppress uv warnings
> The template's `project/pyproject.toml.jinja` previously specified `uv_build` with no upper bound, causing `uv sync` and `uv build` to warn on every run in rendered projects.
>
> - Updates the specifier in [pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/317/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3) from `uv_build` to `uv_build>=0.9,<0.12` with an explanatory comment.
> - Adds `TestCIWorkflows.test_uv_build_has_upper_bound` in [test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/317/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) to fail the test suite if the upper bound is ever removed.
>
> #### 🖇️ Linked Issues
> Resolves [DOT-589](https://linear.app/ismar/issue/DOT-589), which tracked the noisy uv warning produced by the unbounded `uv_build` specifier in every rendered project.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9247f74.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->