### PR TITLE
fix(ci): run CI on pull requests targeting any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,10 @@ name: ci
   push:
     branches:
       - main
+  # Deliberately unfiltered. Gating on `branches: [main]` meant stacked PRs --
+  # which target their parent branch, not main -- never triggered CI at all,
+  # so every PR in a stack but the bottom one was reviewed with no signal.
   pull_request:
-    branches:
-    - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -5,9 +5,10 @@ name: ci
     branches:
     - main
     - test-me-*
+  # Deliberately unfiltered. Gating on `branches: [main]` means a stacked PR --
+  # one targeting its parent branch rather than main -- never triggers CI, so
+  # every PR in a stack but the bottom one gets reviewed with no signal.
   pull_request:
-    branches:
-    - main
 
 concurrency:
   group: {% raw %}${{ github.workflow }}-${{ github.ref }}{% endraw %}

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -11,6 +11,7 @@ import tomllib
 from typing import TYPE_CHECKING, ClassVar
 
 import pytest
+import yaml
 from conftest import REPO_ROOT, generate_project
 
 if TYPE_CHECKING:
@@ -627,6 +628,35 @@ class TestDependencies:
 
 class TestCIWorkflows:
     """Test CI workflow configuration (from smoke_test.sh assertions)."""
+
+    def test_ci_pull_request_trigger_is_unfiltered(self, copier_defaults: dict, project_factory) -> None:
+        """CI must run on PRs targeting ANY base branch, not just main (DOT-619).
+
+        `pull_request: {branches: [main]}` looks harmless and silently disables CI
+        for stacked PRs, which target their parent branch rather than main. Every
+        PR in a stack but the bottom one then gets reviewed with no signal at all
+        -- not a red check, no check.
+
+        Asserting on an absent key because that is the defect: a `branches` filter
+        added back here would look like tightening and read as normal in a diff.
+        The `push` trigger is intentionally left alone; scoping that one to main
+        is correct.
+        """
+        answers = {**copier_defaults, "use_ci": True}
+        project = project_factory(answers)
+
+        ci_yml = project / ".github" / "workflows" / "ci.yml"
+        # "on" is the YAML 1.1 boolean true, hence the quoting in the workflow;
+        # PyYAML resolves the bare key back to True, so accept either.
+        workflow = yaml.safe_load(ci_yml.read_text())
+        triggers = workflow.get("on", workflow.get(True))
+
+        assert "pull_request" in triggers, "CI workflow has no pull_request trigger"
+        pr_trigger = triggers["pull_request"]
+        assert pr_trigger is None or "branches" not in pr_trigger, (
+            "pull_request must not filter on base branch -- a `branches` filter means stacked PRs "
+            f"(base != main) never trigger CI. Got: {pr_trigger!r}"
+        )
 
     def test_ci_has_setup_uv(self, copier_defaults: dict, project_factory) -> None:
         """CI workflow should use setup-uv action."""


### PR DESCRIPTION
## Summary

Removes the `branches: [main]` filter from the `pull_request` trigger in `.github/workflows/ci.yml` and `project/.github/workflows/ci.yml.jinja`, so CI runs on PRs targeting any base branch. Adds a test pinning it.

## Why

Stacked PRs never triggered CI. At all.

This was found the direct way, while submitting the stack this PR sits on top of: **#338 ran a full CI suite; #339 and #340 produced no Actions run whatsoever.** Not a queued run, not a failing run — nothing, after three minutes of polling.

The cause is that stacked PRs target their parent branch by design (#339 based on `trim-shipped-rationale`, #340 based on `fix-coverage-omit`), and neither base is `main`, so `pull_request: {branches: [main]}` never matched.

The failure mode is worse than a broken check. A red X gets noticed; an absent check looks like a PR that simply hasn't been touched yet. Every PR in a stack except the bottom one was being reviewed and approved with no automated gate. It's not never-tested — git-spice retargets each branch onto `main` as its parent merges, and CI runs then — but that puts the first real run *after* the parent has landed, which is the wrong end of the review.

**The template ships the same gating**, so every generated project inherits the blind spot. That's the sharper half of this: `CLAUDE.md` here mandates git-spice for branching, so the template was handing users a CI workflow that its own recommended branching strategy silently bypasses.

## Test plan

- `pytest tests/` — **191 passed**.
- New `TestCIWorkflows::test_ci_pull_request_trigger_is_unfiltered` parses the rendered workflow and asserts `pull_request` carries no `branches` key.
- Verified the assertion discriminates rather than passing vacuously:

  | config | parsed `pull_request` | test passes |
  | --- | --- | --- |
  | `branches: [main]` | `{'branches': ['main']}` | **False** |
  | unfiltered | `None` | True |

- The real proof arrives with this PR: it is itself stacked on `ci-run-on-stacked-prs`'s parent, so **if CI runs on #341 at all, the fix works.**

Side effects checked before changing the trigger:

- **No duplicate runs.** `push` stays scoped to `main`, so pushing a stack branch doesn't double-trigger alongside the `pull_request` event.
- **Concurrency already handles it.** The group is keyed on `github.head_ref || github.run_id`, so each stack branch gets its own group and cancel-in-progress stays correct.
- **`dorny/paths-filter` still behaves.** On a `pull_request` event it diffs against the PR's own base ref, so a stacked PR reports what *that* PR changed rather than the whole stack — the desired behaviour.

The test asserts on an absent key, which is deliberate. A `branches` filter added back here would read as tightening, look unremarkable in a diff, and silently restore the blind spot.

Closes DOT-619


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI workflow to run on pull requests targeting any base branch
> - Removes the `branches` filter from the `pull_request` trigger in [ci.yml](.github/workflows/ci.yml) and [ci.yml.jinja](project/.github/workflows/ci.yml.jinja), so CI runs on stacked PRs whose base is not `main`.
> - The `push` trigger retains its `main` filter, so no duplicate runs occur on stack branch pushes.
> - Adds a test asserting the rendered `pull_request` trigger has no `branches` filter.
>
> #### 🖇️ Linked Issues
> Resolves [DOT-619](https://linear.app/ismar/issue/DOT-619), which identified that stacked PRs targeting non-`main` base branches never received a CI run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc3e3e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->