### PR TITLE
fix(template): exclude .copier-answers.yml from typos

### DIFF
--- a/project/_typos.toml
+++ b/project/_typos.toml
@@ -8,9 +8,18 @@
 # Generated files are excluded because release tooling writes abbreviated git
 # SHAs, which typos reads as prose ("ba" -> "by"/"be").
 #
+# .copier-answers.yml is the same problem with worse consequences. Copier writes
+# `_commit: <git describe>` there, e.g. `0.41.3-3-g2452caf` — and short SHAs are
+# hex, so any of the handful of words spellable from [0-9a-f] trips the
+# dictionary: caf, beef, fade, dead, deca. That makes it fail on a minority of
+# commits and pass on the rest, which is close to impossible to diagnose from
+# the outside. Worse, `_commit` is what `copier update` reads to find the
+# template revision to diff against; a "corrected" SHA points at nothing and
+# breaks updates for the project.
+#
 # Add your own paths here. Data files holding hex-like identifiers — JSON
 # exports, fixtures, snapshots — are the usual reason; prefer a path exclusion
 # over a repo-wide hex `extend-ignore-re`, which would also silence real typos
 # in source and docs.
 [files]
-extend-exclude = ["CHANGELOG.md", "uv.lock"]
+extend-exclude = ["CHANGELOG.md", "uv.lock", ".copier-answers.yml"]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -242,6 +242,11 @@ class TestPreCommitConfig:
         excluded = data["files"]["extend-exclude"]
         assert "CHANGELOG.md" in excluded
         assert "uv.lock" in excluded
+        assert ".copier-answers.yml" in excluded, (
+            "copier writes `_commit: <git describe>` here, and short SHAs are hex — any of "
+            "caf/beef/fade/dead/deca trips the dictionary. Without this exclusion the hook "
+            "fails on a minority of commits, and `copier update` breaks if it is ever 'fixed'."
+        )
 
 
 class TestSemanticReleaseBuildCommand:


### PR DESCRIPTION
## Summary

Adds `.copier-answers.yml` to `extend-exclude` in `project/_typos.toml`, plus a deterministic test.

## Why

Copier writes `_commit: <git describe>` into `.copier-answers.yml`. Short SHAs are hex, so any of the handful of words spellable from `[0-9a-f]` trips the typos dictionary — `caf`, `beef`, `fade`, `dead`, `deca`. When one does, **every** `git commit` in the generated project fails until the template revision changes.

Caught by this stack's own pre-push hook, with the template at `0.41.3-3-g2452caf`:

```
typos....................................................................Failed
- hook id: typos
- exit code: 2

  error: `caf` should be `calf`
    ╭▸ .copier-answers.yml:2:24
    │
  2 │ _commit: 0.41.3-3-g2452caf
    ╰╴                       ━━━
```

**The SHA dependence is what makes this bad.** Most template revisions are fine and a few are broken, so a user sees their commits start failing after a `copier update` that changed nothing they can see, with no way to connect cause and effect. Re-running does not help — the SHA is stable until the template is updated again.

**Before #330 this was not a failure at all — it was silent corruption.** The hook ran with `--write-changes`, so instead of reporting it would have rewritten `_commit: …g2452caf` to `…g2452calf`. That field is what `copier update` reads to find the template revision to diff against, so a "corrected" SHA resolves to nothing and template updates break for that project permanently and invisibly. #330 turned data loss into a loud failure; this is the missing half.

`_typos.toml` already excluded `CHANGELOG.md` and `uv.lock` for exactly this reason — its header comment names abbreviated git SHAs as the cause. The answers file was simply missed.

A path exclusion is preferred over a repo-wide hex `extend-ignore-re`, which would also silence real typos in source and docs. `.copier-answers.yml` is entirely machine-generated, so nothing is lost by skipping it.

## Test plan

- `test_first_commit_succeeds_with_prek_hooks` — the full-prek-chain integration test that caught this — now passes (`1 passed in 7.83s`). It previously failed at `assert 2 == 1`, having exhausted both commit attempts.
- Adds a deterministic assertion to `test_has_typos_config` on the exclude list. The integration test only catches this when HEAD's SHA happens to contain a flagged word, and it is marked `@pytest.mark.slow`, so `poe test` deselects it — which is why this went unnoticed until a pre-push run.
- Full suite green via the pre-push hook: `175 passed`, coverage 96.75%.

Closes DOT-614
