### PR TITLE
refactor(template): replace prek-autoupdate.sh with declarative update filters

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -69,10 +69,24 @@ _exclude:
 # instead of the project's real history — silently flipping visibility for
 # any project whose history disagrees with that default. See
 # migrations/0.41.0_open_source.py.
+#
+# 0.41.4 replaced scripts/prek-autoupdate.sh with a declarative `[update.repos]`
+# tag filter in prek.toml. `copier update` never deletes files, so the script
+# would otherwise linger in every existing project, unreferenced. Runs "after"
+# so the removal happens once the rest of the update has been applied. See
+# migrations/0.41.4_remove_prek_autoupdate_script.py.
+#
+# The script paths are quoted: copier runs these through a shell, and
+# `_copier_conf.src_path` is whatever the user passed to `copier copy` -- an
+# unquoted path containing a space splits into two arguments and python3 fails
+# to open the script.
 _migrations:
 - version: 0.41.0
-  command: python3 {{ _copier_conf.src_path }}/migrations/0.41.0_open_source.py
+  command: python3 "{{ _copier_conf.src_path }}/migrations/0.41.0_open_source.py"
   when: "{{ _stage == 'before' }}"
+- version: 0.41.4
+  command: python3 "{{ _copier_conf.src_path }}/migrations/0.41.4_remove_prek_autoupdate_script.py"
+  when: "{{ _stage == 'after' }}"
 
 # PROMPT --------------------------------
 project_name:
@@ -284,10 +298,10 @@ _tasks:
   - command: "command -v gh >/dev/null && gh repo view --json nameWithOwner -q .nameWithOwner >/dev/null 2>&1 && gh repo edit --delete-branch-on-merge --enable-auto-merge && echo '✓ Enabled delete-branch-on-merge and auto-merge' || true"
     when: "{{ configure_repo_settings | default(false) }}"
   # Copy — setup instructions
-  - command: "printf '\\n🎉 Project created!\\n\\n  ✓ Dependencies installed\\n\\nTo finish setup:\\n  git init && uv run prek install && bash scripts/prek-autoupdate.sh\\n  Create your source files in src/ and tests/\\n'"
+  - command: "printf '\\n🎉 Project created!\\n\\n  ✓ Dependencies installed\\n\\nTo finish setup:\\n  git init && uv run prek install && uv run prek update\\n  Create your source files in src/ and tests/\\n'"
     when: "{{ _copier_operation == 'copy' }}"
   # Update — minimal output. `poe update-template` runs `uv sync --upgrade` and
-  # prek autoupdate after `copier update`, so this banner only confirms what
+  # `prek update` after `copier update`, so this banner only confirms what
   # copier itself did (hooks reinstalled) and doesn't claim "Dependencies synced"
   # — that's the poe chain's job. Same .git guard as above: only fire in the
   # destination, never in the temp render dirs.

--- a/docs/update.md
+++ b/docs/update.md
@@ -61,7 +61,7 @@ This runs:
 
 1. `copier update --trust . --skip-answered --conflict rej` — pull template changes; previously-answered questions are kept, new questions are surfaced interactively, conflicts produce `.rej` files instead of inline conflict markers
 2. `uv sync --upgrade` — upgrade all dependencies
-3. `bash scripts/prek-autoupdate.sh` — update hook versions (wraps `prek autoupdate` with a lychee `nightly` workaround; see `scripts/prek-autoupdate.sh`)
+3. `uv run prek update` — update hook versions. The lychee `nightly` tag is excluded declaratively in `prek.toml` under `[update.repos]`, so a bare `prek update` is safe to run by hand too
 
 ## Handling conflicts
 

