### PR TITLE
fix(template): drop coverage omit that swallowed the only file in a fresh project

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -230,7 +230,11 @@ source = ["src/"]
 
 [tool.coverage.report]
 precision = 2
-omit = ["src/*/__init__.py"]
+# No `omit` here. A pattern like `src/*/__init__.py` matches the ONLY Python
+# file a freshly generated project has, leaving coverage with nothing to report
+# — it warns, writes neither the terminal table nor htmlcov/, and still exits 0.
+# The generated __init__.py is a bare docstring: 0 statements, reports 100%, so
+# omitting it buys nothing.
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING", "if __name__ == .__main__.:"]
 
 [tool.coverage.json]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2048,6 +2048,40 @@ class TestIntegration:
             assert result.returncode == 0, f"`poe {task}` failed at the declared dependency floors:\n{result.stdout}\n{result.stderr}"
 
     @pytest.mark.slow
+    def test_test_cov_produces_a_report(self, tmp_path: Path, copier_defaults: dict) -> None:
+        """`poe test-cov` must produce an actual report on a freshly generated project.
+
+        The bug this pins (DOT-617) was silent in the worst way: coverage measured
+        `src/`, an `omit = ["src/*/__init__.py"]` pattern excluded the only Python
+        file a fresh project has, and coverage was left with nothing to report. It
+        emitted a CovReportWarning, wrote neither the terminal table nor `htmlcov/`,
+        and exited 0 -- so the task looked like it worked.
+
+        Every other coverage assertion in this suite reads pyproject *content*.
+        This one runs the task, which is the only way to catch a config that is
+        internally consistent but produces nothing.
+        """
+        project = generate_project(tmp_path, copier_defaults)
+
+        sync = subprocess.run(["uv", "sync"], cwd=project, capture_output=True, text=True, check=False)
+        assert sync.returncode == 0, f"uv sync failed: {sync.stderr}"
+
+        result = subprocess.run(
+            ["uv", "run", "poe", "test-cov"],
+            cwd=project,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"`poe test-cov` failed:\n{result.stdout}\n{result.stderr}"
+
+        # Exit code 0 is not enough -- that is exactly what the bug produced.
+        output = result.stdout + result.stderr
+        assert "No data to report" not in output, f"coverage had nothing to measure:\n{output}"
+        assert "TOTAL" in output, f"coverage terminal report was not written:\n{output}"
+        assert (project / "htmlcov" / "index.html").exists(), "coverage HTML report was not written"
+
+    @pytest.mark.slow
     def test_first_commit_succeeds_with_prek_hooks(self, tmp_path: Path, copier_defaults: dict) -> None:
         """First `git commit` on a freshly scaffolded project must succeed.
 


### PR DESCRIPTION
## Summary

Removes `omit = ["src/*/__init__.py"]` from the generated `[tool.coverage.report]`, and adds an integration test that runs `poe test-cov` instead of reading config.

## Why

On a freshly generated project, `poe test-cov` produced **no report of any kind** and exited **0**:

```
Poe => pytest --cov --cov-report=term-missing --cov-report=html
tests/test_floor_test.py::test_package_importable PASSED                 [100%]
pytest_cov/plugin.py:366: CovReportWarning: Failed to generate report: No data to report.

WARNING: Failed to generate report: No data to report.

============================== 1 passed in 0.01s ===============================
```

No terminal table, no `htmlcov/` — just a bare `.coverage` data file and a green exit.

`[tool.coverage.run]` measures `src/`. A fresh scaffold contains exactly one Python file there, `src/<package>/__init__.py`, which is precisely what the `omit` pattern excluded. Coverage measured one file, omitted it, and had nothing left to report.

Dropping `omit` costs nothing. The generated `__init__.py` is a bare docstring — **0 statements**, reporting 100% — so omitting it never improved the number. It only cost the entire report, until the user happens to add a real module.

This matters more than its size suggests: `poe test-cov` is one of the first commands run on a new project, and its failure mode was a green exit with no output. That's the same shape as the `build_command` and `sync-with-uv` defects fixed earlier this cycle, where "reports success while doing nothing" *was* the bug.

## Test plan

- New `TestIntegration::test_test_cov_produces_a_report` generates a project, runs `uv sync`, runs `uv run poe test-cov`, and asserts exit 0 **plus** that `No data to report` is absent, `TOTAL` is present, and `htmlcov/index.html` exists. Exit code alone is not enough — that's exactly what the bug produced.
- Verified the test discriminates rather than passing vacuously, by reproducing both states in isolation:

  | | terminal report | outcome |
  | --- | --- | --- |
  | with `omit` | `Failed to generate report: No data to report.` | no `TOTAL`, no `htmlcov/` |
  | without `omit` | `TOTAL  0  0  100.00%` | report written |

- `pytest tests/` — **190 passed**, including the new slow test.
- Placed in `TestIntegration` and marked `slow`, alongside the other tests that exercise a real generated project.

Note this is the first coverage assertion in the suite that *runs* the task. Every other one reads `pyproject.toml` content, which is why a config that was internally consistent but produced nothing went unnoticed.

Closes DOT-617

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop `coverage.report` omit pattern that suppressed reports on fresh projects
> - Removes `omit = ["src/*/__init__.py"]` from [pyproject.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/339/files#diff-0b051e3a19a505a587f29766ed7754641b8d23c75f82576e80fcf69e690bedc3); on a freshly generated project this pattern excluded the only file under `src/`, leaving no data to report and silently producing no terminal or HTML output.
> - Adds an integration test in [test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/339/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) that generates a project, runs `uv run poe test-cov`, and asserts the exit code is 0, output contains `TOTAL`, and `htmlcov/index.html` exists.
>
> #### 🖇️ Linked Issues
> Fixes [DOT-617](https://linear.app/ismar/issue/DOT-617), which tracked `poe test-cov` exiting 0 with no report on a freshly generated project due to the omit pattern swallowing the only measured file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f33f0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
