### PR TITLE
feat(template): add project_audience profile, default to solo-internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ When you run `copier copy`, you'll be asked:
 
 | Prompt | Description |
 | ------ | ----------- |
+| **Project audience** | `solo-internal` (default), `team`, or `public-oss` — sets lighter or fuller defaults for everything below (see [Audience profiles](#audience-profiles)) |
 | **Project name** | Name of your project |
 | **Project description** | One-line description |
 | **Project type** | `app`, `lib`, or `package` — configures pyproject.toml entry points and build settings |
@@ -53,12 +54,29 @@ When you run `copier copy`, you'll be asked:
 | **Repository provider** | `github.com` or `gitlab.com` |
 | **Repository namespace** | GitHub/GitLab username or organization |
 | **License** | Choose from 40+ open source licenses |
+| **Community-health files?** | `CODE_OF_CONDUCT`, `CONTRIBUTING`, `SECURITY`, issue/PR templates, `FUNDING` |
 | **Generate docs site?** | Zensical scaffolding, `docs/`, GitHub Pages workflow |
 | **Enable CI?** | GitHub Actions or GitLab CI |
 | **Enable semantic-release?** | Automated versioning and changelog |
+| **Heavy git hooks?** | Run coverage + docs-build on pre-push (off = fast hooks only; coverage/docs run in CI) |
 | **Publish to PyPI?** | Include PyPI publishing in release workflow |
 | **Use Blacksmith runners?** | 2x faster, 75% cheaper CI runners |
 | **Configure GitHub repo settings?** | Run `gh repo edit` to enable delete-branch-on-merge and auto-merge |
+
+### Audience profiles
+
+`Project audience` is the one high-level choice that sets sensible starting defaults — every individual toggle stays overridable.
+
+| | solo-internal (default) | team | public-oss |
+| --- | --- | --- | --- |
+| Visibility | internal | internal | public |
+| CI | off | on | on |
+| semantic-release | off | on | on |
+| Docs site | off | off | on |
+| Heavy git hooks | off | off | on |
+| Community-health files | off | off | on |
+
+The shipped default is **solo-internal** — the leanest scaffold. Choose **public-oss** for the full open-source stack (docs site, strict hooks, community files), or **team** for a shared internal repo that wants CI and changelogs without the public-facing weight.
 
 ## Quick Start
 

--- a/copier.yml
+++ b/copier.yml
@@ -70,10 +70,19 @@ project_type:
     Application (with CLI entry point — uv init --app): app
     Library (importable package, no CLI — uv init --lib): lib
 
+project_audience:
+  type: str
+  help: "Who is this project for? Sets sensible defaults for visibility, CI, docs, hooks, and OSS files — each still overridable below."
+  default: solo-internal
+  choices:
+    Solo / internal (audience of one — lightest defaults): solo-internal
+    Team (shared internal repo — adds CI + releases): team
+    Public open-source (full stack — docs, strict hooks, OSS files): public-oss
+
 project_visibility:
   type: str
   help: "Project visibility (public = open-source scaffolding, internal = skip community files)"
-  default: public
+  default: "{{ 'public' if project_audience == 'public-oss' else 'internal' }}"
   choices:
     Public (open-source with LICENSE, CoC, CONTRIBUTING, SECURITY): public
     Internal (company/private — skip open-source scaffolding): internal
@@ -183,17 +192,17 @@ python_package_command_line_name:
 use_docs:
   type: bool
   help: "Generate a full documentation site? (zensical site, docs/ tree, mkdocstrings, Pages workflow, docs-build hook). Off = README only."
-  default: true
+  default: "{{ project_audience == 'public-oss' }}"
 
 use_heavy_hooks:
   type: bool
   help: "Run slow checks as git hooks? (coverage + docs-build on pre-push). Off = fast hooks only; coverage and docs run in CI."
-  default: true
+  default: "{{ project_audience == 'public-oss' }}"
 
 use_ci:
   type: bool
   help: "Enable CI workflow? (testing, linting, type checking)"
-  default: "{{ project_visibility == 'public' }}"
+  default: "{{ project_audience != 'solo-internal' }}"
 
 use_semantic_release:
   type: bool

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -1,9 +1,11 @@
 # {{ project_name }}
 
-{% if repository_provider == "github.com" -%}
+{% if use_ci and repository_provider == "github.com" -%}
 [![ci](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/workflows/ci/badge.svg)](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/actions?query=workflow%3Aci)
+{% if use_semantic_release -%}
 [![release](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/workflows/release/badge.svg)](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/actions?query=workflow%3Arelease)
-{% elif repository_provider == "gitlab.com" -%}
+{% endif -%}
+{% elif use_ci and repository_provider == "gitlab.com" -%}
 [![pipeline](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/badges/main/pipeline.svg)](https://{{ repository_host }}/{{ repository_namespace }}/{{ repository_name }}/-/pipelines)
 {% endif -%}
 {%- if use_docs -%}
@@ -17,7 +19,7 @@
 [![pypi version](https://img.shields.io/pypi/v/{{ python_package_distribution_name }}.svg)](https://pypi.org/project/{{ python_package_distribution_name }}/)
 {%- endif %}
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
-{%- if repository_provider == "github.com" %}
+{%- if use_ci and repository_provider == "github.com" %}
 [![codecov](https://codecov.io/github/{{ repository_namespace }}/{{ repository_name }}/graph/badge.svg)](https://codecov.io/github/{{ repository_namespace }}/{{ repository_name }})
 {%- endif %}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def copier_defaults() -> dict:
         "author_username": "testuser",
         "repository_namespace": "testuser",
         "copyright_license": "MIT",
+        "project_audience": "public-oss",
         "use_docs": True,
         "use_ci": True,
         "use_semantic_release": True,

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1402,6 +1402,54 @@ class TestCommunityHealthFiles:
         assert not (project / "LICENSE").exists()
 
 
+class TestAudienceProfiles:
+    """project_audience cascades defaults: solo-internal (light) / team (CI+releases) / public-oss (full)."""
+
+    @staticmethod
+    def _profile_answers(copier_defaults: dict, audience: str) -> dict:
+        # Drop the toggles whose defaults cascade from audience so copier computes them.
+        cascaded = {"use_docs", "use_ci", "use_semantic_release", "project_audience"}
+        answers = {k: v for k, v in copier_defaults.items() if k not in cascaded}
+        answers["project_audience"] = audience
+        return answers
+
+    @staticmethod
+    def _hook_ids(project: Path) -> list[str]:
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+        return [hook["id"] for repo in data["repos"] for hook in repo.get("hooks", [])]
+
+    def test_solo_internal_is_lightest(self, copier_defaults: dict, project_factory) -> None:
+        """solo-internal: no docs site, no CI, no community files, internal visibility, light hooks."""
+        project = project_factory(self._profile_answers(copier_defaults, "solo-internal"))
+        assert not (project / "zensical.toml").exists(), "solo-internal should have no docs site"
+        assert not (project / ".github" / "workflows" / "ci.yml").exists(), "solo-internal should have no CI"
+        assert not (project / "CONTRIBUTING.md").exists(), "solo-internal should have no community files"
+        assert not (project / "LICENSE").exists(), "solo-internal is internal visibility"
+        assert "pytest-cov" not in self._hook_ids(project), "solo-internal should use light hooks"
+        readme = (project / "README.md").read_text()
+        assert "workflows/ci/badge.svg" not in readme, "no CI badge without CI"
+        assert "codecov.io" not in readme, "no codecov badge without CI"
+
+    def test_team_adds_ci_and_releases_but_stays_light(self, copier_defaults: dict, project_factory) -> None:
+        """team: CI + releases on, but no docs site / community files / heavy hooks."""
+        project = project_factory(self._profile_answers(copier_defaults, "team"))
+        assert (project / ".github" / "workflows" / "ci.yml").exists(), "team should have CI"
+        assert (project / ".github" / "workflows" / "release.yml").exists(), "team should have releases"
+        assert not (project / "zensical.toml").exists(), "team should have no docs site"
+        assert not (project / "CONTRIBUTING.md").exists(), "team should have no community files"
+        assert "pytest-cov" not in self._hook_ids(project), "team should keep light hooks"
+
+    def test_public_oss_is_full_stack(self, copier_defaults: dict, project_factory) -> None:
+        """public-oss: docs site, LICENSE, community files, heavy hooks."""
+        project = project_factory(self._profile_answers(copier_defaults, "public-oss"))
+        assert (project / "zensical.toml").exists()
+        assert (project / "LICENSE").exists()
+        assert (project / "CONTRIBUTING.md").exists()
+        assert "pytest-cov" in self._hook_ids(project)
+        assert "workflows/ci/badge.svg" in (project / "README.md").read_text(), "public-oss README has CI badge"
+
+
 class TestMcpRegistry:
     """Test publish_to_mcp_registry question gates MCP registry publishing workflow.
 

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -67,6 +67,7 @@ def _build_context(overrides: dict) -> dict:
         "use_custom_pypi_index": False,
         "use_blacksmith_runners": False,
         "configure_repo_settings": False,
+        "project_audience": "public-oss",
         "project_visibility": "public",
         "use_community_health_files": True,
         "custom_pypi_index_url": "",


### PR DESCRIPTION
Introduce a high-level project_audience question (solo-internal | team |
public-oss) that cascades defaults across the existing toggles. It only sets
each toggle's default — every option stays overridable, and existing projects
keep their saved answers on update (additive, no migration needed).

Cascade:
- solo-internal (new shipped default): internal visibility, no CI, no docs site,
  light hooks, no community-health files.
- team: adds CI + semantic-release/changelog; otherwise stays light.
- public-oss: the full stack (the previous default behaviour).

Also gate the README ci/release/codecov badges on use_ci/use_semantic_release so
a CI-less project no longer ships dead badges, and document the audience
profiles in the template's own README.

Closes DOT-593

Closes #

<!-- Replace # with the issue this PR closes (e.g., "Closes #123" or "Closes PROJ-123").
     Use "Ref" to link without closing. Delete the line for PRs with no issue. -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `project_audience` profile question and default to `solo-internal`
> - Adds a new `project_audience` question to [copier.yml](https://github.com/detailobsessed/copier-uv-bleeding/pull/325/files#diff-a74d725f30a732f10530aec0b66cdc1f1856272e35ede5ba4826ead3075c3d3d) with choices `solo-internal` (default), `team`, and `public-oss`, replacing the previous public-OSS-biased defaults.
> - Cascades defaults from the chosen profile: `solo-internal` disables CI, docs, heavy hooks, and community-health files; `team` enables CI; `public-oss` restores the previous full-stack behavior.
> - Gates CI, release, and Codecov badges in [project/README.md.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/325/files#diff-70ce1c8a5d080116d767f3929cffba301c1503983aeca1f8d3cd918e3c713ed7) behind `use_ci` and `use_semantic_release` so generated READMEs reflect the chosen profile.
> - Test fixtures in [tests/conftest.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/325/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) and [tests/test_template_lint.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/325/files#diff-3e10f2521e1ba86b30c0c71c006ebe4a332abf80e3424d3e80719e10cc5afa44) set `project_audience: public-oss` to preserve existing test coverage; a new `TestAudienceProfiles` suite in [tests/test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/325/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) validates cascade behavior for all three profiles.
> - Behavioral Change: existing projects generated without `project_audience` are unaffected, but new scaffolds now default to `solo-internal` instead of `public-oss`.
>
> #### 🖇️ Linked Issues
> Implements [DOT-593](https://linear.app/ismar/issue/DOT-593), which requested a `project_audience` profile to shift defaults away from public-OSS for solo/internal use cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51a39ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->