--- a/migrations/0.41.4_remove_prek_autoupdate_script.py
+++ b/migrations/0.41.4_remove_prek_autoupdate_script.py
@@ -1,0 +1,71 @@
+"""Migration for the 0.41.4 release: delete the orphaned
+`scripts/prek-autoupdate.sh`.
+
+0.41.4 replaced that wrapper with a declarative `[update.repos]` tag filter in
+`prek.toml`, available since prek 0.4.10. `copier update` never deletes files,
+so without this migration every existing project keeps a script that still
+works but is no longer referenced by `poe update-template` or the docs -- and
+which pins the old `--repo-exclude-tag` approach that the config now covers for
+every invocation rather than only the wrapped one. See DOT-616.
+
+Runs as a `_migrations` "after" step (see copier.yml) so the file is removed
+once the rest of the update has been applied.
+
+Deliberately narrow: it removes the file only when the content is byte-for-byte
+one of the versions the template shipped. A project that edited the script had a
+reason to, and silently discarding that is worse than leaving a stale file
+behind -- the user can delete it themselves once they notice it is unreferenced.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+SCRIPT = Path("scripts") / "prek-autoupdate.sh"
+
+# SHA-256 of every version of this script the template ever shipped. An exact
+# digest rather than a substring match in either direction:
+#
+#   - A substring guard deletes a script a user really did edit, as long as the
+#     matched line survived. Deleting someone's work on a heuristic is the one
+#     outcome this migration must not have.
+#   - It also misses whole shipped versions. The pre-DOT-540 script used a
+#     second `--cooldown-days 7` pass and contains no `--repo-exclude-tag` at
+#     all, so a marker-based guard would flag every project generated before
+#     0.40.0 as "customised" and leave a pristine file behind with a warning.
+#
+# The script carries no `.jinja` suffix, so copier copies it verbatim rather
+# than rendering it -- the bytes are identical in every generated project,
+# which is what makes hashing exact here rather than approximate.
+TEMPLATE_DIGESTS = frozenset(
+    {
+        # 0.38.1 (aa0ccfa, DOT-492): two-pass autoupdate, second pass --cooldown-days 7
+        "d8388e2e64b314dab77b45a1f394a2d2ef5b0e5830357f9d7f95004eea5031bb",
+        # 0.40.0 (e452c32, DOT-540): single pass, --repo-exclude-tag
+        "23cb6d83048dfbd8b65304a5807a15223727c5d69bd412c0dbd37f7e9909a8c5",
+    }
+)
+
+
+def main() -> None:
+    if not SCRIPT.is_file():
+        return
+
+    # Normalise line endings before hashing: a Windows checkout with
+    # `core.autocrlf=true` stores the same shipped file with CRLF, which would
+    # otherwise read as a customisation.
+    body = SCRIPT.read_bytes().replace(b"\r\n", b"\n")
+
+    if hashlib.sha256(body).hexdigest() not in TEMPLATE_DIGESTS:
+        print(f"  ⚠ {SCRIPT} differs from every version this template shipped — leaving it in place.")
+        print("    It is no longer referenced by `poe update-template`; the lychee `nightly`")
+        print("    exclusion now lives in prek.toml, so the script can be deleted once you agree.")
+        return
+
+    SCRIPT.unlink()
+    print(f"  ✓ Removed {SCRIPT} — the lychee `nightly` exclusion now lives in prek.toml")
+
+
+if __name__ == "__main__":
+    main()

--- a/prek.toml
+++ b/prek.toml
@@ -1,9 +1,20 @@
 #:schema https://www.schemastore.org/prek.json
 default_stages = ["pre-commit"]
-# Minimum prek version for builtin hooks and TOML config support
-minimum_prek_version = "0.3.11"  # 0.3.11 introduced --repo-exclude-tag (project/scripts/prek-autoupdate.sh)
+# Minimum prek version for builtin hooks and TOML config support.
+# 0.4.10 introduced the `[update]` tag filters used below (DOT-616).
+minimum_prek_version = "0.4.10"
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
 default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post-rewrite", "pre-commit", "pre-push"]
+
+# lychee tags `nightly` as their GitHub "Latest" release, so `prek update`
+# resolves it as the newest tag and rewrites the pinned rev to a mutable one
+# that lychee's own hook then rejects (lycheeverse/lychee#1601, DOT-492).
+# Excluding the tag here rather than via a wrapper script means every
+# invocation is protected -- a bare `prek update`, CI, an editor integration --
+# not just the one that remembers to go through the wrapper (DOT-616).
+# Remove once lycheeverse/lychee#1601 is fixed upstream (DOT-504).
+[update.repos."https://github.com/lycheeverse/lychee"]
+exclude_tags = ["nightly"]
 
 [[repos]]
 repo = "builtin"
@@ -100,7 +111,8 @@ hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], pr
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-# use bash project/scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492).
+# The `nightly` tag is excluded in the `[update.repos]` block at the top of this
+# file, so a plain `prek update` keeps this on a versioned tag (DOT-492).
 # Note: never put a comment on the same line as `rev` — sync-with-uv anchors its
 # rev regex at end-of-line, so a trailing comment silently disables it (DOT-603).
 rev = "lychee-v0.24.2"

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -1,10 +1,27 @@
 #:schema https://www.schemastore.org/prek.json
 default_stages = ["pre-commit"]
-minimum_prek_version = "0.3.11"  # 0.3.11 introduced --repo-exclude-tag (scripts/prek-autoupdate.sh)
+# 0.4.10 introduced the `[update]` tag filters used below. This is the guard
+# that reaches projects updating from an older template: `prek.toml` is
+# regenerated in full by the template's sync step, but `[dependency-groups]`
+# in pyproject.toml sits inside a template-preserve region, so the `prek>=`
+# floor there stays at whatever the project already had. A too-old prek would
+# otherwise ignore the `[update]` block entirely and silently reintroduce the
+# lychee `nightly` bug. Fails loudly instead (DOT-616).
+minimum_prek_version = "0.4.10"
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
 default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post-rewrite", "pre-commit", "pre-push"]
 
-# Empty `rev` values are filled by `bash scripts/prek-autoupdate.sh`, and kept in
+# lychee tags `nightly` as their GitHub "Latest" release, so `prek update`
+# resolves it as the newest tag and rewrites the pinned rev to a mutable one
+# that lychee's own hook then rejects (lycheeverse/lychee#1601, DOT-492).
+# Declaring the exclusion here rather than wrapping `prek update` in a script
+# means every invocation is protected -- a bare `prek update`, CI, an editor
+# integration -- not just the one that goes through the wrapper (DOT-616).
+# Remove once lycheeverse/lychee#1601 is fixed upstream (DOT-504).
+[update.repos."https://github.com/lycheeverse/lychee"]
+exclude_tags = ["nightly"]
+
+# Empty `rev` values are filled by `prek update`, and kept in
 # step with uv.lock by the sync-with-uv hook below. Never put a trailing comment
 # on a `rev` line: sync-with-uv matches revs with a regex anchored at end-of-line,
 # so a trailing comment makes the line unmatchable and the hook silently reports
@@ -86,7 +103,8 @@ hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], pr
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
-# use scripts/prek-autoupdate.sh, not bare `prek autoupdate` (DOT-492)
+# The `nightly` tag is excluded in the `[update.repos]` block at the top of
+# this file, so a plain `prek update` keeps this on a versioned tag (DOT-492).
 rev = "lychee-v0.24.2"
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -80,7 +80,7 @@ ci = [
 ]
 dev = []
 local = [
-    "prek>=0.3.11",
+    "prek>=0.4.10",
     "pytest-testmon>=2.2",
 ]
 # template-preserve:dependency-groups:end
@@ -288,7 +288,7 @@ prek = "prek run --all-files"
 
 # Template utilities
 check-template = { shell = "copier check-update || true" }
-update-template = { shell = "copier update --trust . --skip-answered --defaults --conflict rej && uv sync --upgrade && bash scripts/prek-autoupdate.sh && echo '  ✓ Dependencies upgraded and hook versions updated' && { ls -1 -- **/*.rej *.rej 2>/dev/null | grep -q . && echo '  ⚠ Copier produced .rej files — review the diffs, apply manually, and delete the .rej files before committing.' || true; }{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
+update-template = { shell = "copier update --trust . --skip-answered --defaults --conflict rej && uv sync --upgrade && uv run prek update && echo '  ✓ Dependencies upgraded and hook versions updated' && { ls -1 -- **/*.rej *.rej 2>/dev/null | grep -q . && echo '  ⚠ Copier produced .rej files — review the diffs, apply manually, and delete the .rej files before committing.' || true; }{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
 
 # Git utilities
 tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"

--- a/project/scripts/prek-autoupdate.sh
+++ b/project/scripts/prek-autoupdate.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# Wraps `uv run prek autoupdate` with a workaround for lychee tagging `nightly`
-# as their GitHub "Latest" release (lycheeverse/lychee#1601). The
-# --repo-exclude-tag flag (prek 0.3.11+) keeps lychee on its real latest
-# versioned tag instead of flipping to `nightly`. Remove the flag when upstream
-# closes lycheeverse/lychee#1601 (DOT-504).
-set -eu
-uv run prek autoupdate --repo-exclude-tag https://github.com/lycheeverse/lychee=nightly "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,11 @@ known-first-party = ["tests"]
     "PLR0904",    # Test classes naturally have many test methods
 ]
 "extensions.py" = ["S404", "S602", "S605", "S607"]  # Template extensions use subprocess for git commands
+# Migrations run as bare `python3` scripts in the destination project during
+# `copier update`, where the repo's logging setup does not exist and stdout is
+# the only channel to the user. A migration that mutates files silently is
+# worse than one that prints.
+"migrations/**" = ["T201"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -253,12 +253,12 @@ class TestPreCommitConfig:
     """Test pre-commit configuration."""
 
     def test_prek_version(self, copier_defaults: dict, project_factory) -> None:
-        """Pre-commit config should pin prek to 0.3.11+ (provides --repo-exclude-tag)."""
+        """Pre-commit config should pin prek to 0.4.10+ (provides the `[update]` tag filters)."""
         project = project_factory(copier_defaults)
 
         config = project / "prek.toml"
         content = config.read_text()
-        assert 'minimum_prek_version = "0.3.11"' in content
+        assert 'minimum_prek_version = "0.4.10"' in content
 
     def test_has_betterleaks(self, copier_defaults: dict, project_factory) -> None:
         """Pre-commit config should have betterleaks."""
@@ -533,12 +533,12 @@ class TestDependencies:
         assert "tomli" not in content
 
     def test_prek_version_updated(self, copier_defaults: dict, project_factory) -> None:
-        """prek dependency should be >= 0.3.11 (introduces --repo-exclude-tag, used by scripts/prek-autoupdate.sh)."""
+        """prek dependency should be >= 0.4.10 (introduces the `[update]` tag filters, DOT-616)."""
         project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
         content = pyproject.read_text()
-        assert '"prek>=0.3.11"' in content
+        assert '"prek>=0.4.10"' in content
 
 
 class TestCIWorkflows:
@@ -1012,7 +1012,7 @@ class TestTemplateUpdateCheck:
         assert "check-template" in content
 
     def test_update_template_poe_task(self, copier_defaults: dict, project_factory) -> None:
-        """Rendered projects should have update-template poe task that chains uv sync --upgrade and prek autoupdate."""
+        """Rendered projects should have update-template poe task that chains uv sync --upgrade and prek update."""
         project = project_factory(copier_defaults)
 
         pyproject = project / "pyproject.toml"
@@ -1032,8 +1032,10 @@ class TestTemplateUpdateCheck:
         assert "--defaults" in content
         assert "--conflict rej" in content
         assert "uv sync --upgrade" in content
-        assert "scripts/prek-autoupdate.sh" in content
-        assert (project / "scripts" / "prek-autoupdate.sh").exists()
+        assert "prek update" in content
+        assert not (project / "scripts" / "prek-autoupdate.sh").exists(), (
+            "the wrapper script was replaced by a declarative `[update.repos]` filter in prek.toml (DOT-616)"
+        )
 
     def test_lychee_rev_is_pinned_not_empty(self, copier_defaults: dict, project_factory) -> None:
         """Lychee should have a pinned rev (not empty) since its 'nightly' tag is mutable."""
@@ -1047,23 +1049,36 @@ class TestTemplateUpdateCheck:
         assert rev, "Lychee rev should be pinned, not empty"
         assert rev.startswith("lychee-v"), f"Lychee rev should be a versioned tag, got: {rev}"
 
-    def test_prek_autoupdate_script_has_lychee_workaround(self, copier_defaults: dict, project_factory) -> None:
-        """scripts/prek-autoupdate.sh wraps `prek autoupdate` with the lychee `nightly` workaround (DOT-492, DOT-540).
+    def test_lychee_nightly_excluded_declaratively(self, copier_defaults: dict, project_factory) -> None:
+        """prek.toml must exclude lychee's `nightly` tag from `prek update` (DOT-492, DOT-540, DOT-616).
 
-        Verifies the script exists, is executable, and uses prek 0.3.11+ `--repo-exclude-tag` to
-        prevent lychee's `rev` from flipping to `nightly` (which lychee's own hook then rejects).
-        Tracks lycheeverse/lychee#1601 — remove the flag once upstream closes that issue (DOT-504).
+        lychee tags `nightly` as their GitHub "Latest" release, so `prek update`
+        resolves it as the newest tag and rewrites the pinned rev to a mutable
+        one that lychee's own hook then rejects (lycheeverse/lychee#1601).
+
+        This lives in the config rather than in a wrapper script so that every
+        invocation is covered -- a bare `prek update`, CI, an editor
+        integration -- not only the one that remembers to go through the
+        wrapper. Requires prek 0.4.10+, which `minimum_prek_version` enforces.
+        Remove once lycheeverse/lychee#1601 is fixed upstream (DOT-504).
         """
         project = project_factory(copier_defaults)
 
