### PR TITLE
test(template): parametrize test_all_default_groups_are_defined

### DIFF
--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -360,14 +360,24 @@ class TestPyprojectGroups:
         default_groups = data["tool"]["uv"]["default-groups"]
         assert "dev" in default_groups, f"'dev' missing from default-groups: {default_groups}"
 
-    def test_all_default_groups_are_defined(self) -> None:
-        """Every group listed in default-groups must exist in [dependency-groups]."""
-        for variant_name, context in CONTEXT_VARIANTS.items():
-            data = self._render_pyproject(context)
-            default_groups = data["tool"]["uv"]["default-groups"]
-            defined_groups = set(data.get("dependency-groups", {}).keys())
-            missing = [g for g in default_groups if g not in defined_groups]
-            assert not missing, f"[{variant_name}] groups in default-groups but not defined: {missing}"
+    @pytest.mark.parametrize(
+        ("variant_name", "context"),
+        list(CONTEXT_VARIANTS.items()),
+        ids=list(CONTEXT_VARIANTS.keys()),
+    )
+    def test_all_default_groups_are_defined(self, variant_name: str, context: dict) -> None:
+        """Every group listed in default-groups must exist in [dependency-groups].
+
+        Parametrized over CONTEXT_VARIANTS so each variant gets its own test node;
+        the previous `for`-loop form short-circuited on the first failing variant
+        and hid downstream failures (DOT-284).
+        """
+        del variant_name  # variant identity is carried by the pytest parametrize id
+        data = self._render_pyproject(context)
+        default_groups = data["tool"]["uv"]["default-groups"]
+        defined_groups = set(data.get("dependency-groups", {}).keys())
+        missing = [g for g in default_groups if g not in defined_groups]
+        assert not missing, f"groups in default-groups but not defined: {missing}"
 
 
 class TestStringFuzzing:


### PR DESCRIPTION
## Summary

Replace the `for`-loop+`assert` form of `TestPyprojectGroups::test_all_default_groups_are_defined` with `@pytest.mark.parametrize` over `CONTEXT_VARIANTS.items()`.

## Why

The previous form short-circuited on the first failing variant and hid downstream failures — so a regression that broke multiple variants would only surface one at a time, one PR per round-trip. The parametrized form gives each variant its own test node (`test_all_default_groups_are_defined[gitlab-ci]`, `[lib-type]`, ...) so a single run reports every broken variant. Matches the pattern already in `TestTemplateLint::test_renders_valid_output`.

Suggested by Devin in [PR #272 review](https://github.com/detailobsessed/copier-uv-bleeding/pull/272#discussion_r2874440031).

## Test plan

- [x] `poe test` (148 passed, 3 deselected)
- [x] Test collection now lists 18 parametrized nodes for the variant matrix
- [x] All variants pass

Closes DOT-284

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parametrize `test_all_default_groups_are_defined` to report failures per variant
> Converts the manual `for` loop over `CONTEXT_VARIANTS` in [test_template_lint.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/320/files#diff-3e10f2521e1ba86b30c0c71c006ebe4a332abf80e3424d3e80719e10cc5afa44) to `@pytest.mark.parametrize`, matching the pattern used in `TestTemplateLint.test_renders_valid_output`. Each variant now gets its own test node, so a failure in one variant no longer short-circuits the others.
>
> #### 🖇️ Linked Issues
> Closes [DOT-284](https://linear.app/ismar/issue/DOT-284), which requested this refactor to match existing parametrize patterns and eliminate early-exit behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e2452a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->