### PR TITLE
test(template): lock down semantic-release CHANGELOG URL format for GitLab

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1539,3 +1539,86 @@ class TestIntegration:
             "`uv sync` in the destination's venv would now error with "
             "'cannot be recreated because it is not a virtual environment'."
         )
+
+    @pytest.mark.slow
+    def test_semantic_release_writes_gitlab_urls_for_selfhosted(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """semantic-release must write GitLab-format commit URLs into CHANGELOG.md when `repository_provider=gitlab.com` (DOT-590).
+
+        Static config tests (`test_gitlab_semantic_release_remote`,
+        `test_gitlab_selfhosted_semantic_release_remote_domain`) cover the rendered TOML, but
+        they don't catch the case where python-semantic-release ignores or misinterprets the
+        config and falls back to GitHub URL conventions — exactly the symptom the user saw
+        (their existing CHANGELOG had `github.com/<namespace>/<pkg>/commit/<sha>` for a GitLab
+        project). This is the end-to-end check: actually run `semantic-release changelog` on
+        a multi-level GitLab self-hosted setup and verify the URL format.
+        """
+        answers = {
+            **copier_defaults,
+            "repository_provider": "gitlab.com",
+            "repository_host": "gitlab.pnet.ch",
+            "repository_namespace": "kop/ismar",
+            "project_name": "Die Zeit",
+            "project_visibility": "internal",
+        }
+        project = generate_project(tmp_path, answers)
+
+        git_env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        }
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=project, check=True)
+        subprocess.run(
+            ["git", "remote", "add", "origin", "git@gitlab.pnet.ch:kop/ismar/die-zeit.git"],
+            cwd=project,
+            check=True,
+        )
+        subprocess.run(["git", "add", "-A"], cwd=project, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "feat: initial commit", "--no-verify"],
+            cwd=project,
+            env=git_env,
+            check=True,
+        )
+
+        sync = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True, check=False)
+        assert sync.returncode == 0, f"uv sync failed: {sync.stderr}"
+
+        # Make a real feat commit so semantic-release has something to changelog.
+        (project / "foo.txt").write_text("x\n")
+        subprocess.run(["git", "add", "foo.txt"], cwd=project, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "feat: add foo", "--no-verify"],
+            cwd=project,
+            env=git_env,
+            check=True,
+        )
+
+        result = subprocess.run(
+            ["uv", "run", "semantic-release", "changelog"],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"semantic-release changelog failed: {result.stderr}"
+
+        changelog = (project / "CHANGELOG.md").read_text()
+
+        # Positive: at least one correctly-formatted gitlab self-hosted commit URL exists.
+        assert "https://gitlab.pnet.ch/kop/ismar/die-zeit/-/commit/" in changelog, (
+            f"Expected gitlab self-hosted commit URL in CHANGELOG.md. Got:\n{changelog}"
+        )
+
+        # Negative: no github.com URLs leaked into the gitlab project's changelog (DOT-590).
+        assert "github.com" not in changelog, f"github.com URL leaked into a gitlab project's CHANGELOG.md (DOT-590):\n{changelog}"
+
+        # Negative: no underscore form of the repo slug (the user's specific symptom — `die_zeit`
+        # instead of `die-zeit`). semantic-release should derive the slug from the git remote
+        # URL, never from python_package_import_name.
+        assert "die_zeit" not in changelog, (
+            f"Underscored repo slug `die_zeit` leaked into CHANGELOG.md — semantic-release "
+            f"appears to be using python_package_import_name instead of the repo slug:\n{changelog}"
+        )


### PR DESCRIPTION
## Summary

- Add `test_semantic_release_writes_gitlab_urls_for_selfhosted` (slow integration test): renders a self-hosted GitLab variant, inits git with a multi-level GitLab remote, makes a feat commit, runs `uv run semantic-release changelog`, asserts the URL format.

## Why

DOT-590 reported broken commit URLs in a rendered project's `CHANGELOG.md` on a self-hosted GitLab (`github.com/<ns>/<pkg>/commit/<sha>` instead of `gitlab.pnet.ch/<ns>/<repo>/-/commit/<sha>`).

Investigation: the template config has been correct since 0.29.2 (commit [7c51d44](https://github.com/detailobsessed/copier-uv-bleeding/commit/7c51d44) added the `[tool.semantic_release.remote]` block for `repository_provider=gitlab.com` with a `domain` override for self-hosted). I verified by rendering a project with the user's exact setup (`repository_provider=gitlab.com`, `repository_host=gitlab.pnet.ch`, multi-level `kop/ismar` namespace), running `uv run semantic-release changelog`, and observing:

```
([`d3cac7a`](https://gitlab.pnet.ch/kop/ismar/die-zeit/-/commit/d3cac7ae...))
```

The user's broken URLs are baked into pre-0.29.2 CHANGELOG entries that can't be retroactively regenerated from the template side. The fix in their existing project is a `sed` over the historical entries; the template itself has nothing to fix.

What this PR adds is defence-in-depth: the existing static tests (`test_gitlab_semantic_release_remote`, `test_gitlab_selfhosted_semantic_release_remote_domain`) only check the rendered TOML, not what python-semantic-release does with it. The new integration test exercises the full chain — config → `semantic-release changelog` → URL output — so any future regression (template refactor, python-semantic-release version, etc.) that breaks the URL format gets caught.

The test makes three assertions:
- Positive: a correctly-formatted `gitlab.pnet.ch/<ns>/<repo>/-/commit/<sha>` URL is present.
- Negative: no `github.com` URL leaked.
- Negative: no underscored `die_zeit` form (the user's specific symptom — semantic-release would never use `python_package_import_name`).

## Test plan

- [x] `poe test` (131 fast tests pass)
- [x] New slow test passes (~5s)
- [x] Manual repro on user's exact setup (gitlab.pnet.ch, multi-level kop/ismar namespace) produces correct GitLab URLs

Closes DOT-590

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add integration test to lock down semantic-release CHANGELOG URL format for self-hosted GitLab
> Adds a slow integration test in [tests/test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/318/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) that scaffolds a project configured for a self-hosted GitLab instance (`gitlab.pnet.ch`, namespace `kop/ismar`, repo `die-zeit`), runs `semantic-release changelog`, and asserts the generated `CHANGELOG.md` contains correct GitLab-style commit URLs (with `/-/commit/`) for the self-hosted host, no `github.com` URLs, and no underscored repo slug (`die_zeit`).
>
> #### 🖇️ Linked Issues
> Addresses [DOT-590](https://linear.app/ismar/issue/DOT-590), which reports that semantic-release generates incorrect `github.com`-formatted commit URLs with the wrong host, wrong URL path format (`/commit/` instead of `/-/commit/`), and wrong repo slug (underscored import name instead of dashed repo slug) for GitLab-hosted projects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a59ef5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->