### PR TITLE
chore(deps): raise dependency floors to the versions the template is tested at

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -66,17 +66,23 @@ Funding = "https://{{ repository_host }}/sponsors/{{ author_username }}"
 [dependency-groups]
 {%- if use_semantic_release %}
 maintain = [
-    "build>=1.2",
-    "python-semantic-release>=10",
+    "build>=1.5",
+    "python-semantic-release>=10.6",
 ]
 {%- endif %}
+# Floors track the versions this template is actually exercised against, not
+# the oldest release that happens to still work. A range wider than the tested
+# one advertises support nobody verifies: `uv sync` resolves to the newest
+# release, so the bottom of a `>=8` range is a configuration the template has
+# never once run under. `ty` is floored tighter than the rest because it is
+# pre-1.0, where any release may change behaviour.
 ci = [
     "ruff>=0.16",
-    "pytest>=8",
-    "pytest-cov>=6",
-    "pytest-randomly>=3.15",
-    "ty>=0.0.14",
-    "poethepoet>=0.41",
+    "pytest>=9",
+    "pytest-cov>=7",
+    "pytest-randomly>=4",
+    "ty>=0.0.64",
+    "poethepoet>=0.48",
 ]
 dev = []
 local = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,13 @@ dev = [
     "hypothesis>=6.0",
     "pytest>=9.0.2",
     "pytest-cov>=7.0.0",
-    "pytest-randomly>=3.16",
+    "pytest-randomly>=4",
     "pytest-xdist>=3.5",
-    "python-semantic-release>=10.5.2",
+    "python-semantic-release>=10.6",
     "pyyaml>=6.0.3",
     "reuse",
     "ruff",
-    "ty>=0.0.14",
+    "ty>=0.0.64",
     "copier-template-extensions>=0.3.3",
 ]
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -540,6 +540,90 @@ class TestDependencies:
         content = pyproject.read_text()
         assert '"prek>=0.4.10"' in content
 
