### PR TITLE
feat(template): decouple community-health files behind a toggle

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -40,14 +40,18 @@ _exclude:
 - "{% if not use_semantic_release %}.github/workflows/release.yml{% endif %}"
 - "{% if not publish_to_mcp_registry %}.github/workflows/mcp-registry-publish.yml{% endif %}"
 - "{% if not use_blacksmith_runners %}.github/actionlint.yaml{% endif %}"
-- "{% if project_visibility == 'internal' %}CODE_OF_CONDUCT.md{% endif %}"
-- "{% if project_visibility == 'internal' %}CONTRIBUTING.md{% endif %}"
-- "{% if project_visibility == 'internal' %}SECURITY.md{% endif %}"
+# Community-health files (OSS contributor onboarding) — gated on use_community_health_files
+- "{% if not use_community_health_files %}CODE_OF_CONDUCT.md{% endif %}"
+- "{% if not use_community_health_files %}CONTRIBUTING.md{% endif %}"
+- "{% if not use_community_health_files %}SECURITY.md{% endif %}"
+- "{% if not use_community_health_files %}docs/code_of_conduct.md{% endif %}"
+- "{% if not use_community_health_files %}docs/contributing.md{% endif %}"
+- "{% if not use_community_health_files %}.github/FUNDING.yml{% endif %}"
+- "{% if not use_community_health_files %}.github/ISSUE_TEMPLATE{% endif %}"
+- "{% if not use_community_health_files %}.github/pull_request_template.md{% endif %}"
+# Licensing files — gated on project_visibility
 - "{% if project_visibility == 'internal' %}LICENSE{% endif %}"
-- "{% if project_visibility == 'internal' %}docs/code_of_conduct.md{% endif %}"
-- "{% if project_visibility == 'internal' %}docs/contributing.md{% endif %}"
 - "{% if project_visibility == 'internal' %}docs/license.md{% endif %}"
-- "{% if project_visibility == 'internal' %}.github/FUNDING.yml{% endif %}"
 
 # PROMPT --------------------------------
 project_name:
@@ -73,6 +77,11 @@ project_visibility:
   choices:
     Public (open-source with LICENSE, CoC, CONTRIBUTING, SECURITY): public
     Internal (company/private — skip open-source scaffolding): internal
+
+use_community_health_files:
+  type: bool
+  help: "Generate OSS community-health files? (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, issue/PR templates, FUNDING)"
+  default: "{{ project_visibility == 'public' }}"
 
 author_fullname:
   type: str

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -51,7 +51,7 @@ Issues = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository
 {%- if repository_host == "github.com" %}
 Discussions = "https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/discussions"
 {%- endif %}
-{%- if repository_host == "github.com" and project_visibility == 'public' %}
+{%- if repository_host == "github.com" and use_community_health_files %}
 Funding = "https://{{ repository_host }}/sponsors/{{ author_username }}"
 {%- endif %}
 

