### PR TITLE
docs: drop '(bleeding edge fork)' from project descriptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "copier-uv-bleeding"
 version = "0.41.10"
-description = "Copier template for Python projects managed by uv (bleeding edge fork)"
+description = "Bleeding edge Copier template for Python projects managed by uv"
 readme = "README.md"
 requires-python = ">=3.14"
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "Copier UV Bleeding"
-site_description = "Copier template for Python projects managed by uv (bleeding edge fork)"
+site_description = "Bleeding edge Copier template for Python projects managed by uv"
 site_url = "https://detailobsessed.github.io/copier-uv-bleeding"
 repo_url = "https://github.com/detailobsessed/copier-uv-bleeding"
 repo_name = "detailobsessed/copier-uv-bleeding"


### PR DESCRIPTION
## Summary

Drops the `(bleeding edge fork)` suffix from `project.description` in
`pyproject.toml` and `site_description` in `zensical.toml`. Both now read
`Bleeding edge Copier template for Python projects managed by uv`, matching
the GitHub repository description.

## Why

The repository left the fork network, so the parenthetical describes a
relationship that no longer exists — `isFork` is now `false` and there is no
parent repo. Left alone it reads as "a fork of something", which is no longer
true of the repo and has not been true of the code for a long time: only 6 of
83 tracked files were last touched upstream, and 5 of those are one-line
`--8<--` include stubs.

**Attribution is deliberately untouched.** The point of this change is
accuracy about repository status, not a claim of sole authorship:

- `LICENSE` keeps both copyright lines. Retaining the notice for Timothée
  Mazzucotelli is an ISC obligation, not a courtesy.
- The README acknowledgment stays verbatim — it already states that this
  project originated as a fork of [pawamoy/copier-uv](https://github.com/pawamoy/copier-uv)
  and has since diverged significantly in scope and philosophy. Past tense,
  still accurate after detaching.

## Test plan

- `grep -rn 'bleeding edge fork'` over the tree returns nothing.
- `check-toml` passes on both edited files; full prek suite green on commit.
- No test asserts on either description string, so nothing needed updating.
- Docs site picks up `site_description` on the next build; no anchors or nav
  entries move.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reword project description to move 'bleeding edge' out of parentheses
> Updates the description string in [pyproject.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/342/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) and [zensical.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/342/files#diff-c785042929d7b216744f869cd6ace6657b73aaf6a5f041da1d096c2b6e34ff04) from `'Copier template for Python projects managed by uv (bleeding edge fork)'` to `'Bleeding edge Copier template for Python projects managed by uv'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e24b39.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->