### PR TITLE
fix(release): unset forwarded UV_* variables when they arrive empty

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -319,8 +319,21 @@ branch = "main"
 # this afterwards either, because the generated workflow runs `uv sync
 # --frozen`, which uses the lockfile as-is rather than asserting it is fresh
 # (`--locked` is the flag that would). DOT-602.
+#
+# The `unset` lines are required for the same reason. Bare entries in
+# build_command_env are resolved as os.getenv(name, "") and assigned
+# unconditionally, so a variable that is unset in CI arrives here as an empty
+# string rather than being omitted. uv parses its own UV_* variables as typed
+# CLI values -- an enum for --link-mode, a path for --cache-dir, a boolish for
+# --system-certs -- so an empty one is a malformed value, not an absent one,
+# and `uv lock` exits 2 before doing any work. The TLS and proxy variables are
+# read as plain strings where empty already means unset, so they need no
+# guard (each of the twelve verified individually against uv 0.12.1). DOT-615.
 build_command = """
 set -e
+[ -n "$UV_SYSTEM_CERTS" ] || unset UV_SYSTEM_CERTS
+[ -n "$UV_CACHE_DIR" ] || unset UV_CACHE_DIR
+[ -n "$UV_LINK_MODE" ] || unset UV_LINK_MODE
 uv lock --upgrade-package "$PACKAGE_NAME"
 git add uv.lock CHANGELOG.md
 uv build
@@ -336,8 +349,8 @@ uv build
 #
 # A bare "VAR" entry is pass-through, resolved as os.getenv(name, "");
 # "VAR=value" sets a literal. Unset variables therefore arrive as empty
-# strings rather than being omitted, which is safe here — uv treats an empty
-# SSL_CERT_FILE/SSL_CERT_DIR as unset (verified against uv 0.12.0).
+# strings rather than being omitted -- see the `unset` guards in build_command
+# above, which any new UV_* entry added here also needs.
 #
 # Keep the proxy variables as a set: HTTPS_PROXY without NO_PROXY routes
 # internal hosts through the corporate proxy, which is the failure mode this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,15 +44,25 @@ branch = "main"
 # `set -e` is required: python-semantic-release runs build_command as a shell
 # script, not an `&&` chain, so without it a failing `uv lock` is swallowed
 # and the release reports success having committed a stale lockfile (DOT-602).
+#
+# The `unset` lines are required because bare build_command_env entries are
+# resolved as os.getenv(name, "") and assigned unconditionally, so a variable
+# unset in CI arrives as an empty string rather than being omitted. uv parses
+# its UV_* variables as typed CLI values (enum, path, boolish), so an empty
+# one is malformed rather than absent and `uv lock` exits 2 (DOT-615).
 build_command = """
 set -e
