### PR TITLE
docs(template): record that uv-sync keeps upstream's --locked on purpose

### DIFF
--- a/docs/generated-config.md
+++ b/docs/generated-config.md
@@ -229,6 +229,37 @@ exports, fixtures, snapshots are the usual reason — prefer a path exclusion
 over a repo-wide hex `extend-ignore-re`, which would also silence real typos in
 source and docs.
 
+### Why `uv-sync` keeps upstream's `--locked` {#prek-uv-sync-locked}
+
+The `uv-sync` hook ships this by default:
+
+```yaml
+- id: uv-sync
+  entry: uv sync --no-active
+  args: ["--locked"]
+```
+
+The template does **not** override `args`, so generated projects run
+`uv sync --no-active --locked` on post-checkout, post-merge and post-rewrite.
+`--locked` asserts the lockfile is already in step with `pyproject.toml` and
+fails if it is not, rather than quietly regenerating it.
+
+This is a deliberate choice, not an oversight — the alternative was considered
+and rejected. Setting `args = []` would make the hook self-heal silently, which
+is friendlier in the moment but hides the fact that someone changed
+dependencies without relocking. "Reports success while doing nothing" is the
+failure shape behind several of this template's worst bugs, so the loud version
+wins.
+
+Note that the original reason this looked broken is gone. It used to fire after
+every release, because a stale `uv.lock` was being committed — `build_command`
+neither staged the regenerated lockfile nor aborted when `uv lock` failed. Both
+are fixed (see [`set -e`](#semantic-release-build-command) and the `git add
+uv.lock` line in `build_command`), so a release commit now carries a lockfile
+that matches.
+
+If the hook fires for you now, it is reporting real drift. Run `uv lock`.
+
 ### Why copier conflict markers get their own guards {#prek-copier-conflicts}
 
 Two hooks exist because `copier update` can leave conflict debris that a normal

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -61,6 +61,11 @@ hooks = [
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
 rev = ""
+# `args` is deliberately NOT overridden: uv-sync inherits upstream's
+# `--locked`, so a lockfile that has drifted from pyproject.toml fails the
+# hook instead of being silently regenerated. Kept on purpose — see the docs
+# before changing it.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-uv-sync-locked
 hooks = [
   { id = "uv-lock", priority = 1 },
   { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 1 },

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1068,6 +1068,31 @@ class TestTemplateUpdateCheck:
             data = tomllib.load(f)
         assert "post-checkout" in data["default_install_hook_types"]
 
+    def test_uv_sync_hook_inherits_upstream_locked(self, copier_defaults: dict, project_factory) -> None:
+        """uv-sync must NOT override `args`, so it keeps upstream's `--locked` (DOT-495).
+
+        Overriding `args` REPLACES the upstream list rather than appending to it --
+        the same mechanic that drops `--write-changes` from the typos hook (DOT-604).
+        So `args = []` here would silently turn `uv sync --locked` into a plain
+        `uv sync` that regenerates a drifted lockfile instead of reporting it.
+
+        That is a deliberate rejection, not an accident: a hook that self-heals
+        quietly hides the drift, and "reports success while doing nothing" is the
+        shape of DOT-602, DOT-603 and DOT-617. Absence of a key is invisible in a
+        diff, hence this test.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        uv_repo = next(r for r in data["repos"] if r.get("repo", "").endswith("/uv-pre-commit"))
+        uv_sync = next(h for h in uv_repo["hooks"] if h["id"] == "uv-sync")
+        assert "args" not in uv_sync, (
+            "uv-sync must inherit upstream's `args = ['--locked']`. Overriding `args` replaces "
+            f"that list, so a drifted lockfile would be regenerated silently instead of failing. Got: {uv_sync!r}"
+        )
+
     def test_check_template_update_hook_exists(self, copier_defaults: dict, project_factory) -> None:
         """prek.toml should have check-template-update hook."""
         project = project_factory(copier_defaults)


### PR DESCRIPTION
## Summary

Records a decision that was previously only implicit: the `uv-sync` hook keeps upstream's `--locked`, deliberately. Adds a comment at the config site, a docs section, and a test that pins it.

No behaviour change — this makes an existing default intentional rather than inherited.

## Why

The `uv-sync` hook ships this upstream:

```yaml
- id: uv-sync
  entry: uv sync --no-active
  args: ["--locked"]
```

`prek.toml.jinja` doesn't override `args`, so generated projects run `uv sync --no-active --locked` on post-checkout, post-merge and post-rewrite. `--locked` asserts the lockfile already matches `pyproject.toml` and fails if not, rather than quietly regenerating it.

Nothing said so, which left it looking like an oversight — and the standing proposal was to override it with `args = []`.

**Keeping the loud behaviour is the right call.** `args = []` makes the hook self-heal silently, which is friendlier in the moment but hides the fact that someone changed dependencies without relocking. "Reports success while doing nothing" is the failure shape behind the last several bugs fixed in this template; adding another instance of it deliberately would be a poor trade.

**The failure originally reported against this setting is also gone.** It fired after every release because a stale `uv.lock` was being committed — `build_command` neither staged the regenerated lockfile nor aborted when `uv lock` failed. Both were fixed earlier this cycle, so a release commit now carries a lockfile that matches. If the hook fires now, it's reporting real drift, and `uv lock` is the answer.

## Test plan

- New `test_uv_sync_hook_inherits_upstream_locked` parses the rendered `prek.toml` and asserts `args` is **absent** from the `uv-sync` hook.
- `pytest tests/` — **190 passed**.

The test asserts on an absent key, which is unusual but load-bearing here. prek's `args` semantics *replace* rather than append, and the same mechanic runs in opposite directions in this file: the override on `typos` is protective (it drops upstream's destructive `--write-changes`), while an override on `uv-sync` would be harmful (it would drop the protective `--locked`). An absent key leaves no trace in a diff and no line to anchor a comment to, so without the test the decision survives only as prose that a future edit can contradict without noticing.

Refs DOT-495

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document that `uv-sync` intentionally inherits upstream's `--locked` arg
> - Adds a comment to [prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/340/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c) explaining that `args` is not overridden so `uv-sync` inherits upstream's `--locked` by design.
> - Adds a documentation section in [generated-config.md](https://github.com/detailobsessed/copier-uv-bleeding/pull/340/files#diff-e3e3958c4d2f18f1ea407d2e5053e57bf3f3131ca05989abf06d2a8d38535b9f) covering the rationale, prior failure modes, and related fixes.
> - Adds a regression test in [test_template.py](https://github.com/detailobsessed/copier-uv-bleeding/pull/340/files#diff-140d5ca36c77559547b5932938faad8b1296414593f6f0da782ab154c9637ea9) that asserts the rendered `uv-sync` hook does not include an `args` key, preventing accidental overrides.
>
> #### 🖇️ Linked Issues
> Resolves [DOT-495](https://linear.app/ismar/issue/DOT-495), which tracked the decision of whether `uv-sync` should inherit upstream's `--locked`. The PR documents and tests that the template deliberately does not override `args`, preserving `--locked` from the upstream hook definition.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2334ada.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
