### PR TITLE
fix(template): silence two spurious per-run warnings (prek $schema + .rej check)

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -1,4 +1,4 @@
-"$schema" = "https://raw.githubusercontent.com/j178/prek/v0.3.11/prek.schema.json"
+#:schema https://www.schemastore.org/prek.json
 default_stages = ["pre-commit"]
 # Minimum prek version for builtin hooks and TOML config support
 minimum_prek_version = "0.3.11"  # 0.3.11 introduced --repo-exclude-tag (project/scripts/prek-autoupdate.sh)

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -1,4 +1,4 @@
-"$schema" = "https://raw.githubusercontent.com/j178/prek/v0.3.11/prek.schema.json"
+#:schema https://www.schemastore.org/prek.json
 default_stages = ["pre-commit"]
 minimum_prek_version = "0.3.11"  # 0.3.11 introduced --repo-exclude-tag (scripts/prek-autoupdate.sh)
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -275,7 +275,7 @@ prek = "prek run --all-files"
 
 # Template utilities
 check-template = { shell = "copier check-update || true" }
-update-template = { shell = "copier update --trust . --skip-answered --defaults --conflict rej && uv sync --upgrade && bash scripts/prek-autoupdate.sh && echo '  ✓ Dependencies upgraded and hook versions updated' && { ls -1 -- **/*.rej *.rej 2>/dev/null | head -1 >/dev/null && echo '  ⚠ Copier produced .rej files — review the diffs, apply manually, and delete the .rej files before committing.' || true; }{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
+update-template = { shell = "copier update --trust . --skip-answered --defaults --conflict rej && uv sync --upgrade && bash scripts/prek-autoupdate.sh && echo '  ✓ Dependencies upgraded and hook versions updated' && { ls -1 -- **/*.rej *.rej 2>/dev/null | grep -q . && echo '  ⚠ Copier produced .rej files — review the diffs, apply manually, and delete the .rej files before committing.' || true; }{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"


### PR DESCRIPTION
## Summary

Two small template fixes that each eliminated a warning generated projects printed on **every** run.

- **`prek.toml` `$schema` key → `#:schema` directive.** prek doesn't recognize `$schema` as a config key and warns `Ignored unexpected keys in prek.toml: $schema` on every run, commit, and checkout/merge hook. Replaced it with prek's `#:schema https://www.schemastore.org/prek.json` comment directive in both `project/prek.toml.jinja` and this repo's own `prek.toml` (dual-config rule). Being a comment it's silent; taplo-backed IDEs keep autocomplete/validation; the version-less schemastore URL never goes stale.
- **`.rej` detection in the `update-template` task.** It piped `ls ... | head -1` to detect copier conflict files. Under `/bin/sh` (no `pipefail`) the pipeline's exit status is `head`'s, and `head` exits 0 on empty input — so the "Copier produced .rej files" warning fired every time, training users to ignore it. Switched to `grep -q .`, which exits non-zero on empty input, so the warning only appears when `.rej` files actually exist.

## Why

Both warnings were pure noise on every invocation, which erodes trust in the genuinely-useful warnings around them.

## Test plan

- `uv run pytest tests/test_template_lint.py` — 39 passed (validates rendered TOML across all answer combos).
- prek no longer emits the `$schema` unknown-key warning on this repo.

Closes DOT-591
Closes DOT-592

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spurious `.rej` warning and `$schema` noise in `update-template` task
> - Fixes `update-template` always printing the `.rej` warning by replacing `head -1 >/dev/null` with `grep -q .` in [project/pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/321/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3). `head` exits 0 on empty input under `/bin/sh` (no `pipefail`), so the warning fired on every run; `grep -q .` exits non-zero on empty input.
> - Replaces the TOML `$schema` key with a comment-style directive (`#:schema https://www.schemastore.org/prek.json`) in both [prek.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/321/files#diff-72359463e1c50ddcb8dfabe900898a8f1d92416bbe6754f2e497f62d96232021) and [project/prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/321/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c) to silence the per-run schema warning.
>
> #### 🖇️ Linked Issues
> Resolves [DOT-592](https://linear.app/ismar/issue/DOT-592), which tracked the `.rej` detection always printing the warning due to the pipe exit status being `head`'s rather than `ls`'s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a6ab7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->