### PR TITLE
feat(template): add use_heavy_hooks profile, lighten default git hooks

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -185,6 +185,11 @@ use_docs:
   help: "Generate a full documentation site? (zensical site, docs/ tree, mkdocstrings, Pages workflow, docs-build hook). Off = README only."
   default: true
 
+use_heavy_hooks:
+  type: bool
+  help: "Run slow checks as git hooks? (coverage + docs-build on pre-push). Off = fast hooks only; coverage and docs run in CI."
+  default: true
+
 use_ci:
   type: bool
   help: "Enable CI workflow? (testing, linting, type checking)"

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -110,6 +110,8 @@ verbose = true
 stages = ["pre-commit"]
 priority = 1
 
+{%- if use_heavy_hooks %}
+
 [[repos.hooks]]
 id = "pytest-cov"
 name = "pytest with coverage"
@@ -120,8 +122,9 @@ pass_filenames = false
 verbose = true
 stages = ["pre-push"]
 priority = 1
+{%- endif %}
 
-{%- if use_docs %}
+{%- if use_docs and use_heavy_hooks %}
 
 [[repos.hooks]]
 id = "docs-build"
@@ -143,12 +146,13 @@ pass_filenames = false
 verbose = true
 stages = ["post-checkout"]
 
+{%- if use_semantic_release %}
+
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"
 rev = ""  # prek autoupdate will fill this
 hooks = [
   { id = "conventional-pre-commit", stages = ["commit-msg"], priority = 1, args = [
-    "--strict",
     "--verbose",
     "feat",
     "fix",
@@ -162,3 +166,4 @@ hooks = [
     "test",
   ] },
 ]
+{%- endif %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -175,6 +175,43 @@ class TestPreCommitConfig:
         assert "pyupgrade" not in content
 
 
+class TestHookProfiles:
+    """use_heavy_hooks gates slow git hooks; fast hooks stay always-on."""
+
+    @staticmethod
+    def _hook_ids(project: Path) -> list[str]:
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+        return [hook["id"] for repo in data["repos"] for hook in repo.get("hooks", [])]
+
+    def test_heavy_hooks_default_includes_slow_hooks(self, copier_defaults: dict, project_factory) -> None:
+        """The default profile runs coverage and docs-build as git hooks."""
+        ids = self._hook_ids(project_factory(copier_defaults))
+        assert "pytest-cov" in ids
+        assert "docs-build" in ids
+
+    def test_light_hooks_drop_slow_hooks_keep_fast_ones(self, copier_defaults: dict, project_factory) -> None:
+        """use_heavy_hooks=false removes coverage and docs-build but keeps the fast hooks."""
+        ids = self._hook_ids(project_factory({**copier_defaults, "use_heavy_hooks": False}))
+        assert "pytest-cov" not in ids
+        assert "docs-build" not in ids
+        for fast in ("ruff", "ty", "pytest-testmon"):
+            assert fast in ids, f"{fast} should stay always-on"
+
+    def test_conventional_commit_gated_on_semantic_release(self, copier_defaults: dict, project_factory) -> None:
+        """conventional-pre-commit ships only with semantic-release, and without --strict."""
+        with_release = project_factory({**copier_defaults, "use_semantic_release": True})
+        assert "conventional-pre-commit" in self._hook_ids(with_release)
+        assert "--strict" not in (with_release / "prek.toml").read_text()
+
+        without_release = project_factory({
+            **copier_defaults,
+            "use_ci": False,
+            "use_semantic_release": False,
+        })
+        assert "conventional-pre-commit" not in self._hook_ids(without_release)
+
+
 class TestDependencies:
     """Test dependency configuration."""
 

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -59,6 +59,7 @@ def _build_context(overrides: dict) -> dict:
         "python_package_import_name": "my_test_project",
         "python_package_command_line_name": "my-test-project",
         "use_docs": True,
+        "use_heavy_hooks": True,
         "use_ci": True,
         "use_semantic_release": True,
         "publish_to_pypi": True,
@@ -243,6 +244,10 @@ CONTEXT_VARIANTS: dict[str, dict] = {
     }),
     "no-docs": _build_context({
         "use_docs": False,
+    }),
+    # Lightweight hooks — pytest-cov and docs-build dropped from git hooks
+    "lightweight-hooks": _build_context({
+        "use_heavy_hooks": False,
     }),
     "no-docs-no-ci": _build_context({
         "use_docs": False,


### PR DESCRIPTION
Introduce a use_heavy_hooks question (default true) that gates the slow,
release-oriented hooks so a lightweight profile keeps only fast feedback:

- pytest-cov (full coverage, pre-push) and docs-build (pre-push) now run only
  when use_heavy_hooks is on; with it off they run in CI instead.
- conventional-pre-commit (commit-msg) now ships only when use_semantic_release
  is on (it exists to feed the changelog), and drops --strict.

Fast hooks stay always-on: ruff, ruff-format, ty, pytest-testmon, betterleaks,
typos, builtins, shellcheck, lychee. Defaults preserve current behaviour; the
audience profile (DOT-593) will flip use_heavy_hooks off for solo-internal.

Closes DOT-594

Closes #

<!-- Replace # with the issue this PR closes (e.g., "Closes #123" or "Closes PROJ-123").
     Use "Ref" to link without closing. Delete the line for PRs with no issue. -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `use_heavy_hooks` profile to make slow git hooks opt-in
> - Adds a `use_heavy_hooks` boolean question to [copier.yml](https://github.com/detailobsessed/copier-uv-bleeding/pull/324/files#diff-a74d725f30a732f10530aec0b66cdc1f1856272e35ede5ba4826ead3075c3d3d) (default `true`) that controls whether slow pre-push hooks are included in generated projects.
> - Gates the `pytest-cov` pre-push hook behind `use_heavy_hooks`, and the `docs-build` hook behind both `use_docs` and `use_heavy_hooks` in [project/prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/324/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c).
> - Gates `conventional-pre-commit` on `use_semantic_release` and removes the `--strict` flag from its args.
> - Adds test coverage in [tests/test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/324/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) verifying hook inclusion/exclusion under both profiles.
> - Behavioral Change: existing generated projects using the default (`use_heavy_hooks=true`) are unaffected, but re-generating with `use_heavy_hooks=false` drops `pytest-cov` and `docs-build` hooks entirely.
>
> #### 🖇️ Linked Issues
> Partially addresses [DOT-594](https://linear.app/ismar/issue/DOT-594), which proposes making heavy git hooks opt-in, and is part of the broader audience-profile effort tracked in [DOT-593](https://linear.app/ismar/issue/DOT-593).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c9bfa9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->