### PR TITLE
fix(template): make release build_command fail loudly and reach the network

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -281,11 +281,52 @@ watch = "gh run watch"
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
+# `set -e` is required. python-semantic-release hands build_command to the
+# shell as a script, not as an `&&` chain, so without it a failing `uv lock`
+# is swallowed: the remaining lines still run, `uv build` exits 0, and the
+# release reports success having committed a stale lockfile. CI cannot catch
+# this afterwards either, because the generated workflow runs `uv sync
+# --frozen`, which uses the lockfile as-is rather than asserting it is fresh
+# (`--locked` is the flag that would). DOT-602.
 build_command = """
+set -e
 uv lock --upgrade-package "$PACKAGE_NAME"
 git add uv.lock CHANGELOG.md
 uv build
 """
+# python-semantic-release REPLACES the environment for build_command instead
+# of extending it: it builds a hardcoded allowlist (PATH, HOME, VIRTUAL_ENV,
+# CI, GITHUB_ACTIONS, ...) and passes it to shell() as `env=`. Everything
+# else is dropped. Since the build_command above runs `uv lock`, which is a
+# network operation, it would otherwise execute with no TLS, proxy or cache
+# configuration while every other job in the same pipeline has all of it.
+# This inverts the usual CI intuition that exporting a variable in the job is
+# enough. DOT-605.
+#
+# A bare "VAR" entry is pass-through, resolved as os.getenv(name, "");
+# "VAR=value" sets a literal. Unset variables therefore arrive as empty
+# strings rather than being omitted, which is safe here — uv treats an empty
+# SSL_CERT_FILE/SSL_CERT_DIR as unset (verified against uv 0.12.0).
+#
+# Keep the proxy variables as a set: HTTPS_PROXY without NO_PROXY routes
+# internal hosts through the corporate proxy, which is the failure mode this
+# replaces. SSL_CERT_DIR is included alongside SSL_CERT_FILE because uv 0.12
+# made an invalid value in either one a hard HTTPS failure rather than a
+# warning-and-fall-back.
+build_command_env = [
+    "UV_SYSTEM_CERTS",
+    "UV_CACHE_DIR",
+    "UV_LINK_MODE",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+]
 commit_message = "chore(release): {version}"
 tag_format = "{version}"
 allow_zero_version = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,32 @@ filterwarnings = [
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
+# `set -e` is required: python-semantic-release runs build_command as a shell
+# script, not an `&&` chain, so without it a failing `uv lock` is swallowed
+# and the release reports success having committed a stale lockfile (DOT-602).
 build_command = """
+set -e
 uv lock --upgrade-package "$PACKAGE_NAME"
 git add uv.lock CHANGELOG.md
 """
+# python-semantic-release REPLACES rather than extends the environment for
+# build_command, so `uv lock` above would otherwise run with no TLS, proxy or
+# cache configuration. Bare entries are pass-through via os.getenv(name, "");
+# unset variables arrive as empty strings, which uv treats as unset (DOT-605).
+build_command_env = [
+    "UV_SYSTEM_CERTS",
+    "UV_CACHE_DIR",
+    "UV_LINK_MODE",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+]
 commit_message = "chore(release): {version}"
 tag_format = "{version}"
 allow_zero_version = true

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -244,6 +244,79 @@ class TestPreCommitConfig:
         assert "uv.lock" in excluded
 
 
+class TestSemanticReleaseBuildCommand:
+    """build_command must fail loudly and reach the network (DOT-602, DOT-605)."""
+
+    @staticmethod
+    def _semantic_release(project: Path) -> dict:
+        with (project / "pyproject.toml").open("rb") as f:
+            return tomllib.load(f)["tool"]["semantic_release"]
+
+    def test_build_command_aborts_on_failure(self, copier_defaults: dict, project_factory) -> None:
+        """build_command must `set -e` so a failing `uv lock` aborts the release (DOT-602).
+
+        python-semantic-release runs build_command as a shell script rather
+        than an `&&` chain. Without `set -e`, a failed `uv lock` lets the
+        following lines run anyway, `uv build` exits 0, and the release is
+        reported green having committed a stale lockfile. Nothing downstream
+        catches it either: the generated CI runs `uv sync --frozen`, which
+        consumes the lockfile as-is instead of asserting freshness.
+        """
+        project = project_factory({**copier_defaults, "use_semantic_release": True})
+        build_command = self._semantic_release(project)["build_command"]
+
+        lines = [line.strip() for line in build_command.strip().splitlines() if line.strip()]
+        assert lines, "build_command should not be empty"
+        assert lines[0] == "set -e", (
+            "build_command must start with `set -e`, otherwise a failing `uv lock` is "
+            f"swallowed and the release silently ships a stale lockfile. Got {lines!r}"
+        )
+
+    def test_build_command_env_passes_through_network_config(self, copier_defaults: dict, project_factory) -> None:
+        """build_command_env must forward TLS/proxy/cache config (DOT-605).
+
+        python-semantic-release replaces rather than extends the environment
+        for build_command, keeping only a hardcoded allowlist. Since
+        build_command runs `uv lock`, a network operation, anything not listed
+        here is dropped and the lock runs without the CI's TLS, proxy and cache
+        settings. uv 0.12 made an invalid SSL_CERT_FILE/SSL_CERT_DIR a hard
+        HTTPS failure rather than a warning, so this is release-breaking on any
+        project behind a corporate CA or proxy.
+        """
+        project = project_factory({**copier_defaults, "use_semantic_release": True})
+        config = self._semantic_release(project)
+
+        assert "build_command_env" in config, (
+            "build_command runs `uv lock` over the network, so build_command_env must "
+            "forward the environment python-semantic-release would otherwise drop."
+        )
+        env = config["build_command_env"]
+
+        for required in ("UV_SYSTEM_CERTS", "SSL_CERT_FILE", "SSL_CERT_DIR", "REQUESTS_CA_BUNDLE"):
+            assert required in env, f"{required} must be forwarded for corporate-CA setups; got {env!r}"
+
+        # Proxy variables must travel as a set: HTTPS_PROXY without NO_PROXY
+        # routes internal hosts through the corporate proxy, which is the exact
+        # failure this replaces. Both cases matter -- tools disagree on which
+        # they read.
+        for lower in ("http_proxy", "https_proxy", "no_proxy"):
+            assert lower in env, f"{lower} missing; proxy vars must be forwarded as a set. Got {env!r}"
+            assert lower.upper() in env, f"{lower.upper()} missing; proxy vars must be forwarded as a set. Got {env!r}"
+
+    def test_build_command_env_entries_are_pass_through(self, copier_defaults: dict, project_factory) -> None:
+        """Entries must be bare names, not `NAME=value` literals.
+
+        A bare entry is resolved as os.getenv(name, ""), forwarding whatever CI
+        set. Hardcoding a value in the template would override the CI's real
+        configuration instead of passing it through.
+        """
+        project = project_factory({**copier_defaults, "use_semantic_release": True})
+        env = self._semantic_release(project)["build_command_env"]
+
+        hardcoded = [entry for entry in env if "=" in entry]
+        assert not hardcoded, f"build_command_env entries must be pass-through names, not literals: {hardcoded!r}"
+
+
 class TestHookProfiles:
     """use_heavy_hooks gates slow git hooks; fast hooks stay always-on."""
 


### PR DESCRIPTION
## Summary

Two defects in the same `build_command` block in both `project/pyproject.toml.jinja` and this repo's own `pyproject.toml`, either of which lets a release report success while shipping a stale lockfile.

- **`set -e`** — python-semantic-release hands `build_command` to the shell as a *script*, not an `&&` chain. Without `set -e`, a failing `uv lock` was swallowed: the remaining lines still ran, the build exited 0, and the release went green.
- **`build_command_env`** — PSR *replaces* rather than extends the environment for `build_command`, building a hardcoded allowlist (`PATH`, `HOME`, `VIRTUAL_ENV`, `CI`, …) and passing it to `shell()` as `env=`. Everything else is dropped. Since `build_command` runs `uv lock` — a network operation — it executed with no TLS, proxy or cache configuration while every other job in the pipeline had all of it.

Adds the first test coverage this block has ever had.

## Why

The `set -e` failure was observed downstream in `hpqc-toolkit`, where four consecutive release commits touched only `CHANGELOG.md` and `pyproject.toml` and never `uv.lock`. Nothing catches it afterwards either: the generated CI runs `uv sync --frozen`, which consumes the lockfile as-is rather than asserting freshness (`--locked` is the flag that would).

The environment problem gets materially worse under uv 0.12. Measured against a cold cache with an invalid `SSL_CERT_FILE`:

| uv version | result |
|---|---|
| 0.11.33 | warns, resolves successfully |
| 0.12.0 | fails — `invalid peer certificate: UnknownIssuer` |

A silent fallback became a release-breaking error, so this stops being latent the moment the uv 0.12 PR above it lands.

PSR runs `build_command` *before* the release commit, so aborting there leaves no half-made commit or tag.

Entries are bare pass-through names. PSR resolves those via `os.getenv(name, "")` and assigns unconditionally, so unset variables arrive as **empty strings** rather than being omitted — verified against uv 0.12.0 that empty `SSL_CERT_FILE`/`SSL_CERT_DIR` are treated as unset, so this is safe for projects that set none of them. `SSL_CERT_DIR` is included beyond the list in DOT-605 because uv 0.12 hard-fails on it too. The proxy variables are kept as a set: `HTTPS_PROXY` without `NO_PROXY` routes internal hosts through the corporate proxy, which is the failure mode this replaces.

This block has now regressed twice (DOT-393, DOT-479) precisely because it had no tests.

## Test plan

- `TestSemanticReleaseBuildCommand` — three new tests: `build_command` aborts on failure, `build_command_env` passes through the network configuration, and its entries are pass-through names rather than `NAME=value` assignments.
- Verified PSR's behaviour directly against `config.py:857-859`, which assigns `os.getenv(name, "")` unconditionally.
- Verified empirically against uv 0.12.0 on a cold cache with real network access that empty `SSL_CERT_FILE`/`SSL_CERT_DIR` behave as unset.
- Reproduced the uv 0.11 → 0.12 escalation shown in the table above.
- Full suite green on a clean tree.

Closes DOT-602
Closes DOT-605