--- a/project/zensical.toml.jinja
+++ b/project/zensical.toml.jinja
@@ -29,7 +29,7 @@ nav = [
   ]},
   {"API reference" = "reference/api.md"},
   {"Development" = [
-{%- if project_visibility == 'public' %}
+{%- if use_community_health_files %}
     {"Contributing" = "contributing.md"},
     {"Code of Conduct" = "code_of_conduct.md"},
 {%- endif %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1319,6 +1319,52 @@ class TestProjectVisibility:
         assert ".github.io" in content
 
 
+class TestCommunityHealthFiles:
+    """use_community_health_files gates OSS onboarding files independently of visibility.
+
+    Community-health files (CoC, CONTRIBUTING, SECURITY, issue/PR templates, FUNDING)
+    are a separate axis from licensing (LICENSE), so a public project can opt out of
+    them and an internal project can opt in.
+    """
+
+    HEALTH_FILES: ClassVar[list[str]] = [
+        "CODE_OF_CONDUCT.md",
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+        ".github/FUNDING.yml",
+        ".github/pull_request_template.md",
+    ]
+
+    def test_public_without_community_health_excludes_files(self, copier_defaults: dict, project_factory) -> None:
+        """A public project with the toggle off ships no community-health files, but keeps LICENSE."""
+        answers = {
+            **copier_defaults,
+            "project_visibility": "public",
+            "use_community_health_files": False,
+        }
+        project = project_factory(answers)
+
+        for f in self.HEALTH_FILES:
+            assert not (project / f).exists(), f"{f} should be excluded when community-health is off"
+        assert not (project / ".github" / "ISSUE_TEMPLATE").exists()
+        # Licensing is a separate axis — a public project keeps its LICENSE.
+        assert (project / "LICENSE").exists()
+
+    def test_internal_with_community_health_keeps_files(self, copier_defaults: dict, project_factory) -> None:
+        """An internal project can opt into community-health files; LICENSE still follows visibility."""
+        answers = {
+            **copier_defaults,
+            "project_visibility": "internal",
+            "use_community_health_files": True,
+        }
+        project = project_factory(answers)
+
+        assert (project / "CONTRIBUTING.md").exists()
+        assert (project / ".github" / "ISSUE_TEMPLATE").exists()
+        # Licensing still follows visibility — an internal project has no LICENSE.
+        assert not (project / "LICENSE").exists()
+
+
 class TestMcpRegistry:
     """Test publish_to_mcp_registry question gates MCP registry publishing workflow.
 

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -67,6 +67,7 @@ def _build_context(overrides: dict) -> dict:
         "use_blacksmith_runners": False,
         "configure_repo_settings": False,
         "project_visibility": "public",
+        "use_community_health_files": True,
         "custom_pypi_index_url": "",
         "current_year": datetime.now(UTC).year,
     }
@@ -169,16 +170,17 @@ def _collect_templates() -> list[Path]:
     return templates
 
 
-_COMMUNITY_FILES = (
+_COMMUNITY_HEALTH_FILES = (
     "CODE_OF_CONDUCT",
     "CONTRIBUTING",
     "SECURITY",
-    "LICENSE",
-    "license.md",
     "contributing.md",
     "code_of_conduct.md",
     "FUNDING",
+    "ISSUE_TEMPLATE",
+    "pull_request_template",
 )
+_LICENSE_FILES = ("LICENSE", "license.md")
 
 
 def _should_skip(rel_str: str, context: dict) -> bool:
@@ -190,7 +192,8 @@ def _should_skip(rel_str: str, context: dict) -> bool:
         (not context.get("use_semantic_release") and "release.yml" in rel_str),
         (not context.get("publish_to_mcp_registry") and "mcp-registry-publish.yml" in rel_str),
         (not context.get("use_docs") and any(x in rel_str for x in ("docs/", "docs.yml", "zensical.toml"))),
-        (context.get("project_visibility") == "internal" and any(x in rel_str for x in _COMMUNITY_FILES)),
+        (not context.get("use_community_health_files", True) and any(x in rel_str for x in _COMMUNITY_HEALTH_FILES)),
+        (context.get("project_visibility") == "internal" and any(x in rel_str for x in _LICENSE_FILES)),
     )
     return any(skip_rules)
 
@@ -258,13 +261,19 @@ CONTEXT_VARIANTS: dict[str, dict] = {
     }),
     # Project types
     "lib-type": _build_context({"project_type": "lib"}),
+    # Community-health toggle (independent of visibility)
+    "public-no-community": _build_context({
+        "use_community_health_files": False,
+    }),
     # Visibility
     "internal": _build_context({
         "project_visibility": "internal",
+        "use_community_health_files": False,
         "publish_to_pypi": False,
     }),
     "internal-selfhosted-gitlab": _build_context({
         "project_visibility": "internal",
+        "use_community_health_files": False,
         "repository_provider": "gitlab.com",
         "repository_host": "gitlab.company.com",
         "publish_to_pypi": False,
@@ -272,6 +281,7 @@ CONTEXT_VARIANTS: dict[str, dict] = {
     }),
     "internal-selfhosted-github": _build_context({
         "project_visibility": "internal",
+        "use_community_health_files": False,
         "repository_provider": "github.com",
         "repository_host": "github.company.com",
         "publish_to_pypi": False,
@@ -284,6 +294,7 @@ CONTEXT_VARIANTS: dict[str, dict] = {
     # Custom PyPI index (corporate Artifactory/Nexus)
     "custom-pypi-index": _build_context({
         "project_visibility": "internal",
+        "use_community_health_files": False,
         "use_custom_pypi_index": True,
         "custom_pypi_index_url": "https://artifactory.company.com/api/pypi/python-virtual/simple",
         "publish_to_pypi": False,


### PR DESCRIPTION
Add a use_community_health_files question so OSS onboarding files
(CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, issue/PR templates, FUNDING) and
their docs pages and nav entries are gated independently of project_visibility.

The default mirrors the previous behaviour ({{ project_visibility == 'public' }}),
so existing projects are unaffected on copier update. Licensing files (LICENSE,
docs/license.md) stay tied to project_visibility — a separate axis.

Closes DOT-595

Closes #

<!-- Replace # with the issue this PR closes (e.g., "Closes #123" or "Closes PROJ-123").
     Use "Ref" to link without closing. Delete the line for PRs with no issue. -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `use_community_health_files` toggle to decouple community-health files from project visibility
> - Adds a `use_community_health_files` boolean prompt to [copier.yml](https://github.com/detailobsessed/copier-uv-bleeding/pull/322/files#diff-a74d725f30a732f10530aec0b66cdc1f1856272e35ede5ba4826ead3075c3d3d), defaulting to `true` for public projects, that independently controls generation of `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `.github/ISSUE_TEMPLATE/`, `.github/pull_request_template.md`, and `.github/FUNDING.yml`.
> - Updates [project/pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/322/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3) and [project/zensical.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/322/files#diff-bbae021b90f251bb40ada1b5805edfd21282b872332aa3a3cba0cc47c16d424c) to gate the Funding URL and docs nav entries on the new toggle rather than `project_visibility`.
> - `LICENSE` and `docs/license.md` remain gated by `project_visibility` (internal projects still exclude them).
> - Adds test coverage in [tests/test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/322/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) and updates the lint matrix in [tests/test_template_lint.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/322/files#diff-3e10f2521e1ba86b30c0c71c006ebe4a332abf80e3424d3e80719e10cc5afa44) to cover enabled/disabled combinations across visibilities.
>
> #### 🖇️ Linked Issues
> Closes [DOT-595](https://linear.app/ismar/issue/DOT-595), which requested a dedicated toggle for OSS community-health files to reduce noise in solo/internal projects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5861832.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->