+    # Floors track the versions the template is actually exercised against, not the
+    # oldest release that happens to still work. `uv sync` resolves to the newest
+    # release, so the bottom of a `>=8` range is a configuration nobody has ever run
+    # the template under -- it advertises support that is not verified. Pinning them
+    # here makes widening a range a deliberate, reviewed edit rather than a leftover.
+    EXPECTED_FLOORS: ClassVar[dict[str, dict[str, str]]] = {
+        "maintain": {"build": "1.5", "python-semantic-release": "10.6"},
+        "ci": {
+            "ruff": "0.16",
+            "pytest": "9",
+            "pytest-cov": "7",
+            "pytest-randomly": "4",
+            "ty": "0.0.64",
+            "poethepoet": "0.48",
+        },
+        "local": {"prek": "0.4.10", "pytest-testmon": "2.2"},
+    }
+
+    @staticmethod
+    def _floors(specs: list[str]) -> dict[str, str]:
+        """Map ``["pytest>=9", ...]`` to ``{"pytest": "9", ...}``, ignoring unpinned entries."""
+        return dict(spec.split(">=", 1) for spec in specs if ">=" in spec)
+
+    def test_shipped_dependency_floors_are_current(self, copier_defaults: dict, project_factory) -> None:
+        """Every tool group must declare the floor the template is tested at.
+
+        Note these live inside the `dependency-groups` template-preserve region, so
+        raising them reaches newly generated projects only. That is fine while no
+        config depends on the newer behaviour -- when one does, the guard has to go
+        in the propagated section instead, the way ruff's `required-version` and
+        prek's `minimum_prek_version` do.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "pyproject.toml").open("rb") as f:
+            groups = tomllib.load(f)["dependency-groups"]
+
+        for group, expected in self.EXPECTED_FLOORS.items():
+            actual = self._floors(groups[group])
+            for package, floor in expected.items():
+                assert actual.get(package) == floor, (
+                    f"[dependency-groups] {group}: expected {package}>={floor}, got {actual.get(package)!r}"
+                )
+
+    def test_every_tool_dependency_declares_a_floor(self, copier_defaults: dict, project_factory) -> None:
+        """No bare package names in the tool groups.
+
+        An unpinned entry resolves to whatever exists on the day someone runs
+        `uv sync`, which is exactly the unverified-configuration problem the floors
+        exist to prevent -- except silently, since there is nothing to review.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "pyproject.toml").open("rb") as f:
+            groups = tomllib.load(f)["dependency-groups"]
+
+        unpinned = {group: [s for s in groups[group] if ">=" not in s] for group in self.EXPECTED_FLOORS}
+        assert not any(unpinned.values()), f"tool dependencies must declare a `>=` floor: { {g: v for g, v in unpinned.items() if v} }"
+
+    def test_this_repo_is_not_older_than_the_floors_it_ships(self, copier_defaults: dict, project_factory) -> None:
+        """The template's own dev group must not lag the floors it hands to users.
+
+        This repo and `project/pyproject.toml.jinja` are the usual dual-config pair,
+        and the template half is the one that gets attention. `ty>=0.0.14` sat here
+        for fifty patch releases while the template shipped a current floor -- so the
+        tool the template claims to be tested against was not the one testing it.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "pyproject.toml").open("rb") as f:
+            shipped = tomllib.load(f)["dependency-groups"]
+        with (REPO_ROOT / "pyproject.toml").open("rb") as f:
+            ours = self._floors(tomllib.load(f)["dependency-groups"]["dev"])
+
+        def parts(version: str) -> tuple[int, ...]:
+            return tuple(int(n) for n in version.split(".") if n.isdigit())
+
+        for group in self.EXPECTED_FLOORS:
+            for package, floor in self._floors(shipped[group]).items():
+                if package in ours:
+                    assert parts(ours[package]) >= parts(floor), (
+                        f"this repo pins {package}>={ours[package]} but ships {package}>={floor} to generated projects"
+                    )
+
 
 class TestCIWorkflows:
     """Test CI workflow configuration (from smoke_test.sh assertions)."""
@@ -1958,6 +2042,31 @@ class TestIntegration:
         # Run uv sync
         result = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True, check=False)
         assert result.returncode == 0, f"uv sync failed: {result.stderr}"
+
+    @pytest.mark.slow
+    def test_declared_floors_actually_work(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """A generated project must lint, typecheck and test at its declared floors.
+
+        Every other floor test asserts on what pyproject *says*. This one runs the
+        bottom of every declared range, which is the only thing that catches a floor
+        that is a lie -- the shape of both the ruff bug in #333 (`extend-select`
+        assumes 0.16's defaults, floor said 0.14) and DOT-616 (prek's `[update]`
+        tag filters need 0.4.10, floor said 0.3.11).
+
+        `UV_RESOLUTION` has to be in the environment, not just on the `uv sync` line:
+        `uv run` re-resolves and would silently swap the lockfile back to `highest`
+        ("Ignoring existing lockfile due to change in resolution mode"), so the run
+        would measure the newest releases while appearing to measure the floors.
+        """
+        project = generate_project(tmp_path, copier_defaults)
+        env = {**os.environ, "UV_RESOLUTION": "lowest-direct"}
+
+        sync = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True, check=False, env=env)
+        assert sync.returncode == 0, f"uv sync at declared floors failed: {sync.stderr}"
+
+        for task in ("lint", "typecheck", "test"):
+            result = subprocess.run(["uv", "run", "poe", task], cwd=project, capture_output=True, text=True, check=False, env=env)
+            assert result.returncode == 0, f"`poe {task}` failed at the declared dependency floors:\n{result.stdout}\n{result.stderr}"
 
     @pytest.mark.slow
     def test_first_commit_succeeds_with_prek_hooks(self, tmp_path: Path, copier_defaults: dict) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -179,13 +179,13 @@ dev = [
     { name = "poethepoet" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "pytest-randomly", specifier = ">=3.16" },
+    { name = "pytest-randomly", specifier = ">=4" },
     { name = "pytest-xdist", specifier = ">=3.5" },
-    { name = "python-semantic-release", specifier = ">=10.5.2" },
+    { name = "python-semantic-release", specifier = ">=10.6" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "reuse" },
     { name = "ruff" },
-    { name = "ty", specifier = ">=0.0.14" },
+    { name = "ty", specifier = ">=0.0.64" },
     { name = "zensical" },
 ]
 


### PR DESCRIPTION
## Summary

Raises every tool dependency floor to the version the template is actually exercised against, in both `project/pyproject.toml.jinja` and this repo's own dev group, and adds four tests so they cannot drift back.

| package | was | now | resolves to today |
|---|---|---|---|
| pytest | `>=8` | `>=9` | 9.1.1 |
| pytest-cov | `>=6` | `>=7` | 7.1.0 |
| pytest-randomly | `>=3.15` | `>=4` | 4.1.0 |
| ty | `>=0.0.14` | `>=0.0.64` | 0.0.64 |
| poethepoet | `>=0.41` | `>=0.48` | 0.48.0 |
| python-semantic-release | `>=10` | `>=10.6` | 10.6.1 |
| build | `>=1.2` | `>=1.5` | 1.5.0 |

`ruff>=0.16`, `prek>=0.4.10` and `pytest-testmon>=2.2` are already current and unchanged.

## Why

`uv sync` resolves to the newest release, so nothing ever ran at the bottom of these ranges. `ty>=0.0.14` spanned fifty patch releases of a pre-1.0 type checker; `pytest>=8` spanned a major version. A range wider than the tested one advertises support nobody verifies — and twice recently that gap was load-bearing rather than cosmetic:

- `extend-select` (#333) assumes ruff 0.16's 413 default rules. On the then-declared `>=0.14` floor (59 defaults) it silently lints *less* than the config claims.
- prek's `[update]` tag filters (#336) need 0.4.10. On the then-declared `>=0.3.11` floor the block is ignored and the lychee `nightly` bug comes straight back.

Both needed a separate guard inside a propagated section — ruff's `required-version`, prek's `minimum_prek_version` — precisely because the floor was not trustworthy.

## Propagation

The floors live inside the `template-preserve:dependency-groups` region, so this reaches **newly generated projects only**; existing projects keep their wider ranges on `copier update`. Harmless today because nothing depends behaviourally on the new floors. The moment something does, the guard belongs in a propagated section, not here.

## Tests

Three fast, one slow:

- `test_shipped_dependency_floors_are_current` — explicit floor table. Its only job is to make widening a range a reviewed edit; a leftover `>=8` is otherwise indistinguishable from a deliberate one.
- `test_every_tool_dependency_declares_a_floor` — no bare package names in the tool groups.
- `test_this_repo_is_not_older_than_the_floors_it_ships` — the dual-config guard. **This one found a third stale pin I had missed by hand**: this repo pinned `python-semantic-release>=10.5.2` while shipping `>=10.6` to users, meaning the tool version the template claims to be tested against was not the one doing the testing.
- `test_declared_floors_actually_work` (slow) — the one that matters. Syncs a generated project with `--resolution lowest-direct` and runs `poe lint`, `typecheck` and `test` against the floors themselves. Every other floor test reads pyproject; this executes it.

`UV_RESOLUTION` is set in the environment rather than on the `uv sync` line because `uv run` re-resolves and silently swaps the lockfile back to `highest` ("Ignoring existing lockfile due to change in resolution mode"). That mistake made my first floor measurement report the newest releases while appearing to report the floors.

## Test plan

- Verified the slow test is not vacuous — the lockfile it produces pins `pytest 9.0.0` (not 9.1.1), `ruff 0.16.0`, `ty 0.0.64`, `prek 0.4.10`, `python-semantic-release 10.6.0`. Lint, typecheck and tests all pass at those versions.
- Full suite green on a clean tree including slow tests: `182 passed`. `ruff check`, `ruff format --check` and `ty check` clean.

## Not done here

`build` in the `maintain` group looks vestigial — `build_command` runs `uv build`, and nothing in `project/` invokes `python -m build`. I raised its floor rather than deleting it: that group is release-adjacent and releases broke twice this week, so the asymmetry favours keeping one unused dev dependency over discovering a late failure in someone else's CI. Worth removing in a follow-up.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise dependency floors in the project template to tested versions
> - Bumps minimum versions in [pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/337/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3) for `build` (≥1.5), `python-semantic-release` (≥10.6), `pytest` (≥9), `pytest-cov` (≥7), `pytest-randomly` (≥4), `ty` (≥0.0.64), and `poethepoet` (≥0.48).
> - Updates the repo's own [pyproject.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/337/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) `dev` group to match the new floors for `pytest-randomly`, `python-semantic-release`, and `ty`.
> - Adds a `TestDependencies` test class with checks that shipped floors match `EXPECTED_FLOORS`, that every tool dependency declares a `>=` floor, and that this repo's own pins are not older than what it ships.
> - Adds a slow integration test (`test_declared_floors_actually_work`) that generates a project, resolves deps at `UV_RESOLUTION=lowest-direct`, and runs lint, typecheck, and test to confirm the floors are functional.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6366a53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->