+[ -n "$UV_SYSTEM_CERTS" ] || unset UV_SYSTEM_CERTS
+[ -n "$UV_CACHE_DIR" ] || unset UV_CACHE_DIR
+[ -n "$UV_LINK_MODE" ] || unset UV_LINK_MODE
 uv lock --upgrade-package "$PACKAGE_NAME"
 git add uv.lock CHANGELOG.md
 """
 # python-semantic-release REPLACES rather than extends the environment for
 # build_command, so `uv lock` above would otherwise run with no TLS, proxy or
 # cache configuration. Bare entries are pass-through via os.getenv(name, "");
-# unset variables arrive as empty strings, which uv treats as unset (DOT-605).
+# unset variables arrive as empty strings, so any new UV_* entry here also
+# needs an `unset` guard in build_command above (DOT-605, DOT-615).
 build_command_env = [
     "UV_SYSTEM_CERTS",
     "UV_CACHE_DIR",

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -431,6 +431,50 @@ class TestSemanticReleaseBuildCommand:
         hardcoded = [entry for entry in env if "=" in entry]
         assert not hardcoded, f"build_command_env entries must be pass-through names, not literals: {hardcoded!r}"
 
+    @staticmethod
+    def _assert_uv_vars_guarded(config: dict, source: str) -> None:
+        """Every forwarded UV_* variable must be unset when it arrives empty (DOT-615).
+
+        python-semantic-release assigns bare build_command_env entries
+        unconditionally via os.getenv(name, ""), so a variable that is unset in
+        CI reaches the subprocess as an empty string rather than being omitted.
+        uv parses its own UV_* variables as typed CLI values -- an enum for
+        --link-mode, a path for --cache-dir, a boolish for --system-certs -- so
+        an empty one is a malformed value rather than an absent one, and `uv
+        lock` exits 2 before doing any work.
+
+        The TLS and proxy variables are read as plain strings where empty
+        already means unset, so they are exempt. Restricting the check to UV_*
+        is also the invariant any future addition to the list has to satisfy.
+        """
+        build_command = config["build_command"]
+
+        for name in [entry for entry in config["build_command_env"] if entry.startswith("UV_")]:
+            assert f"unset {name}" in build_command, (
+                f"{source}: {name} is forwarded but never unset when empty. "
+                f"python-semantic-release will pass {name}='' to `uv lock`, which rejects "
+                f'it as a malformed value and aborts the release. Add `[ -n "${name}" ] '
+                f"|| unset {name}` to build_command. Got:\n{build_command}"
+            )
+
+    def test_forwarded_uv_variables_are_unset_when_empty(self, copier_defaults: dict, project_factory) -> None:
+        """Generated projects must guard every forwarded UV_* variable (DOT-615)."""
+        project = project_factory({**copier_defaults, "use_semantic_release": True})
+        self._assert_uv_vars_guarded(self._semantic_release(project), "generated project")
+
+    def test_this_repo_guards_its_own_forwarded_uv_variables(self) -> None:
+        """The template's own release config needs the same guards (DOT-615).
+
+        `[tool.semantic_release]` is one of the dual configs: it exists both in
+        `project/pyproject.toml.jinja` and in this repo's `pyproject.toml`,
+        which is what releases the template itself. Every other test in this
+        class inspects a generated project only, so a regression confined to
+        this repo's copy passes the whole suite and surfaces as a failed
+        release -- which is exactly how DOT-615 was found.
+        """
+        with (REPO_ROOT / "pyproject.toml").open("rb") as f:
+            self._assert_uv_vars_guarded(tomllib.load(f)["tool"]["semantic_release"], "this repo's pyproject.toml")
+
 
 class TestHookProfiles:
     """use_heavy_hooks gates slow git hooks; fast hooks stay always-on."""


### PR DESCRIPTION
## Summary

Guards every forwarded `UV_*` variable in `build_command` so an empty value is unset rather than passed to `uv lock`. Fixes the release job, which has failed on every run since #331 merged.

## Why

```
uv lock --upgrade-package "$PACKAGE_NAME"

error: a value is required for '--link-mode <LINK_MODE>' but none was supplied
  [possible values: clone, copy, hardlink, symlink]

ERROR Build command failed with exit code 2   version.py:305
Build failed, aborting release
```

python-semantic-release resolves bare `build_command_env` entries as `os.getenv(name, "")` and assigns them **unconditionally**, so a variable that is unset in CI arrives as an *empty string* rather than being omitted.

uv parses its own `UV_*` variables as typed CLI values — an enum for `--link-mode`, a path for `--cache-dir`, a boolish for `--system-certs` — so an empty one is a **malformed value, not an absent one**, and `uv lock` exits 2 before doing any work.

Measured one variable at a time against uv 0.12.1, across all twelve forwarded names:

| variable | `VAR=""` |
|---|---|
| `UV_SYSTEM_CERTS` | **error** — invalid value ``: expected a boolish value |
| `UV_CACHE_DIR` | **error** — a value is required for `--cache-dir` |
| `UV_LINK_MODE` | **error** — a value is required for `--link-mode` |
| `SSL_CERT_FILE`, `SSL_CERT_DIR`, `REQUESTS_CA_BUNDLE` | ok |
| `HTTP(S)_PROXY`, `NO_PROXY` + lowercase | ok |

#331 verified only the two `SSL_CERT_*` variables and generalised that result to all twelve; the `UV_*` ones were never tested. The three that break are exactly the ones uv reads as typed values — the other nine are plain strings where empty already means unset.

`set -e` (also from #331) is working as designed here: it is what turns this into a loud abort instead of a release that goes green having committed a stale lockfile.

**Why explicit per-variable guards rather than a loop over the list:** a loop needs bash's `${!var}` indirection, and python-semantic-release selects the shell via `shellingham` with a `/bin/sh` fallback, where dash fails to *parse* that syntax. The "every `UV_*` entry has a guard" invariant is enforced by the test suite instead, which moves the failure from release time to CI time.

**Why not just drop the three from `build_command_env`:** that also fixes the release but loses genuine pass-through — `astral-sh/setup-uv` sets `UV_CACHE_DIR` when caching is enabled.

## Scope

Both halves of the dual config. `[tool.semantic_release]` is **not** inside a `template-preserve` region, so the fix propagates on `copier update` — but any project generated since #331 has a broken release until it updates.

## Test plan

- Reproduced the failure under python-semantic-release's exact environment replacement (`env -i` + the three empty `UV_*` vars), and confirmed the guard prologue fixes it: `Resolved 1 package in 3ms`.
- Two tests, sharing one assertion helper: `test_forwarded_uv_variables_are_unset_when_empty` (generated projects) and `test_this_repo_guards_its_own_forwarded_uv_variables` (this repo's `pyproject.toml`).
- **Verified the tests fail on the pre-fix config**, not merely pass on the fixed one — stripping the guards produces the intended assertion failure.
- The second test closes the gap that let this through: every existing test in `TestSemanticReleaseBuildCommand` inspects a *generated* project, so a regression confined to this repo's own copy passed the entire suite and surfaced only as a failed release.
- Full suite green on a clean tree, including slow tests: `178 passed`.
- `ruff check` and `ruff format --check` clean.

Closes DOT-615


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `build_command` to unset empty `UV_*` env vars before running `uv lock`
> - Forwarded `UV_*` variables (`UV_LINK_MODE`, `UV_CACHE_DIR`, `UV_SYSTEM_CERTS`) that are absent in CI arrive as empty strings via `python-semantic-release`'s `build_command_env` resolution, causing `uv lock` to exit 2 with a parse error before doing any work.
> - Adds `[ -n "$VAR" ] || unset VAR` guards at the top of `build_command` in both [pyproject.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/335/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) and [project/pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/335/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3) so uv only sees the variable when it carries a real value.
> - Adds tests in [tests/test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/335/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) that assert every forwarded `UV_*` variable has a corresponding `unset` guard in `build_command`, covering both generated projects and this repo's own config.
> - Risk: any project generated since [DOT-605](https://linear.app/ismar/issue/DOT-605) merged has a broken release until it runs `copier update` to pick up the guard lines.
>
> #### 🖇️ Linked Issues
> Fixes [DOT-615](https://linear.app/ismar/issue/DOT-615), the regression where every release failed with `error: a value is required for '--link-mode'` after [DOT-605](https://linear.app/ismar/issue/DOT-605) added `UV_*` variables to `build_command_env`. [DOT-605](https://linear.app/ismar/issue/DOT-605) itself fixed the original missing TLS/proxy/cache config in `build_command`. [DOT-602](https://linear.app/ismar/issue/DOT-602) added `set -e` which made the failure visible rather than silently shipping a stale lockfile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f65a89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->