-        script = project / "scripts" / "prek-autoupdate.sh"
-        assert script.exists(), "prek-autoupdate.sh must ship in the scaffolded project"
-        assert os.access(script, os.X_OK), "prek-autoupdate.sh must be executable"
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
 
-        body = script.read_text()
-        assert "prek autoupdate" in body, "script must invoke `prek autoupdate`"
-        assert "--repo-exclude-tag https://github.com/lycheeverse/lychee=nightly" in body, (
-            "script must exclude the lychee `nightly` tag so prek picks the latest versioned tag"
+        repo = "https://github.com/lycheeverse/lychee"
+        filters = data.get("update", {}).get("repos", {}).get(repo)
+        assert filters is not None, (
+            f'prek.toml must declare [update.repos."{repo}"]; without it a plain `prek update` '
+            f"rewrites the pinned rev to `nightly`. Got update config: {data.get('update')!r}"
+        )
+        assert "nightly" in filters.get("exclude_tags", []), f"`nightly` must be in exclude_tags for {repo}; got {filters!r}"
+
+        assert data["minimum_prek_version"] == "0.4.10", (
+            "the [update] tag filters above need prek 0.4.10+. minimum_prek_version is the guard "
+            "that reaches updating projects, since the pyproject `prek>=` floor sits inside a "
+            f"template-preserve region. Got {data.get('minimum_prek_version')!r}"
         )
 
     def test_check_merge_conflict_has_assume_in_merge(self, copier_defaults: dict, project_factory) -> None:
@@ -1572,6 +1587,114 @@ class TestOpenSourceMigration:
         assert "open_source" not in result
 
 
+class TestRemovePrekAutoupdateScriptMigration:
+    """The 0.41.4 `_migrations` step deletes the orphaned `scripts/prek-autoupdate.sh`.
+
+    `copier update` never deletes files, so without this the wrapper lingers in
+    every existing project, unreferenced by `poe update-template` or the docs
+    (DOT-616).
+
+    Deleting a user's file is the risk here, so the guard is an exact digest of
+    every version the template shipped rather than a substring match. A substring
+    guard fails in both directions, which is a #336 review finding: it deletes a
+    genuinely edited script as long as the matched line survives, and it flags the
+    pre-0.40.0 script -- which used a `--cooldown-days 7` second pass and contains
+    no `--repo-exclude-tag` at all -- as customised when it is pristine.
+    """
+
+    SCRIPT: ClassVar[pathlib.Path] = REPO_ROOT / "migrations" / "0.41.4_remove_prek_autoupdate_script.py"
+    TARGET: ClassVar[pathlib.Path] = pathlib.Path("scripts") / "prek-autoupdate.sh"
+
+    # Byte-for-byte as shipped. Kept here rather than read from git history so the
+    # test fails if someone edits the digests in the migration to match a new file.
+    SHIPPED_0_38_1: ClassVar[str] = (
+        "#!/usr/bin/env bash\n"
+        "# Wraps `uv run prek autoupdate` with a workaround for lychee marking `nightly` as\n"
+        '# their GitHub "Latest" release (DOT-492). The second pass with --cooldown-days 7\n'
+        "# reverts lychee's `rev` from `nightly` back to the most recent versioned tag.\n"
+        "# Remove once lychee stops marking nightly as Latest (DOT-504).\n"
+        "set -eu\n"
+        'uv run prek autoupdate "$@"\n'
+        'uv run prek autoupdate --repo https://github.com/lycheeverse/lychee --cooldown-days 7 "$@"\n'
+    )
+    SHIPPED_0_40_0: ClassVar[str] = (
+        "#!/usr/bin/env bash\n"
+        "# Wraps `uv run prek autoupdate` with a workaround for lychee tagging `nightly`\n"
+        '# as their GitHub "Latest" release (lycheeverse/lychee#1601). The\n'
+        "# --repo-exclude-tag flag (prek 0.3.11+) keeps lychee on its real latest\n"
+        "# versioned tag instead of flipping to `nightly`. Remove the flag when upstream\n"
+        "# closes lycheeverse/lychee#1601 (DOT-504).\n"
+        "set -eu\n"
+        'uv run prek autoupdate --repo-exclude-tag https://github.com/lycheeverse/lychee=nightly "$@"\n'
+    )
+
+    def test_migration_registered_in_copier_yml(self) -> None:
+        """copier.yml's `_migrations` entry must reference the script that actually exists."""
+        content = (REPO_ROOT / "copier.yml").read_text()
+        assert "migrations/0.41.4_remove_prek_autoupdate_script.py" in content
+        assert self.SCRIPT.is_file(), f"{self.SCRIPT} referenced in copier.yml but missing"
+
+    def test_migration_commands_quote_the_script_path(self) -> None:
+        """copier runs string `_migrations` commands with `shell=True`.
+
+        `_copier_conf.src_path` is whatever the user passed to `copier copy`, so an
+        unquoted path containing a space splits into two arguments and python3 fails
+        to open the script (#336 review finding).
+        """
+        content = (REPO_ROOT / "copier.yml").read_text()
+        unquoted = re.findall(r"^\s*command:\s*python3\s+(?!\")\S*\{\{.*$", content, re.MULTILINE)
+        assert not unquoted, f"migration script paths must be quoted for paths with spaces: {unquoted}"
+
+    def _run(self, tmp_path: pathlib.Path, body: str | None) -> tuple[bool, str]:
+        """Run the migration in `tmp_path`; return (file still exists, stdout)."""
+        target = tmp_path / self.TARGET
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if body is not None:
+            target.write_text(body, newline="")
+        result = subprocess.run(["python3", str(self.SCRIPT)], cwd=tmp_path, capture_output=True, text=True, check=False)
+        assert result.returncode == 0, f"migration failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        return target.exists(), result.stdout
+
+    @pytest.mark.parametrize("shipped", ["SHIPPED_0_38_1", "SHIPPED_0_40_0"])
+    def test_removes_every_version_the_template_shipped(self, tmp_path: Path, shipped: str) -> None:
+        """Both shipped versions are pristine and must go, including the pre-0.40.0 one
+        that predates `--repo-exclude-tag` entirely."""
+        exists, stdout = self._run(tmp_path, getattr(self, shipped))
+        assert not exists, f"pristine {shipped} was left behind: {stdout}"
+        assert "Removed" in stdout
+
+    def test_removes_a_shipped_version_checked_out_with_crlf(self, tmp_path: Path) -> None:
+        """A Windows checkout with `core.autocrlf=true` stores the same bytes with CRLF.
+        That is not a customisation and must not read as one."""
+        exists, _ = self._run(tmp_path, self.SHIPPED_0_40_0.replace("\n", "\r\n"))
+        assert not exists, "CRLF line endings were mistaken for a user customisation"
+
+    def test_keeps_a_customised_script(self, tmp_path: Path) -> None:
+        """The failure mode that matters: never delete work the user did.
+
+        This script keeps the original invocation intact and only appends a line,
+        which is exactly what a substring guard would wave through.
+        """
+        exists, stdout = self._run(tmp_path, self.SHIPPED_0_40_0 + "uv run prek run --all-files\n")
+        assert exists, "a customised script was deleted"
+        assert "leaving it in place" in stdout
+
+    def test_noop_when_the_script_is_absent(self, tmp_path: Path) -> None:
+        """Projects generated after 0.41.4 never had the file; the migration must stay silent."""
+        exists, stdout = self._run(tmp_path, None)
+        assert not exists
+        assert stdout.strip() == "", f"expected no output, got: {stdout!r}"
+
+    def test_digests_match_the_versions_actually_shipped(self) -> None:
+        """Guards against the digests drifting from the file contents they claim to describe."""
+        import hashlib
+
+        content = self.SCRIPT.read_text()
+        for shipped in (self.SHIPPED_0_38_1, self.SHIPPED_0_40_0):
+            digest = hashlib.sha256(shipped.encode()).hexdigest()
+            assert digest in content, f"migration is missing the digest for a shipped version: {digest}"
+
+
 class TestMarkedSectionsSync:
     """`_tasks` step (see copier.yml) that replaces `copier update`'s fuzzy-patch
     handling of `pyproject.toml`/`prek.toml` with a regenerate-and-preserve
@@ -1843,7 +1966,7 @@ class TestIntegration:
         Reproduces the exact user flow from a fresh folder:
             copier copy ... && cd <dest>
             uv sync
-            git init && uv run prek install && bash scripts/prek-autoupdate.sh
+            git init && uv run prek install && uv run prek update
             git add -A && git commit -m "feat: init commit"
 
         Originally added as a regression test for DOT-491 (pytest-testmon hook exited 5
@@ -1881,14 +2004,21 @@ class TestIntegration:
             check=False,
         )
         assert install.returncode == 0, f"prek install failed: {install.stderr}"
-        autoupdate = subprocess.run(
-            ["bash", "scripts/prek-autoupdate.sh"],
+        update = subprocess.run(
+            ["uv", "run", "prek", "update"],
             cwd=project,
             capture_output=True,
             text=True,
             check=False,
         )
-        assert autoupdate.returncode == 0, f"prek-autoupdate.sh failed: {autoupdate.stderr}"
+        assert update.returncode == 0, f"prek update failed: {update.stderr}"
+
+        # The whole point of moving the lychee exclusion into prek.toml is that a
+        # bare `prek update` -- the one a user actually types -- is safe. Assert
+        # on the outcome rather than on the config, which is checked separately.
+        with (project / "prek.toml").open("rb") as f:
+            lychee = next(r for r in tomllib.load(f)["repos"] if r.get("repo", "").endswith("/lychee"))
+        assert lychee["rev"].startswith("lychee-v"), f"`prek update` flipped lychee to a mutable tag: {lychee['rev']!r} (DOT-492, DOT-616)"
 
         # Mirror the real user flow: hooks may auto-fix files (formatters, lockfile sync)
         # on the first run, abort the commit, and the user re-stages and retries.


### PR DESCRIPTION
## Summary

Deletes `scripts/prek-autoupdate.sh` and replaces it with a declarative `[update.repos]` tag filter in `prek.toml`, available since prek 0.4.10.

## Why

lychee tags `nightly` as their GitHub "Latest" release, so `prek update` resolves it as the newest tag and rewrites the pinned rev to a mutable one that lychee's own hook then rejects (lycheeverse/lychee#1601). The template shipped a wrapper script passing `--repo-exclude-tag` to work around it.

**The wrapper only protected the invocation that went through it.** Verified against prek 0.4.11 in a throwaway repo:

| config | `prek update` result |
|---|---|
| no guard | `lychee-v0.24.0` → **`nightly`** |
| `[update.repos."…/lychee"] exclude_tags = ["nightly"]` | `lychee-v0.24.0` → **`lychee-v0.24.2`** |

A bare `prek update` still flips the rev today. Habitual `prek update`, CI, an editor integration or an agent all bypassed the script. Moving the exclusion into the config makes it unconditional. The block also survives prek rewriting the file during the update.

### `minimum_prek_version` is the load-bearing half

`prek.toml` is regenerated in full by `migrations/sync_marked_sections.py` (only `extra-local-hooks` is preserved), so `minimum_prek_version = "0.4.10"` reaches projects updating from an older template.

The pyproject floor does **not**: `[dependency-groups]` sits inside a `template-preserve` region, so an updating project keeps its own `prek>=0.3.11`. A too-old prek would ignore the `[update]` block entirely and silently reintroduce the bug. The config constraint fails loudly instead:

```
`prek` version `0.4.10` or newer is required, but version `0.4.9` is installed.
To update, run `brew update && brew upgrade prek`.
```

Structurally the same guard as the ruff `required-version` added in #333, for the same reason.

### Migration

`copier update` never deletes files, so a `_migrations` entry removes the orphaned script from existing projects.

**It refuses to delete a script the user edited.** The guard is an exact SHA-256 against every version the template shipped, not a substring match — a #336 review finding, and correct in both directions:

- A substring guard deletes a genuinely customised script as long as the matched line survives. That outcome is unrecoverable, so a heuristic is the wrong tool regardless of how accurate it is.
- It also *misses whole shipped versions*. The pre-0.40.0 script used a `--cooldown-days 7` second pass and contains no `--repo-exclude-tag` at all, so a marker-based guard flags every project generated before 0.40.0 as "customised" and leaves a pristine file behind with a warning.

Hashing is exact here rather than approximate because the script carries no `.jinja` suffix — copier copies it verbatim, so the bytes are identical in every generated project. Line endings are normalised first so a Windows checkout with `core.autocrlf=true` does not read as a customisation.

### Migration command quoting

Both `_migrations` commands now quote the interpolated script path. `copier/_main.py:405` sets `shell=True` for string-form commands and `_copier_conf.src_path` is whatever the user passed to `copier copy`, so an unquoted path containing a space splits into two arguments. The pre-existing 0.41.0 migration had the same latent bug and is fixed alongside.

### `migrations/**` T201 exemption

Migrations run as bare `python3` in the destination project, where the repo's logging setup does not exist and stdout is the only channel to the user. A migration that mutates files silently is worse than one that prints. Same category as the existing `extensions.py` exemption.

## Test plan

- Both directions verified empirically against prek 0.4.11, not inferred from the changelog.
- `minimum_prek_version` enforcement confirmed to produce an actionable error naming both the required and installed versions.
- Migration exercised on all five branches by hand *and* in tests: both shipped versions removed, a CRLF checkout removed, a customised script left in place with a warning, an absent file a silent no-op. It previously shipped with no test coverage at all, which is why neither direction of the old guard was ever exercised.
- `test_lychee_nightly_excluded_declaratively` replaces `test_prek_autoupdate_script_has_lychee_workaround`, asserting the config *and* the `minimum_prek_version` premise it depends on.
- The slow integration test now runs a bare `prek update` on a rendered project and asserts the resulting rev is still a versioned tag — the outcome, not just the configuration.
- Full suite green on a clean tree including slow tests: `186 passed`. `ruff check`, `ruff format --check` and `ty check` clean.

## Not closed by this

DOT-504 tracks removing the workaround once lycheeverse/lychee#1601 is fixed upstream. Re-confirmed still unfixed on 2026-07-29 — only the remediation got smaller.

Closes DOT-616
