### PR TITLE
refactor(template): extend ruff's defaults instead of replacing them

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -71,7 +71,7 @@ maintain = [
 ]
 {%- endif %}
 ci = [
-    "ruff>=0.14",
+    "ruff>=0.16",
     "pytest>=8",
     "pytest-cov>=6",
     "pytest-randomly>=3.15",
@@ -98,6 +98,15 @@ url = "{{ custom_pypi_index_url }}"
 [tool.ruff]
 target-version = "py314"
 line-length = 140
+# `extend-select` below assumes ruff 0.16's broad defaults (413 rules). On 0.14
+# and 0.15 the defaults are just 59 rules (E4/E7/E9/F), so extending them would
+# silently drop the prefixes that were deleted here as redundant — DTZ, FA, FLY
+# and PIE — with no warning at all. Fail loudly instead of linting less than the
+# config claims. This lives here rather than only in the `ci` dependency floor
+# because that group is inside a template-preserve region: a project updating
+# from an older template keeps its own `ruff>=0.14` but does receive this
+# section, so the floor alone would not protect it.
+required-version = ">=0.16"
 # Preview rules are unstable by definition — they change behaviour and can be
 # removed between patch releases. Turning them on also opts into preview-only
 # config syntax that then cannot be turned off again: `rule-codes-in-selectors`
@@ -109,8 +118,19 @@ line-length = 140
 preview = false
 
 [tool.ruff.lint]
-select = [
-    # Core — universal baseline (ruff defaults + pycodestyle warnings)
+# `extend-select`, not `select`. Ruff's default rule set is broad (413 rules
+# as of 0.16) and grows with each release. `select` REPLACES that set, so a
+# curated list silently switches off every default it omits — this list was
+# disabling 81 of them, including all ten flake8-async rules, blind-except,
+# the leftover-debugger check and the flake8-pyi rules, with nothing warning
+# that it was doing so. `extend-select` layers on top of the defaults instead,
+# so future ruff releases add coverage rather than quietly losing it.
+#
+# Only list a prefix here if it is NOT already on by default. Entries that
+# become default should be deleted rather than kept "for documentation": a
+# redundant entry is indistinguishable from a load-bearing one.
+extend-select = [
+    # Core — pycodestyle beyond the default subset
     "E",    # pycodestyle errors
     "W",    # pycodestyle warnings
     "F",    # Pyflakes
@@ -118,20 +138,17 @@ select = [
     # Modern Python — enforce current idioms
     "UP",   # pyupgrade — use modern syntax (match, type unions, etc.)
     "I",    # isort — deterministic import ordering
-    "FA",   # flake8-future-annotations — `from __future__ import annotations`
 
     # Code quality — catch bugs and enforce clean patterns
     "A",    # flake8-builtins — prevent shadowing builtins (id, type, list)
     "B",    # flake8-bugbear — common bugs and design issues
     "SIM",  # flake8-simplify — simplifiable constructs
     "C4",   # flake8-comprehensions — better comprehensions
-    "PIE",  # flake8-pie — misc quality improvements
     "RET",  # flake8-return — consistent return statements
     "RSE",  # flake8-raise — raise best practices
     "ISC",  # flake8-implicit-str-concat — catch missing commas in collections
     "RUF",  # Ruff-specific rules
     "FURB", # refurb — modernise and simplify code
-    "FLY",  # flynt — prefer f-strings over .format() and %
     "PGH",  # pygrep-hooks — catch bare `# type: ignore`, eval(), etc.
 
     # Import hygiene
@@ -143,7 +160,6 @@ select = [
     # "N",  # pep8-naming — PEP 8 naming conventions
 
     # Correctness
-    "DTZ",  # flake8-datetimez — enforce timezone-aware datetimes
     "PTH",  # flake8-use-pathlib — prefer pathlib over os.path
 
     # Error messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,10 @@ patch_tags = ["fix", "perf", "refactor", "ci", "docs", "chore", "style", "build"
 [tool.ruff]
 target-version = "py314"
 line-length = 140
+# `extend-select` below assumes ruff 0.16's broad defaults (413 rules). On 0.14
+# and 0.15 the defaults are just 59 rules (E4/E7/E9/F), so extending them would
+# silently drop the prefixes deleted here as redundant — DTZ, FA, FLY, PIE.
+required-version = ">=0.16"
 # Preview rules are unstable by definition — they change behaviour and can be
 # removed between patch releases. Turning them on also opts into preview-only
 # config syntax that then cannot be turned off again: `rule-codes-in-selectors`
@@ -97,8 +101,19 @@ line-length = 140
 preview = false
 
 [tool.ruff.lint]
-select = [
-    # Core — universal baseline (ruff defaults + pycodestyle warnings)
+# `extend-select`, not `select`. Ruff's default rule set is broad (413 rules
+# as of 0.16) and grows with each release. `select` REPLACES that set, so a
+# curated list silently switches off every default it omits — this list was
+# disabling 81 of them, including all ten flake8-async rules, blind-except,
+# the leftover-debugger check and the flake8-pyi rules, with nothing warning
+# that it was doing so. `extend-select` layers on top of the defaults instead,
+# so future ruff releases add coverage rather than quietly losing it.
+#
+# Only list a prefix here if it is NOT already on by default. Entries that
+# become default should be deleted rather than kept "for documentation": a
+# redundant entry is indistinguishable from a load-bearing one.
+extend-select = [
+    # Core — pycodestyle beyond the default subset
     "E",    # pycodestyle errors
     "W",    # pycodestyle warnings
     "F",    # Pyflakes
@@ -106,20 +121,17 @@ select = [
     # Modern Python — enforce current idioms
     "UP",   # pyupgrade — use modern syntax (match, type unions, etc.)
     "I",    # isort — deterministic import ordering
-    "FA",   # flake8-future-annotations — `from __future__ import annotations`
 
     # Code quality — catch bugs and enforce clean patterns
     "A",    # flake8-builtins — prevent shadowing builtins (id, type, list)
     "B",    # flake8-bugbear — common bugs and design issues
     "SIM",  # flake8-simplify — simplifiable constructs
     "C4",   # flake8-comprehensions — better comprehensions
-    "PIE",  # flake8-pie — misc quality improvements
     "RET",  # flake8-return — consistent return statements
     "RSE",  # flake8-raise — raise best practices
     "ISC",  # flake8-implicit-str-concat — catch missing commas in collections
     "RUF",  # Ruff-specific rules
     "FURB", # refurb — modernise and simplify code
-    "FLY",  # flynt — prefer f-strings over .format() and %
     "PGH",  # pygrep-hooks — catch bare `# type: ignore`, eval(), etc.
 
     # Import hygiene
@@ -131,7 +143,6 @@ select = [
     # "N",  # pep8-naming — PEP 8 naming conventions
 
     # Correctness
-    "DTZ",  # flake8-datetimez — enforce timezone-aware datetimes
     "PTH",  # flake8-use-pathlib — prefer pathlib over os.path
 
     # Error messages

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -67,6 +67,69 @@ class TestCoreFiles:
         assert "[tool.ruff]" in content
         assert "[tool.ruff.lint]" in content
 
+    def test_ruff_extends_defaults_rather_than_replacing_them(self, copier_defaults: dict, project_factory) -> None:
+        """Ruff config must use `extend-select`, never `select`.
+
+        `select` REPLACES ruff's default rule set; `extend-select` layers on
+        top of it. Ruff's defaults are broad (413 rules as of 0.16) and grow
+        with each release, so a curated `select` list silently switches off
+        every default it happens to omit — and nothing warns that it has.
+        Before this was fixed the template disabled 81 default rules that way,
+        including every flake8-async rule, blind-except and the leftover
+        debugger check.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "pyproject.toml").open("rb") as f:
+            lint = tomllib.load(f)["tool"]["ruff"]["lint"]
+
+        assert "select" not in lint, (
+            "`select` replaces ruff's defaults, silently disabling every rule it omits. "
+            "Use `extend-select` so new ruff defaults are added rather than dropped."
+        )
+        assert "extend-select" in lint, "ruff config should declare extend-select"
+
+    def test_ruff_does_not_select_default_rules(self, copier_defaults: dict, project_factory) -> None:
+        """Prefixes that ruff now enables by default should not be re-listed.
+
+        A redundant entry is indistinguishable from a load-bearing one, so they
+        get deleted rather than kept "for documentation". These four are fully
+        covered by stable ruff 0.16's defaults.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "pyproject.toml").open("rb") as f:
+            selected = tomllib.load(f)["tool"]["ruff"]["lint"]["extend-select"]
+
+        redundant = sorted({"DTZ", "FA", "FLY", "PIE"} & set(selected))
+        assert not redundant, f"these prefixes are fully enabled by ruff's defaults; drop them: {redundant!r}"
+
+    def test_ruff_required_version_matches_the_extend_select_premise(self, copier_defaults: dict, project_factory) -> None:
+        """`extend-select` is only safe on ruff >=0.16, so the config must demand it.
+
+        Ruff 0.14/0.15 enable 59 default rules (E4/E7/E9/F); 0.16 enables 413.
+        The four prefixes deleted as "redundant" are covered by the 413 and not
+        by the 59, so on an older ruff `extend-select` drops them silently.
+
+        `required-version` is the load-bearing guard rather than the `ci`
+        dependency floor: that group lives inside a `template-preserve` region,
+        so a project updating from an older template keeps its own `ruff>=0.14`
+        while still receiving this `[tool.ruff]` section. Only a constraint
+        inside the propagated section protects it, and it fails loudly.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "pyproject.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        assert data["tool"]["ruff"].get("required-version") == ">=0.16", (
+            "extend-select assumes ruff 0.16's 413 default rules; without required-version "
+            "an older ruff silently drops DTZ/FA/FLY/PIE instead of failing"
+        )
+
+        ci_deps = data["dependency-groups"]["ci"]
+        assert "ruff>=0.16" in ci_deps, f"the ci group should pin the same floor; got {ci_deps!r}"
+
     def test_ruff_preview_is_disabled(self, copier_defaults: dict, project_factory) -> None:
         """Generated projects must not opt into ruff's preview rules.
 

--- a/tests/test_template_lint.py
+++ b/tests/test_template_lint.py
@@ -350,7 +350,13 @@ class TestTemplateLint:
             try:
                 template = _ENV.get_template(str(rel))
                 rendered = template.render(context)
-            except Exception as exc:
+            # Deliberately broad: this test's job is to report every render
+            # failure across every template and context variant in one pass.
+            # Jinja raises a wide range here (TemplateSyntaxError,
+            # UndefinedError, and arbitrary exceptions from custom filters),
+            # and narrowing the catch would turn an unanticipated failure into
+            # a test error instead of a readable report line.
+            except Exception as exc:  # noqa: BLE001
                 errors.append(f"RENDER FAIL {label}: {exc}")
                 continue
 


### PR DESCRIPTION
## Summary

Switches both ruff configs from `select` to `extend-select`, and deletes four prefixes that ruff now enables by default.

## Why

`select` **replaces** ruff's default rule set; `extend-select` layers on top of it. Both configs used `select`, so every default the curated list happened to omit was switched off — silently, with nothing in ruff distinguishing "this rule was considered and rejected" from "this rule did not exist when the list was written."

Measured on stable ruff 0.16 by dumping the resolved rule set via `ruff check --show-settings`:

| config | rules enabled | defaults missing |
|---|---|---|
| bare defaults | 413 | — |
| template list, `select` | 598 | **81** |
| template list, `extend-select` | 679 | 0 |

The 81 being lost include all ten flake8-async rules (blocking HTTP, `open`, `sleep` and subprocess calls inside async functions), `blind-except`, the leftover-debugger check, the flake8-logging-format and flake8-executable rules, and the flake8-pyi group. None of that was a decision anyone made.

This also inverts how the list ages. Under `select`, every rule ruff adds to its defaults is one more rule the template quietly excludes; under `extend-select` the same release adds coverage instead. That matters more here than in an ordinary project, since the list is inherited by everything generated from the template.

**Four prefixes dropped as redundant:** `FA`, `PIE`, `FLY`, `DTZ`. Each was checked in isolation — selected alone, every rule it contributes is already among the 413 defaults, so the entry does nothing. They are deleted rather than kept as documentation, because a redundant entry is indistinguishable from a load-bearing one and the next reader has no way to tell which is which. The header comment states that rule so the list does not silently re-accumulate them.

### Version guard (raised by Macroscope in review)

Dropping those four is only safe on ruff 0.16. Its predecessors enable **59** default rules (`E4`/`E7`/`E9`/`F`), not 413, and none of the four are among the 59 — so on ruff 0.14/0.15 `extend-select` layers onto a nearly empty base and the four vanish with no warning. The generated `ci` group floor was `ruff>=0.14`, which permits exactly that.

| ruff | default rules | covers DTZ/FA/FLY/PIE? |
|---|---|---|
| 0.15 | 59 | no |
| 0.16 | 413 | yes |

Guarded with `required-version = ">=0.16"` in `[tool.ruff]`, plus the `ci` floor raised to `ruff>=0.16`.

**`required-version` is the load-bearing half.** The `[dependency-groups]` block sits inside a `template-preserve` region, so a project updating from an older template keeps its own `ruff>=0.14` while still receiving this `[tool.ruff.lint]` section, which is *not* preserved. Raising the floor alone would fix newly generated projects and leave updating ones holding the change without its prerequisite. Only a constraint inside the propagated section reaches them — and it fails loudly rather than linting less than the config claims.

`blind-except` was among the 81, so it now fires for the first time on the deliberately broad `except Exception` in `test_template_lint.py`, whose job is to collect every render failure across every template and context variant into one readable report. Suppressed with `# noqa: BLE001` plus an explanation of why the catch is broad on purpose — **not** the preview `# ruff: ignore[...]` form, which under `preview = false` neither suppresses nor errors.

## Test plan

- `ruff check .` passes in this repo and on a freshly rendered project.
- Rule counts in the table above were measured, not estimated — three configs dumped via `ruff check --show-settings` and diffed.
- Each of the four dropped prefixes verified individually against the default set.
- Verified both suppression forms under `preview = false`: `# noqa: BLE001` suppresses, `# ruff: ignore[blind-except]` silently does not.
- Three tests: `test_ruff_extends_defaults_rather_than_replacing_them` (asserts `select` absent, `extend-select` present), `test_ruff_does_not_select_default_rules` (pins the four dropped prefixes so they cannot drift back in), and `test_ruff_required_version_matches_the_extend_select_premise` (asserts both halves of the version guard).
- Version guard verified end-to-end on a rendered project: ruff 0.16 → `All checks passed!`; ruff 0.15 → `Required version >=0.16 does not match the running version 0.15.0`, a hard config error rather than a silent reduction in coverage.
- Ruff 0.15's default rule set dumped and diffed the same way as 0.16's to confirm the 59-vs-413 figures.
- Full suite green on a clean tree: `170 passed`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend ruff's defaults instead of replacing them in linting config
> - Switches `select` to `extend-select` in [pyproject.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/333/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) and [project/pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/333/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3), so ruff's built-in defaults are preserved rather than overwritten.
> - Removes rule prefixes `DTZ`, `FA`, `FLY`, and `PIE` from `extend-select` since they are now defaults in ruff 0.16.
> - Adds `required-version = ">=0.16"` to both configs and bumps the CI `ruff` dependency to `>=0.16`, so older ruff versions fail fast instead of silently dropping default rules.
> - Adds three tests in [tests/test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/333/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) to enforce the use of `extend-select`, the absence of redundant default prefixes, and the `>=0.16` version floor in generated projects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 822c006.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->