### PR TITLE
feat(template): drop no-commit-to-main pre-push hook by default

### DIFF
--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -68,7 +68,7 @@ jobs:
       run: uv lock
     - uses: j178/prek-action@v1
       env:
-        SKIP: no-commit-to-main,pytest-testmon,uv-lock
+        SKIP: pytest-testmon,uv-lock
       with:
         extra-args: '--all-files'
 

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -26,5 +26,19 @@
 ## Branch protection
 
 The CI workflow includes a `ci-pass` gate job that aggregates the status of all CI jobs.
-Add a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) for `main` requiring the **`ci-pass`** status check to pass before merging.
+Add a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) for `main` requiring the **`ci-pass`** status check to pass before merging — recommended for team workflows.
+
+This project ships **no** local hook blocking pushes to `main`, so a solo workflow can commit straight to `main` for trivial/safe changes (typo fixes, doc tweaks, dep bumps). Add a `no-commit-to-main` pre-push hook to `prek.toml` if you want PR-only enforcement.
+{%- elif repository_provider == "gitlab.com" %}
+## Branch protection
+
+This project ships no local hook blocking pushes to `main`, so a solo workflow can commit straight to `main` for trivial/safe changes.
+
+Some self-hosted GitLab instances enforce a default protected-branch rule on `main`. If yours does and you want the solo workflow, drop the rule:
+
+```bash
+glab api projects/<id>/protected_branches/main -X DELETE
+```
+
+Keep the rule (and add a `no-commit-to-main` pre-push hook to `prek.toml`) if you want PR-only enforcement.
 {%- endif %}

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -80,16 +80,6 @@ hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, typ
 [[repos]]
 repo = "local"
 
-[[repos.hooks]]
-id = "no-commit-to-main"
-name = "prevent pushes to main"
-entry = "bash -c 'test \"$(git rev-parse --abbrev-ref HEAD)\" != main || { echo Direct pushes to main not allowed. Use a branch + PR. && exit 1; }'"
-language = "system"
-always_run = true
-pass_filenames = false
-stages = ["pre-push"]
-priority = 0
-
 # Block commits containing .rej files produced by `copier update --conflict rej` (DOT-542).
 # https://copier.readthedocs.io/en/stable/updating/#tips-and-tricks
 [[repos.hooks]]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -303,7 +303,12 @@ class TestCIWorkflows:
         project = project_factory(answers)
 
         content = (project / ".github" / "workflows" / "ci.yml").read_text()
-        assert "SKIP: no-commit-to-main,pytest-testmon,uv-lock" in content
+        assert "SKIP: pytest-testmon,uv-lock" in content
+        # `no-commit-to-main` was removed from the template (DOT-541) — must not reappear in SKIP.
+        assert "no-commit-to-main" not in content, (
+            "CI workflow still references `no-commit-to-main` in SKIP — the hook was removed "
+            "from prek.toml (DOT-541), so this entry must go too."
+        )
 
     def test_ci_prek_refreshes_lockfile(self, copier_defaults: dict, project_factory) -> None:
         """CI prek job should refresh the lockfile before running hooks."""
@@ -818,6 +823,26 @@ class TestTemplateUpdateCheck:
             f"`uv sync` in the destination during update (see DOT-587). The poe "
             f"`update-template` chain syncs deps AFTER this banner. Drop the line.\n"
             f"Banner:\n{banner}"
+        )
+
+    def test_no_commit_to_main_hook_absent(self, copier_defaults: dict, project_factory) -> None:
+        """The `no-commit-to-main` pre-push hook must not ship in prek.toml (DOT-541).
+
+        Solo workflows commit straight to main for trivial / safe changes (typo fixes, doc
+        tweaks, dep bumps). The template used to ship a `no-commit-to-main` pre-push hook
+        that blocked that workflow unconditionally, forcing every change through a PR even
+        when there was no reviewer to wait for. The template no longer ships it; users who
+        want PR-only enforcement can add a six-line local hook themselves.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        all_hook_ids = [h["id"] for repo in data["repos"] for h in repo.get("hooks", [])]
+        assert "no-commit-to-main" not in all_hook_ids, (
+            f"prek.toml ships a `no-commit-to-main` hook — the template was changed to drop it "
+            f"(DOT-541) so solo workflows can commit straight to main. Current hooks: {all_hook_ids!r}"
         )
 
 


### PR DESCRIPTION
## Summary

- Drop the `no-commit-to-main` local pre-push hook from `project/prek.toml.jinja`.
- Remove `no-commit-to-main` from the CI `prek-action` `SKIP` env (no hook to skip anymore).
- Extend the GitHub `Branch protection` README note to explicitly call out that the template ships no main-blocking hook.
- Add an equivalent `Branch protection` README note for GitLab projects, including the `glab api ... -X DELETE` recipe for instances that enforce a default protected-branch rule.
- Update `test_ci_prek_skips_redundant_hooks` to expect the new SKIP value.
- Add `test_no_commit_to_main_hook_absent` so the hook can't silently come back.

## Why

The shipped hook unconditionally blocked direct pushes to `main`, forcing every change through a PR branch — including trivial / safe changes (typo fixes, doc tweaks, dep bumps) on solo projects with no reviewer to wait for. That ran against the workflow guidance in the user's global CLAUDE.md ("commit straight to main for trivial / safe changes" is the first listed mode).

Solo workflows now get a clear path to commit directly to `main`. Users who want PR-only enforcement can re-add the six-line hook locally — `prek.toml` is on the template's `_skip_if_exists` list during `copier adopt`, so their customizations survive updates.

## On the GitLab protected-branch rule

The other half of DOT-541 was a GitLab protected-branch rule on `main` that pushed users toward MRs. Verified that rule is **instance-driven**, not template-driven:
- `inherited: false` on the user's `kop/tools/unblut` rule rules out group-level inheritance.
- No `api/v4/projects/.../protected_branches` call exists anywhere in the template.

So the template can only document it. The new GitLab `Branch protection` section explains how to drop the rule if a user wants the solo workflow on a self-hosted instance that enforces it; no automation added.

## Test plan

- [x] `poe test` (132 fast tests pass)
- [x] `test_no_commit_to_main_hook_absent` passes, and verified to **fail** if the hook is re-introduced
- [x] `test_ci_prek_skips_redundant_hooks` passes with the new SKIP value

Closes DOT-541

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `no-commit-to-main` pre-push hook from the project template
> - Removes the `no-commit-to-main` pre-push hook from [prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/319/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c), so newly generated projects no longer block direct pushes to `main`.
> - Drops `no-commit-to-main` from the CI workflow's `SKIP` list in [ci.yml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/319/files#diff-6c442173f492d833d3318468a025efe9d82b99678a526f832742f22de893b5b9), since the hook no longer exists.
> - Expands [README.md.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/319/files#diff-70ce1c8a5d080116d767f3929cffba301c1503983aeca1f8d3cd918e3c713ed7) with guidance on branch protection for GitHub and GitLab, including a `glab` API command to remove GitLab's default protected-branch rule and instructions for re-adding the hook manually for PR-only enforcement.
> - Behavioral Change: existing projects are unaffected; only newly generated projects will lack the push blocker.
>
> #### 🖇️ Linked Issues
> Resolves [DOT-541](https://linear.app/ismar/issue/DOT-541), which identified that the `no-commit-to-main` prek hook (along with GitLab's protected-branch rule) forces an MR-based workflow even for solo developers who want to commit directly to `main`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5c8d9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->