### PR TITLE
fix(template): stop typos rewriting files and unblock sync-with-uv

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -85,7 +85,13 @@ hooks = [{ id = "actionlint", priority = 1 }]
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
 rev = "v1.46.0"
-hooks = [{ id = "typos", priority = 1 }]
+# Upstream ships `args = ["--write-changes", "--force-exclude"]`, so the hook
+# rewrites files in place — it has silently corrupted hex identifiers (Mongo
+# ObjectIds, git SHAs) in checked-in data files (DOT-604). Overriding `args`
+# REPLACES the upstream list rather than appending, which is what drops the
+# write flag here. Keep `--force-exclude`: it is what makes typos honour
+# _typos.toml when prek passes explicit staged filenames.
+hooks = [{ id = "typos", args = ["--force-exclude"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
@@ -94,7 +100,10 @@ hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], pr
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.24.2"  # use bash project/scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
+# use bash project/scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492).
+# Note: never put a comment on the same line as `rev` — sync-with-uv anchors its
+# rev regex at end-of-line, so a trailing comment silently disables it (DOT-603).
+rev = "lychee-v0.24.2"
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]

--- a/project/_typos.toml
+++ b/project/_typos.toml
@@ -1,0 +1,16 @@
+# Spell-checker configuration for the `typos` hook in prek.toml.
+#
+# The hook runs read-only: prek.toml overrides its args to drop the upstream
+# `--write-changes` default, so typos reports rather than rewrites (DOT-604).
+# `--force-exclude` is kept there so the exclusions below still apply when prek
+# passes explicit staged filenames rather than letting typos walk the tree.
+#
+# Generated files are excluded because release tooling writes abbreviated git
+# SHAs, which typos reads as prose ("ba" -> "by"/"be").
+#
+# Add your own paths here. Data files holding hex-like identifiers — JSON
+# exports, fixtures, snapshots — are the usual reason; prefer a path exclusion
+# over a repo-wide hex `extend-ignore-re`, which would also silence real typos
+# in source and docs.
+[files]
+extend-exclude = ["CHANGELOG.md", "uv.lock"]

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -4,6 +4,12 @@ minimum_prek_version = "0.3.11"  # 0.3.11 introduced --repo-exclude-tag (scripts
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
 default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post-rewrite", "pre-commit", "pre-push"]
 
+# Empty `rev` values are filled by `bash scripts/prek-autoupdate.sh`, and kept in
+# step with uv.lock by the sync-with-uv hook below. Never put a trailing comment
+# on a `rev` line: sync-with-uv matches revs with a regex anchored at end-of-line,
+# so a trailing comment makes the line unmatchable and the hook silently reports
+# success while updating nothing (DOT-603). Put per-repo notes on the line above.
+
 [[repos]]
 repo = "builtin"
 hooks = [
@@ -26,17 +32,17 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/detailobsessed/sync-with-uv"
-rev = ""  # prek autoupdate will fill this
+rev = ""
 hooks = [{ id = "sync-with-uv", priority = 0 }]
 
 [[repos]]
 repo = "https://github.com/betterleaks/betterleaks"
-rev = ""  # prek autoupdate will fill this
+rev = ""
 hooks = [{ id = "betterleaks", priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = ""  # prek autoupdate will fill this
+rev = ""
 hooks = [
   { id = "ruff", args = ["--fix"], priority = 1 },
   { id = "ruff-format", priority = 1 },
@@ -44,7 +50,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = ""  # prek autoupdate will fill this
+rev = ""
 hooks = [
   { id = "uv-lock", priority = 1 },
   { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 1 },
@@ -52,29 +58,36 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/shellcheck-py/shellcheck-py"
-rev = ""  # prek autoupdate will fill this
+rev = ""
 hooks = [{ id = "shellcheck", priority = 1 }]
 {%- if repository_provider == "github.com" %}
 
 [[repos]]
 repo = "https://github.com/rhysd/actionlint"
-rev = ""  # prek autoupdate will fill this
+rev = ""
 hooks = [{ id = "actionlint", priority = 1 }]
 {%- endif %}
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
-rev = ""  # prek autoupdate will fill this
-hooks = [{ id = "typos", priority = 1 }]
+rev = ""
+# Upstream ships `args = ["--write-changes", "--force-exclude"]`, so the hook
+# rewrites files in place — it has silently corrupted hex identifiers (Mongo
+# ObjectIds, git SHAs) in checked-in data files (DOT-604). Overriding `args`
+# REPLACES the upstream list rather than appending, which is what drops the
+# write flag here. Keep `--force-exclude`: it is what makes typos honour
+# _typos.toml when prek passes explicit staged filenames.
+hooks = [{ id = "typos", args = ["--force-exclude"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
-rev = ""  # prek autoupdate will fill this
+rev = ""
 hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], priority = 1 }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-rev = "lychee-v0.24.2"  # use scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
+# use scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
+rev = "lychee-v0.24.2"
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]
@@ -143,7 +156,7 @@ stages = ["post-checkout"]
 
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"
-rev = ""  # prek autoupdate will fill this
+rev = ""
 hooks = [
   { id = "conventional-pre-commit", stages = ["commit-msg"], priority = 1, args = [
     "--verbose",

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -175,6 +175,74 @@ class TestPreCommitConfig:
         content = config.read_text()
         assert "pyupgrade" not in content
 
+    def test_rev_lines_have_no_trailing_comment(self, copier_defaults: dict, project_factory) -> None:
+        """Every `rev` line must be matchable by sync-with-uv (DOT-603).
+
+        sync-with-uv matches revs with a regex anchored at end-of-line, so a
+        trailing comment makes the line unmatchable. The hook then matches zero
+        revs and reports success, silently doing nothing forever. This is the
+        regex from sync_with_uv.py verbatim, so this test fails for the same
+        reason the real hook would go quiet.
+        """
+        repo_rev_re = re.compile(r"""^\s*rev\s*=\s*(['"])([^'"]*)\1\s*$""")
+        project = project_factory(copier_defaults)
+
+        rev_lines = [line for line in (project / "prek.toml").read_text().splitlines() if re.match(r"^\s*rev\s*=", line)]
+        assert rev_lines, "expected prek.toml to declare at least one rev"
+
+        unmatched = [line for line in rev_lines if not repo_rev_re.match(line)]
+        assert not unmatched, (
+            "these rev lines are invisible to sync-with-uv, which would silently "
+            f"stop syncing hook versions with uv.lock: {unmatched!r}. Put per-repo "
+            "notes on the line above the rev, not after it."
+        )
+
+    def test_typos_hook_does_not_write_changes(self, copier_defaults: dict, project_factory) -> None:
+        """The typos hook must report, not rewrite files in place (DOT-604).
+
+        Upstream ships `args = ["--write-changes", "--force-exclude"]`. Left at
+        the default it edits files, and has corrupted hex identifiers (Mongo
+        ObjectIds, git SHAs) that it read as misspelled prose. Config `args`
+        replace the upstream list rather than appending, so the override must
+        also re-supply `--force-exclude` or _typos.toml stops being honoured
+        when prek passes explicit staged filenames.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        typos = [hook for repo in data["repos"] for hook in repo.get("hooks", []) if hook["id"] == "typos"]
+        assert typos, "expected a typos hook in prek.toml"
+
+        for hook in typos:
+            args = hook.get("args")
+            assert args is not None, (
+                "typos must override args; the upstream default includes --write-changes, which rewrites files in place."
+            )
+            assert "--write-changes" not in args, f"typos must not run with --write-changes; got {args!r}"
+            assert "--force-exclude" in args, (
+                f"keep --force-exclude so _typos.toml exclusions still apply when prek passes explicit filenames; got {args!r}"
+            )
+
+    def test_has_typos_config(self, copier_defaults: dict, project_factory) -> None:
+        """Generated project ships a _typos.toml excluding generated files (DOT-604).
+
+        Release tooling writes abbreviated git SHAs into CHANGELOG.md, which
+        typos reads as prose.
+        """
+        project = project_factory(copier_defaults)
+
+        config = project / "_typos.toml"
+        assert config.exists(), "generated project should ship a _typos.toml"
+
+        with config.open("rb") as f:
+            data = tomllib.load(f)
+
+        excluded = data["files"]["extend-exclude"]
+        assert "CHANGELOG.md" in excluded
+        assert "uv.lock" in excluded
+
 
 class TestHookProfiles:
     """use_heavy_hooks gates slow git hooks; fast hooks stay always-on."""


### PR DESCRIPTION
Two independent defects in the generated prek config, both of which fail
silently in every project generated from this template.

typos (DOT-604): the hook was configured as a bare `{ id = "typos" }`, so
it inherited the upstream default args `[--write-changes, --force-exclude]`
and rewrote files in place. It read hex identifiers as prose and corrupted
them — Mongo ObjectIds in a checked-in JSON export (`afe` -> `safe`, `dbe`
-> `be`) and abbreviated git SHAs in CHANGELOG.md. Config `args` replace
the upstream list rather than appending, so overriding with
`[--force-exclude]` drops the write flag; `--force-exclude` is re-supplied
deliberately, since it is what makes typos honour _typos.toml when prek
passes explicit staged filenames.

Also ship a generated _typos.toml excluding CHANGELOG.md and uv.lock. This
repo already had one; it was never propagated to the template, which is why
generated projects had no exclusions at all.

sync-with-uv (DOT-603): every `rev` line carried a trailing
`# prek autoupdate will fill this` comment. sync-with-uv matches revs with a
regex anchored at end-of-line, so the comment made all 9 lines unmatchable.
The hook matched zero revs and reported success on every run —
indistinguishable from having nothing to do — letting the venv and hook
versions of the same tool drift apart indefinitely. The comment is replaced
by one header note explaining the constraint. The lychee rev had the same
problem via its DOT-492 note, which is moved above the rev rather than
dropped.

Closes DOT-603
Closes DOT-604


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix typos hook to run read-only and remove trailing comments from `rev` lines to unblock `sync-with-uv`
> - Overrides the `typos` hook args to `["--force-exclude"]`, removing `--write-changes` so the hook reports errors instead of rewriting files in place ([prek.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/330/files#diff-72359463e1c50ddcb8dfabe900898a8f1d92416bbe6754f2e497f62d96232021), [project/prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/330/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c)).
> - Adds [project/_typos.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/330/files#diff-f3444f97761e63c63a59daccbf47771d4eb681d90069945763c29cc456dfee54) to exclude `CHANGELOG.md` and `uv.lock` from typos checks, preventing false-positive rewrites of generated content and hex identifiers.
> - Removes trailing comments from all `rev = "..."` lines in the template so `sync-with-uv`'s end-of-line regex can match and update them; moves explanatory comments to the line above.
> - Adds three tests in [tests/test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/330/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) asserting that `rev` lines have no trailing comments, that the typos hook never passes `--write-changes`, and that `_typos.toml` excludes the expected files.
> - Risk: projects generated before this fix have had `sync-with-uv` silently skip all rev updates and `typos` potentially rewriting data files since template `0.41.2`.
>
> #### 🖇️ Linked Issues
> - [DOT-603](https://linear.app/ismar/issue/DOT-603): trailing comments on `rev` lines caused `sync-with-uv` to match zero lines and report false success — fixed by removing all trailing comments from `rev` lines.
> - [DOT-604](https://linear.app/ismar/issue/DOT-604): `typos` ran with `--write-changes` and silently corrupted checked-in data files (e.g. Mongo ObjectIds) — fixed by overriding args to omit `--write-changes` and adding `_typos.toml` exclusions.
> - [DOT-492](https://linear.app/ismar/issue/DOT-492): referenced in context; the lychee `rev` comment is moved off the `rev` line as part of this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4273b43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
