### PR TITLE
refactor(template): move config rationale to docs, drop gh wrapper poe tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ It is designed to be used as a starting point for new Python projects, providing
 - **[prek](https://github.com/j178/prek)** — Rust-powered pre-commit hook runner (replaces pre-commit)
 - **[poethepoet](https://github.com/nat-n/poethepoet)** — task runner with pre-configured tasks for every workflow
 - **[pytest](https://github.com/pytest-dev/pytest)** — testing with coverage and randomization
-- **[Zensical](https://zensical.org/)** — beautiful documentation with API autodoc
 - **[semantic-release](https://github.com/python-semantic-release/python-semantic-release)** — automated versioning and changelogs from conventional commits
 - **[betterleaks](https://github.com/betterleaks/betterleaks)** — secret scanning on every commit (detects API keys, tokens, and credentials in staged changes)
 - **[lychee](https://github.com/lycheeverse/lychee)** — fast link checking in CI
@@ -46,37 +45,25 @@ When you run `copier copy`, you'll be asked:
 
 | Prompt | Description |
 | ------ | ----------- |
-| **Project audience** | `solo-internal` (default), `team`, or `public-oss` — sets lighter or fuller defaults for everything below (see [Audience profiles](#audience-profiles)) |
 | **Project name** | Name of your project |
 | **Project description** | One-line description |
-| **Project type** | `app`, `lib`, or `package` — configures pyproject.toml entry points and build settings |
+| **Project type** | `app` (CLI entry point, like `uv init --app`) or `lib` (importable package, like `uv init --lib`) |
 | **Author info** | Name, email, username (auto-detected from git) |
 | **Repository provider** | `github.com` or `gitlab.com` |
+| **Repository host** | Hostname — override for self-hosted GitLab (e.g. `gitlab.company.com`) |
 | **Repository namespace** | GitHub/GitLab username or organization |
-| **License** | Choose from 40+ open source licenses |
-| **Community-health files?** | `CODE_OF_CONDUCT`, `CONTRIBUTING`, `SECURITY`, issue/PR templates, `FUNDING` |
-| **Generate docs site?** | Zensical scaffolding, `docs/`, GitHub Pages workflow |
+| **Open-source this project?** | Adds a LICENSE plus `CODE_OF_CONDUCT`, `CONTRIBUTING`, `SECURITY`, issue/PR templates and `FUNDING`. Off = internal/private, none of those. Defaults on for GitHub |
+| **License** | Choose from 40+ open source licenses (asked only when open-sourcing) |
+| **Heavy git hooks?** | Run coverage on pre-push (off = fast hooks only; coverage runs in CI) |
 | **Enable CI?** | GitHub Actions or GitLab CI |
 | **Enable semantic-release?** | Automated versioning and changelog |
-| **Heavy git hooks?** | Run coverage + docs-build on pre-push (off = fast hooks only; coverage/docs run in CI) |
 | **Publish to PyPI?** | Include PyPI publishing in release workflow |
+| **Publish to MCP Registry?** | Include the MCP Registry publish workflow |
+| **Use a custom PyPI index?** | Point uv at Artifactory, Nexus, etc. |
 | **Use Blacksmith runners?** | 2x faster, 75% cheaper CI runners |
 | **Configure GitHub repo settings?** | Run `gh repo edit` to enable delete-branch-on-merge and auto-merge |
 
-### Audience profiles
-
-`Project audience` is the one high-level choice that sets sensible starting defaults — every individual toggle stays overridable.
-
-| | solo-internal (default) | team | public-oss |
-| --- | --- | --- | --- |
-| Visibility | internal | internal | public |
-| CI | off | on | on |
-| semantic-release | off | on | on |
-| Docs site | off | off | on |
-| Heavy git hooks | off | off | on |
-| Community-health files | off | off | on |
-
-The shipped default is **solo-internal** — the leanest scaffold. Choose **public-oss** for the full open-source stack (docs site, strict hooks, community files), or **team** for a shared internal repo that wants CI and changelogs without the public-facing weight.
+The booleans cascade: `use_ci` gates `use_semantic_release`, which gates `publish_to_pypi` and `publish_to_mcp_registry`. Answering "no" high up skips everything beneath it.
 
 ## Quick Start
 
@@ -144,13 +131,6 @@ All projects come with pre-configured [poethepoet](https://github.com/nat-n/poet
 | `poe test-affected` | Run only tests affected by changes ([testmon](https://github.com/tarpas/pytest-testmon)) |
 | `poe test-all` | Run all tests |
 | `poe test-cov` | Run tests with coverage report |
-| `poe docs` | Serve docs locally |
-| `poe docs-build` | Build docs with strict mode |
 | `poe prek` | Run all pre-commit hooks |
 | `poe check-template` | Check for template updates (manual) |
 | `poe update-template` | Apply template updates via copier |
-| `poe tags` | List git tags by version |
-| `poe runs` | List recent CI runs |
-| `poe checks` | Watch PR checks |
-| `poe watch` | Watch current CI run |
-| `poe releases` | List recent GitHub releases |

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,2 +1,11 @@
 [files]
 extend-exclude = ["CHANGELOG.md", "uv.lock"]
+
+# docs/generated-config.md quotes these verbatim as examples of the hex strings
+# typos misreads as prose — the page explaining the problem trips it. Accepting
+# the two words that actually fire is narrower than excluding the whole page,
+# which would silence real typos in it. Only list words the dictionary rejects
+# today; a redundant entry is indistinguishable from a load-bearing one.
+[default.extend-words]
+ba = "ba"
+caf = "caf"

--- a/docs/generated-config.md
+++ b/docs/generated-config.md
@@ -1,0 +1,242 @@
+# Why the generated config looks like this
+
+Most of `pyproject.toml` in a generated project is ordinary. A handful of
+settings are not, and look wrong or removable until you know what they defend
+against. Every one of them exists because something broke.
+
+The generated file carries a one-line pointer to the relevant section here
+rather than the full explanation — the reasoning is template history, not
+something every new project should inherit in its own config.
+
+## Build backend
+
+### Why `uv_build` is pinned to a window {#build-backend-pin}
+
+```toml
+requires = ["uv_build>=0.12,<0.13"]
+```
+
+An unbounded `uv_build` makes uv warn on every `uv sync` and `uv build`, and a
+breaking `uv_build` release would silently break sdist builds in every project
+generated from this template at once. The bound is the current minor series
+plus the next major; bump the window when `uv_build` crosses it (DOT-589).
+
+The window moved to the `0.12` series for uv 0.12, which enforces PEP 625:
+source distributions must be `.tar.gz`, and `.tar.bz2` / `.tar.xz` are
+rejected, as are wheels using bzip2/LZMA/XZ compression. `uv_build` already
+emits PEP 625-conforming artifacts, so the move was a no-op for generated
+projects — verified by building an sdist and a wheel from a rendered project
+under `uv_build` 0.12 and installing the result.
+
+## Dependencies
+
+### Why the dependency floors are tight {#dependency-floors}
+
+Floors in `[dependency-groups]` track the versions this template is actually
+exercised against, not the oldest release that happens to still work.
+
+A range wider than the tested one advertises support nobody verifies: `uv sync`
+resolves to the newest release, so the bottom of a `>=8` range is a
+configuration the template has never once run under. `ty` is floored tighter
+than the rest because it is pre-1.0, where any release may change behaviour.
+
+## Ruff
+
+### Why `required-version` is set {#ruff-required-version}
+
+```toml
+required-version = ">=0.16"
+```
+
+The `extend-select` list assumes ruff 0.16's broad defaults (413 rules). On
+0.14 and 0.15 the defaults are just 59 rules (E4/E7/E9/F), so extending them
+would silently drop the prefixes deleted from the list as redundant — `DTZ`,
+`FA`, `FLY` and `PIE` — with no warning at all. Failing loudly is the better
+trade.
+
+This lives in `[tool.ruff]` rather than only in the `ci` dependency floor
+because that group sits inside a [template-preserve region](update.md): a
+project updating from an older template keeps its own `ruff>=0.14` but does
+receive this section, so the floor alone would not protect it.
+
+### Why preview rules are off {#ruff-preview}
+
+```toml
+preview = false
+```
+
+Preview rules are unstable by definition — they change behaviour and can be
+removed between patch releases, which would turn a routine ruff upgrade into a
+broken lint run for every template user.
+
+Turning preview on also opts into preview-only config syntax that then cannot
+be turned off again:
+
+- `rule-codes-in-selectors` (RUF201) demands rule *names* in ignore selectors,
+  but names are themselves rejected outside preview
+  (`Selecting rules by name requires preview mode`).
+- `noqa-comments` demands `# ruff: ignore[...]`, which stable ruff does not
+  honour as a suppression at all.
+
+Rule codes and `# noqa:` work in both modes, so they are the portable choice.
+Stable ruff 0.16 already enables 413 rules.
+
+### Why `extend-select` and not `select` {#ruff-extend-select}
+
+Ruff's default rule set is broad (413 rules as of 0.16) and grows with each
+release. `select` **replaces** that set, so a curated list silently switches off
+every default it omits — the list this template used to ship was disabling 81
+of them, including all ten flake8-async rules, blind-except, the leftover-
+debugger check and the flake8-pyi rules, with nothing warning that it was doing
+so.
+
+`extend-select` layers on top of the defaults instead, so future ruff releases
+add coverage rather than quietly losing it.
+
+Only list a prefix in `extend-select` if it is **not** already on by default.
+Entries that become default should be deleted rather than kept "for
+documentation": a redundant entry is indistinguishable from a load-bearing one.
+
+## Semantic release
+
+These apply only when `use_semantic_release` is enabled.
+
+### Why `build_command` starts with `set -e` {#semantic-release-build-command}
+
+python-semantic-release hands `build_command` to the shell as a *script*, not
+as an `&&` chain. Without `set -e` a failing `uv lock` is swallowed: the
+remaining lines still run, `uv build` exits 0, and the release reports success
+having committed a stale lockfile.
+
+CI cannot catch this afterwards either, because the generated workflow runs
+`uv sync --frozen`, which uses the lockfile as-is rather than asserting it is
+fresh (`--locked` is the flag that would). DOT-602.
+
+### Why `build_command` unsets empty `UV_*` variables {#semantic-release-unset-guards}
+
+```sh
+[ -n "$UV_SYSTEM_CERTS" ] || unset UV_SYSTEM_CERTS
+```
+
+Bare entries in `build_command_env` are resolved as `os.getenv(name, "")` and
+assigned unconditionally, so a variable that is unset in CI arrives as an empty
+string rather than being omitted.
+
+uv parses its own `UV_*` variables as typed CLI values — an enum for
+`--link-mode`, a path for `--cache-dir`, a boolish for `--system-certs` — so an
+empty one is a *malformed* value, not an absent one, and `uv lock` exits 2
+before doing any work.
+
+The TLS and proxy variables are read as plain strings where empty already means
+unset, so they need no guard. Each of the twelve was verified individually
+against uv 0.12.1. DOT-615.
+
+**Any new `UV_*` entry added to `build_command_env` needs a matching guard.**
+
+### Why `build_command_env` exists at all {#semantic-release-build-command-env}
+
+python-semantic-release **replaces** the environment for `build_command`
+instead of extending it: it builds a hardcoded allowlist (`PATH`, `HOME`,
+`VIRTUAL_ENV`, `CI`, `GITHUB_ACTIONS`, …) and passes it to `shell()` as `env=`.
+Everything else is dropped.
+
+Since `build_command` runs `uv lock`, which is a network operation, it would
+otherwise execute with no TLS, proxy or cache configuration while every other
+job in the same pipeline has all of it. This inverts the usual CI intuition
+that exporting a variable in the job is enough. DOT-605.
+
+A bare `"VAR"` entry is pass-through; `"VAR=value"` sets a literal.
+
+Keep the proxy variables as a set: `HTTPS_PROXY` without `NO_PROXY` routes
+internal hosts through the corporate proxy, which is the failure mode this
+replaces. `SSL_CERT_DIR` is included alongside `SSL_CERT_FILE` because uv 0.12
+made an invalid value in either one a hard HTTPS failure rather than a
+warning-and-fall-back.
+
+## Hooks
+
+These cover `prek.toml` and `_typos.toml`.
+
+### Why `minimum_prek_version` is pinned {#prek-minimum-version}
+
+prek 0.4.10 introduced the `[update]` tag filters used to exclude lychee's
+`nightly` tag. That version floor is the guard that reaches projects updating
+from an older template: `prek.toml` is regenerated in full by the template's
+[sync step](update.md), but `[dependency-groups]` in `pyproject.toml` sits
+inside a template-preserve region, so the `prek>=` floor there stays at
+whatever the project already had.
+
+A too-old prek would otherwise ignore the `[update]` block entirely and
+silently reintroduce the lychee bug below. `minimum_prek_version` fails loudly
+instead. DOT-616.
+
+### Why lychee's `nightly` tag is excluded from updates {#prek-lychee-nightly}
+
+```toml
+[update.repos."https://github.com/lycheeverse/lychee"]
+exclude_tags = ["nightly"]
+```
+
+lychee tags `nightly` as their GitHub "Latest" release, so `prek update`
+resolves it as the newest tag and rewrites the pinned rev to a mutable one that
+lychee's own hook then rejects
+([lycheeverse/lychee#1601](https://github.com/lycheeverse/lychee/issues/1601),
+DOT-492).
+
+Declaring the exclusion in config rather than wrapping `prek update` in a
+script means every invocation is protected — a bare `prek update`, CI, an
+editor integration — not just the one that goes through the wrapper (DOT-616).
+Remove once upstream fixes it (DOT-504).
+
+### Why `rev` lines must not carry trailing comments {#prek-rev-lines}
+
+Empty `rev` values are filled by `prek update` and kept in step with `uv.lock`
+by the `sync-with-uv` hook. That hook matches revs with a regex anchored at
+end-of-line, so a trailing comment on a `rev` line makes it unmatchable — and
+the hook then silently reports success while updating nothing. DOT-603.
+
+Put per-repo notes on the line *above* the `rev`.
+
+### Why the `typos` hook overrides `args` {#prek-typos-args}
+
+Upstream ships `args = ["--write-changes", "--force-exclude"]`, so the hook
+rewrites files in place. It has silently corrupted hex identifiers — Mongo
+ObjectIds, git SHAs — in checked-in data files (DOT-604).
+
+Overriding `args` **replaces** the upstream list rather than appending to it,
+which is what drops the write flag. Keep `--force-exclude`: it is what makes
+typos honour `_typos.toml` when prek passes explicit staged filenames instead
+of letting typos walk the tree.
+
+### Why `_typos.toml` excludes generated files {#typos-exclusions}
+
+Release tooling writes abbreviated git SHAs, which typos reads as prose
+(`ba` → `by`/`be`).
+
+`.copier-answers.yml` is the same problem with worse consequences. Copier
+writes `_commit: <git describe>` there, e.g. `0.41.3-3-g2452caf` — and short
+SHAs are hex, so any of the handful of words spellable from `[0-9a-f]` trips
+the dictionary: `caf`, `beef`, `fade`, `dead`, `deca`. That makes it fail on a
+minority of commits and pass on the rest, which is close to impossible to
+diagnose from the outside.
+
+Worse, `_commit` is what `copier update` reads to find the template revision to
+diff against; a "corrected" SHA points at nothing and breaks updates for the
+project entirely.
+
+When adding your own exclusions — data files holding hex-like identifiers, JSON
+exports, fixtures, snapshots are the usual reason — prefer a path exclusion
+over a repo-wide hex `extend-ignore-re`, which would also silence real typos in
+source and docs.
+
+### Why copier conflict markers get their own guards {#prek-copier-conflicts}
+
+Two hooks exist because `copier update` can leave conflict debris that a normal
+commit would otherwise carry into history:
+
+- `check-merge-conflict` runs with `--assume-in-merge`, which catches markers
+  left by `copier update --conflict inline`. Without the flag the hook skips
+  the check, because there is no `.git/MERGE_MSG` outside a real merge.
+- `no-copier-rej-files` blocks commits containing `.rej` files produced by
+  `copier update --conflict rej` (DOT-542). See Copier's
+  [tips and tricks](https://copier.readthedocs.io/en/stable/updating/#tips-and-tricks).

--- a/project/_typos.toml
+++ b/project/_typos.toml
@@ -1,25 +1,10 @@
 # Spell-checker configuration for the `typos` hook in prek.toml.
 #
-# The hook runs read-only: prek.toml overrides its args to drop the upstream
-# `--write-changes` default, so typos reports rather than rewrites (DOT-604).
-# `--force-exclude` is kept there so the exclusions below still apply when prek
-# passes explicit staged filenames rather than letting typos walk the tree.
+# These exclusions are load-bearing, not cosmetic: release tooling and copier
+# write abbreviated git SHAs into these files, and typos reads hex as prose.
+# A "corrected" SHA in .copier-answers.yml breaks `copier update` outright.
 #
-# Generated files are excluded because release tooling writes abbreviated git
-# SHAs, which typos reads as prose ("ba" -> "by"/"be").
-#
-# .copier-answers.yml is the same problem with worse consequences. Copier writes
-# `_commit: <git describe>` there, e.g. `0.41.3-3-g2452caf` — and short SHAs are
-# hex, so any of the handful of words spellable from [0-9a-f] trips the
-# dictionary: caf, beef, fade, dead, deca. That makes it fail on a minority of
-# commits and pass on the rest, which is close to impossible to diagnose from
-# the outside. Worse, `_commit` is what `copier update` reads to find the
-# template revision to diff against; a "corrected" SHA points at nothing and
-# breaks updates for the project.
-#
-# Add your own paths here. Data files holding hex-like identifiers — JSON
-# exports, fixtures, snapshots — are the usual reason; prefer a path exclusion
-# over a repo-wide hex `extend-ignore-re`, which would also silence real typos
-# in source and docs.
+# Add your own paths here rather than a repo-wide hex `extend-ignore-re`.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#typos-exclusions
 [files]
 extend-exclude = ["CHANGELOG.md", "uv.lock", ".copier-answers.yml"]

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -1,31 +1,22 @@
 #:schema https://www.schemastore.org/prek.json
 default_stages = ["pre-commit"]
-# 0.4.10 introduced the `[update]` tag filters used below. This is the guard
-# that reaches projects updating from an older template: `prek.toml` is
-# regenerated in full by the template's sync step, but `[dependency-groups]`
-# in pyproject.toml sits inside a template-preserve region, so the `prek>=`
-# floor there stays at whatever the project already had. A too-old prek would
-# otherwise ignore the `[update]` block entirely and silently reintroduce the
-# lychee `nightly` bug. Fails loudly instead (DOT-616).
+# Required — an older prek silently ignores the `[update]` block below.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-minimum-version
 minimum_prek_version = "0.4.10"
 # All available: commit-msg, post-checkout, post-commit, post-merge, post-rewrite, pre-commit, pre-merge-commit, pre-push, pre-rebase, prepare-commit-msg
 default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post-rewrite", "pre-commit", "pre-push"]
 
-# lychee tags `nightly` as their GitHub "Latest" release, so `prek update`
-# resolves it as the newest tag and rewrites the pinned rev to a mutable one
-# that lychee's own hook then rejects (lycheeverse/lychee#1601, DOT-492).
-# Declaring the exclusion here rather than wrapping `prek update` in a script
-# means every invocation is protected -- a bare `prek update`, CI, an editor
-# integration -- not just the one that goes through the wrapper (DOT-616).
-# Remove once lycheeverse/lychee#1601 is fixed upstream (DOT-504).
+# Without this, `prek update` pins lychee to a mutable `nightly` tag that
+# lychee's own hook then rejects. Remove once lycheeverse/lychee#1601 is fixed.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-lychee-nightly
 [update.repos."https://github.com/lycheeverse/lychee"]
 exclude_tags = ["nightly"]
 
-# Empty `rev` values are filled by `prek update`, and kept in
-# step with uv.lock by the sync-with-uv hook below. Never put a trailing comment
-# on a `rev` line: sync-with-uv matches revs with a regex anchored at end-of-line,
-# so a trailing comment makes the line unmatchable and the hook silently reports
-# success while updating nothing (DOT-603). Put per-repo notes on the line above.
+# Empty `rev` values are filled by `prek update` and kept in step with uv.lock
+# by the sync-with-uv hook. NEVER put a trailing comment on a `rev` line — it
+# makes the line unmatchable and sync-with-uv then silently updates nothing.
+# Put per-repo notes on the line above.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-rev-lines
 
 [[repos]]
 repo = "builtin"
@@ -36,7 +27,9 @@ hooks = [
   { id = "check-toml", priority = 0 },
   { id = "check-json", priority = 0 },
   { id = "check-added-large-files", priority = 0 },
-  { id = "check-merge-conflict", args = ["--assume-in-merge"], priority = 0 },  # --assume-in-merge catches markers from `copier update --conflict inline` (no .git/MERGE_MSG)
+  # --assume-in-merge catches markers from `copier update --conflict inline`.
+  # https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-copier-conflicts
+  { id = "check-merge-conflict", args = ["--assume-in-merge"], priority = 0 },
   { id = "check-case-conflict", priority = 0 },
   { id = "check-symlinks", priority = 0 },
   { id = "check-executables-have-shebangs", priority = 0 },
@@ -88,12 +81,10 @@ hooks = [{ id = "actionlint", priority = 1 }]
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
 rev = ""
-# Upstream ships `args = ["--write-changes", "--force-exclude"]`, so the hook
-# rewrites files in place — it has silently corrupted hex identifiers (Mongo
-# ObjectIds, git SHAs) in checked-in data files (DOT-604). Overriding `args`
-# REPLACES the upstream list rather than appending, which is what drops the
-# write flag here. Keep `--force-exclude`: it is what makes typos honour
-# _typos.toml when prek passes explicit staged filenames.
+# `args` is overridden to drop upstream's `--write-changes`, which rewrites
+# files in place and has corrupted hex identifiers in checked-in data. Keep
+# `--force-exclude` — it is what makes typos honour _typos.toml.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-typos-args
 hooks = [{ id = "typos", args = ["--force-exclude"], priority = 1 }]
 
 [[repos]]
@@ -104,15 +95,15 @@ hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], pr
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
 # The `nightly` tag is excluded in the `[update.repos]` block at the top of
-# this file, so a plain `prek update` keeps this on a versioned tag (DOT-492).
+# this file, so a plain `prek update` keeps this on a versioned tag.
 rev = "lychee-v0.24.2"
 hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]
 repo = "local"
 
-# Block commits containing .rej files produced by `copier update --conflict rej` (DOT-542).
-# https://copier.readthedocs.io/en/stable/updating/#tips-and-tricks
+# Block commits containing .rej files produced by `copier update --conflict rej`.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-copier-conflicts
 [[repos.hooks]]
 id = "no-copier-rej-files"
 name = "block copier .rej files"

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -1,15 +1,7 @@
 [build-system]
-# uv warns on every `uv sync` / `uv build` if uv_build is unbounded — and a
-# breaking uv_build release would silently break sdist builds in every rendered
-# project. Pin to the current minor series and the next major, and bump the
-# window when uv_build crosses it (DOT-589).
-#
-# Moved to the 0.12 series for uv 0.12, which enforces PEP 625: source
-# distributions must be `.tar.gz`, and `.tar.bz2`/`.tar.xz` are rejected, as
-# are wheels using bzip2/LZMA/XZ compression. uv_build already emits
-# PEP 625-conforming artifacts, so this is a no-op for the generated project
-# — verified by building an sdist and a wheel from a rendered project under
-# uv_build 0.12 and installing the result.
+# Bounded deliberately — an unbounded uv_build warns on every sync and can
+# break sdist builds. Bump the window when uv_build crosses it.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#build-backend-pin
 requires = ["uv_build>=0.12,<0.13"]
 build-backend = "uv_build"
 
@@ -70,12 +62,9 @@ maintain = [
     "python-semantic-release>=10.6",
 ]
 {%- endif %}
-# Floors track the versions this template is actually exercised against, not
-# the oldest release that happens to still work. A range wider than the tested
-# one advertises support nobody verifies: `uv sync` resolves to the newest
-# release, so the bottom of a `>=8` range is a configuration the template has
-# never once run under. `ty` is floored tighter than the rest because it is
-# pre-1.0, where any release may change behaviour.
+# Floors track the versions this template is tested at, not the oldest release
+# that still works.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#dependency-floors
 ci = [
     "ruff>=0.16",
     "pytest>=9",
@@ -104,37 +93,20 @@ url = "{{ custom_pypi_index_url }}"
 [tool.ruff]
 target-version = "py314"
 line-length = 140
-# `extend-select` below assumes ruff 0.16's broad defaults (413 rules). On 0.14
-# and 0.15 the defaults are just 59 rules (E4/E7/E9/F), so extending them would
-# silently drop the prefixes that were deleted here as redundant — DTZ, FA, FLY
-# and PIE — with no warning at all. Fail loudly instead of linting less than the
-# config claims. This lives here rather than only in the `ci` dependency floor
-# because that group is inside a template-preserve region: a project updating
-# from an older template keeps its own `ruff>=0.14` but does receive this
-# section, so the floor alone would not protect it.
+# Required — `extend-select` below assumes 0.16's 413 stable defaults. On 0.14
+# and 0.15 it would silently lint far less than this config claims.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#ruff-required-version
 required-version = ">=0.16"
-# Preview rules are unstable by definition — they change behaviour and can be
-# removed between patch releases. Turning them on also opts into preview-only
-# config syntax that then cannot be turned off again: `rule-codes-in-selectors`
-# (RUF201) demands rule NAMES in ignore selectors, but names are themselves
-# rejected outside preview ("Selecting rules by name requires preview mode"),
-# and `noqa-comments` demands `# ruff: ignore[...]`, which stable ruff does not
-# honour as a suppression at all. Rule codes and `# noqa:` work in both modes,
-# so they are the portable choice. Stable ruff 0.16 already enables 413 rules.
+# Preview rules change behaviour between patch releases, and preview-only
+# suppression syntax cannot be turned off again once adopted.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#ruff-preview
 preview = false
 
 [tool.ruff.lint]
-# `extend-select`, not `select`. Ruff's default rule set is broad (413 rules
-# as of 0.16) and grows with each release. `select` REPLACES that set, so a
-# curated list silently switches off every default it omits — this list was
-# disabling 81 of them, including all ten flake8-async rules, blind-except,
-# the leftover-debugger check and the flake8-pyi rules, with nothing warning
-# that it was doing so. `extend-select` layers on top of the defaults instead,
-# so future ruff releases add coverage rather than quietly losing it.
-#
-# Only list a prefix here if it is NOT already on by default. Entries that
-# become default should be deleted rather than kept "for documentation": a
-# redundant entry is indistinguishable from a load-bearing one.
+# `extend-select`, not `select` — `select` REPLACES ruff's defaults and would
+# silently switch off every one this list omits. Only add a prefix here if it
+# is NOT already on by default; delete entries once they become default.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#ruff-extend-select
 extend-select = [
     # Core — pycodestyle beyond the default subset
     "E",    # pycodestyle errors
@@ -291,23 +263,9 @@ fix = ["lint --fix", "format"]
 # Pre-commit
 prek = "prek run --all-files"
 
-
 # Template utilities
 check-template = { shell = "copier check-update || true" }
 update-template = { shell = "copier update --trust . --skip-answered --defaults --conflict rej && uv sync --upgrade && uv run prek update && echo '  ✓ Dependencies upgraded and hook versions updated' && { ls -1 -- **/*.rej *.rej 2>/dev/null | grep -q . && echo '  ⚠ Copier produced .rej files — review the diffs, apply manually, and delete the .rej files before committing.' || true; }{% if use_semantic_release %} && { grep -q 'git add uv.lock CHANGELOG.md' pyproject.toml || echo '  ⚠ WARNING: build_command in pyproject.toml is missing \"git add uv.lock CHANGELOG.md\" — releases will produce stale lockfiles. Add \"git add uv.lock CHANGELOG.md\" to build_command.'; }{% endif %}" }
-
-# Git utilities
-tags = "sh -c 'git fetch --tags && git tag --sort=-version:refname'"
-{%- if repository_provider == "github.com" %}
-
-# GitHub utilities
-# actions-up: https://github.com/azat-io/actions-up
-actionsup = "actions-up"
-releases = "gh release list --limit 10"
-runs = "gh run list --limit 10"
-checks = "gh pr checks --watch"
-watch = "gh run watch"
-{%- endif %}
 
 # template-preserve:extra-poe-tasks:start
 # Add your own project-specific poe tasks below — preserved across `copier update`.
@@ -318,23 +276,10 @@ watch = "gh run watch"
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
-# `set -e` is required. python-semantic-release hands build_command to the
-# shell as a script, not as an `&&` chain, so without it a failing `uv lock`
-# is swallowed: the remaining lines still run, `uv build` exits 0, and the
-# release reports success having committed a stale lockfile. CI cannot catch
-# this afterwards either, because the generated workflow runs `uv sync
-# --frozen`, which uses the lockfile as-is rather than asserting it is fresh
-# (`--locked` is the flag that would). DOT-602.
-#
-# The `unset` lines are required for the same reason. Bare entries in
-# build_command_env are resolved as os.getenv(name, "") and assigned
-# unconditionally, so a variable that is unset in CI arrives here as an empty
-# string rather than being omitted. uv parses its own UV_* variables as typed
-# CLI values -- an enum for --link-mode, a path for --cache-dir, a boolish for
-# --system-certs -- so an empty one is a malformed value, not an absent one,
-# and `uv lock` exits 2 before doing any work. The TLS and proxy variables are
-# read as plain strings where empty already means unset, so they need no
-# guard (each of the twelve verified individually against uv 0.12.1). DOT-615.
+# Do not remove `set -e` or the `unset` guards. Without `set -e` a failing
+# `uv lock` is swallowed and the release ships a stale lockfile; without the
+# guards an empty UV_* variable makes `uv lock` exit 2 before doing any work.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#semantic-release-build-command
 build_command = """
 set -e
 [ -n "$UV_SYSTEM_CERTS" ] || unset UV_SYSTEM_CERTS
@@ -344,25 +289,11 @@ uv lock --upgrade-package "$PACKAGE_NAME"
 git add uv.lock CHANGELOG.md
 uv build
 """
-# python-semantic-release REPLACES the environment for build_command instead
-# of extending it: it builds a hardcoded allowlist (PATH, HOME, VIRTUAL_ENV,
-# CI, GITHUB_ACTIONS, ...) and passes it to shell() as `env=`. Everything
-# else is dropped. Since the build_command above runs `uv lock`, which is a
-# network operation, it would otherwise execute with no TLS, proxy or cache
-# configuration while every other job in the same pipeline has all of it.
-# This inverts the usual CI intuition that exporting a variable in the job is
-# enough. DOT-605.
-#
-# A bare "VAR" entry is pass-through, resolved as os.getenv(name, "");
-# "VAR=value" sets a literal. Unset variables therefore arrive as empty
-# strings rather than being omitted -- see the `unset` guards in build_command
-# above, which any new UV_* entry added here also needs.
-#
-# Keep the proxy variables as a set: HTTPS_PROXY without NO_PROXY routes
-# internal hosts through the corporate proxy, which is the failure mode this
-# replaces. SSL_CERT_DIR is included alongside SSL_CERT_FILE because uv 0.12
-# made an invalid value in either one a hard HTTPS failure rather than a
-# warning-and-fall-back.
+# Required: python-semantic-release REPLACES the environment for build_command
+# rather than extending it, so `uv lock` would otherwise run with no TLS, proxy
+# or cache config. Any new UV_* entry here needs an `unset` guard above, and
+# the proxy variables must stay a set.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#semantic-release-build-command-env
 build_command_env = [
     "UV_SYSTEM_CERTS",
     "UV_CACHE_DIR",

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1046,16 +1046,6 @@ class TestTemplateCleanup:
         content = pyproject.read_text()
         assert "tests/fixtures" not in content
 
-    def test_github_has_gh_cli_tasks(self, copier_defaults: dict, project_factory) -> None:
-        """GitHub projects should have gh CLI poe tasks."""
-        project = project_factory(copier_defaults)
-
-        pyproject = project / "pyproject.toml"
-        content = pyproject.read_text()
-        assert "gh release list" in content
-        assert "gh run list" in content
-        assert "gh run watch" in content
-
 
 class TestTemplateUpdateCheck:
     """Test template update check hook and related tasks (#161)."""
@@ -1370,17 +1360,6 @@ class TestGitLabSupport:
             data = tomllib.load(f)
         repo_urls = [r["repo"] for r in data["repos"]]
         assert "https://github.com/crate-ci/typos" in repo_urls
-
-    def test_gitlab_no_gh_cli_tasks(self, copier_defaults: dict, project_factory) -> None:
-        """GitLab projects should not have gh CLI poe tasks."""
-        answers = {**copier_defaults, "repository_provider": "gitlab.com"}
-        project = project_factory(answers)
-
-        pyproject = project / "pyproject.toml"
-        content = pyproject.read_text()
-        assert "gh release list" not in content
-        assert "gh run list" not in content
-        assert "docs-deploy" not in content
 
     def test_gitlab_no_discussions_url(self, copier_defaults: dict, project_factory) -> None:
         """GitLab projects should not have Discussions URL."""

--- a/zensical.toml
+++ b/zensical.toml
@@ -16,6 +16,7 @@ nav = [
   ]},
   {"Usage" = [
     {"Updating a project" = "update.md"},
+    {"Why the generated config looks like this" = "generated-config.md"},
   ]},
 ]
 


### PR DESCRIPTION
## Summary

Moves the rationale for the template's non-obvious config out of the files that ship to users, and drops a group of poe tasks that a template shouldn't have an opinion about.

- **New `docs/generated-config.md`** — a single page explaining the thirteen settings that look wrong or removable until you know what they defend against: the `uv_build` pin window, the dependency-floor policy, ruff's `required-version` / `preview` / `extend-select` choices, semantic-release's `set -e` and env-replacement traps, `minimum_prek_version`, the lychee `nightly` exclusion, the no-trailing-comment rule on `rev` lines, the `typos` args override, the `.copier-answers.yml` hex-SHA trap, and the copier conflict guards.
- **`project/pyproject.toml.jinja`: 401 → 332 lines, 118 → 60 comment lines.** Each site keeps a 2–4 line note saying *what breaks if you delete this*, plus a link.
- **`project/prek.toml.jinja`: 193 → 184 lines; `project/_typos.toml`: 26 → 10.** Same treatment.
- **Zero `DOT-` references now ship to generated projects** (was 7 across three files).
- **Removes six poe tasks** — `tags`, `releases`, `runs`, `checks`, `watch`, `actionsup`.
- **Fixes the README**, which documented a question set that hasn't existed since 0.41.0.

## Why

**The rationale was shipping into every scaffolded project.** 29% of the generated `pyproject.toml` was prose about python-semantic-release internals, uv's typed `UV_*` parsing and ruff's preview semantics, including thirteen references to a private tracker the reader cannot open. That's this template's institutional memory, not something a new project should inherit in its own config. The knowledge is worth keeping — it's just worth keeping *somewhere the reader can act on it*.

**The removed poe tasks were thin `gh` aliases.** `poe runs` → `gh run list --limit 10`. A template making that decision for you is scope creep. Worse, `actionsup` invoked a binary declared in no dependency group, so it failed on every freshly generated project. Removing the group also drops the last `repository_provider == "github.com"` gate in the poe section, which is why two now-vacuous tests go with it.

**The README was actively wrong.** Its prompt table described a `Project audience` prompt with `solo-internal` / `team` / `public-oss` profiles, separate community-health and docs-site toggles, and a `package` project type — all folded into `open_source` or removed in 0.41.0. It also listed `poe docs` / `poe docs-build` and Zensical as things a generated project gets; the docs site was dropped from generated projects in #327. Anyone reading it and running `copier copy` would have been prompted for entirely different things.

## Test plan

- `pytest tests/` — **188 passed** (190 baseline minus the two tests whose subject was removed).
- `pytest tests/test_template_lint.py` — 39 passed; renders every template against all `CONTEXT_VARIANTS` and validates the TOML/YAML/Python/Markdown, so the trimmed files are confirmed valid across every answer combination.
- Baseline verified by stashing and re-running: 190 passed on a clean tree, confirming the 38 failures seen mid-work were the known dirty-tree flake and not these changes.
- Full prek chain green, including `lychee` on the new docs page.

Note: `_typos.toml` gains narrowly-scoped `ba` and `caf` entries. The new docs page quotes those verbatim as examples of the hex strings typos misreads as prose, so the page explaining the problem trips it. Accepting the two words that actually fire is narrower than excluding the page, which would silence real typos in it.

Refs DOT-163

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move generated config rationale to docs and drop GitHub CLI poe tasks from template
> - Adds [docs/generated-config.md](https://github.com/detailobsessed/copier-uv-bleeding/pull/338/files#diff-e3e3958c4d2f18f1ea407d2e5053e57bf3f3131ca05989abf06d2a8d38535b9f), a new documentation page explaining the rationale behind generated configuration choices (build backend pins, ruff settings, semantic-release config, typos exclusions, etc.).
> - Trims inline comments in [project/pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/338/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3) and [project/prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/338/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c) to link to the new docs page instead.
> - Removes the `tags`, `actionsup`, `releases`, `runs`, `checks`, and `watch` poe tasks from generated projects; removes corresponding tests from [tests/test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/338/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9).
> - Adds `ba` and `caf` to the typos allowlist in [_typos.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/338/files#diff-e936c0fb5ab3dfb5a78d7e9b66fba7bada4187148866402e8cb2b585b5fc5799) to avoid false positives.
> - Behavioral Change: generated projects no longer include the `tags` poe task or any GitHub CLI poe tasks.
>
> #### 🖇️ Linked Issues
> Partially addresses [DOT-163](https://linear.app/ismar/issue/DOT-163) by documenting the rationale behind opinionated defaults in the generated config and improving README clarity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8656cae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
