### PR TITLE
chore(prek): drop no-commit-to-branch, add BOM and submodule builtins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       run: uv lock
     - uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
       env:
-        SKIP: no-commit-to-branch,pytest-cov,lychee,uv-lock
+        SKIP: pytest-cov,lychee,uv-lock
       with:
         extra-args: '--all-files'
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ pytest tests/test_template.py::TestProjectTypes::test_app_type_has_cli -v
 
 ## Tooling Notes
 
-**prek** -- TOML config (`prek.toml`), not YAML. Hooks with the same `priority` run in parallel (0 = cheap builtins, 1 = everything else). `files` accepts glob patterns via `files = { glob = ["docs/**"] }`. Use `prek util identify <file>` to debug type filters. `PREK_QUIET=1` suppresses passing hooks.
+**prek** -- TOML config (`prek.toml`), not YAML. `priority` schedules hooks: ascending order, same value runs concurrently, omitted means sequential-by-order. Per prek's reference, two hooks in one group that mutate the same files have **undefined** results, and a group that modifies files fails as a whole with no attribution to the responsible hook -- so a new fixing hook needs a priority no other hook writing those same files uses. Group 0 is read-only checks; builtin mutators are 1-4; group 5 holds fixers with disjoint file types, with `ruff-format` at 6 after `ruff --fix`. `prek util list-builtins` is the authoritative builtin id list. `[priorities]` alias tables need prek 0.4.11+. `files` accepts glob patterns via `files = { glob = ["docs/**"] }`. Use `prek util identify <file>` to debug type filters. `PREK_QUIET=1` suppresses passing hooks.
 
 **ty** -- Reads `requires-python` from `pyproject.toml` to determine stdlib availability. If set too low, it won't resolve newer stdlib modules. Must be `>=3.14` for this template.
 

--- a/docs/generated-config.md
+++ b/docs/generated-config.md
@@ -229,6 +229,63 @@ exports, fixtures, snapshots are the usual reason — prefer a path exclusion
 over a repo-wide hex `extend-ignore-re`, which would also silence real typos in
 source and docs.
 
+### Why file-rewriting hooks each get their own priority {#prek-hook-priorities}
+
+`priority` is a prek-only scheduling extension: hooks run in ascending priority
+order, and hooks sharing a value run concurrently. Omitting it entirely gets you
+an implicit value from hook order, i.e. sequential behaviour. So parallelism here
+is opt-in — and for anything that writes files, opting in is a correctness
+decision, not a performance one.
+
+prek's own reference is explicit about it:
+
+> **Parallel hooks modifying files** — If two hooks run in the same priority
+> group and both mutate the same files (or depend on shared state), results are
+> **undefined**. Use separate priorities to avoid overlap.
+
+There is a second, independent reason:
+
+> If a hook modifies files without emitting a non-zero exit code (e.g.
+> `ruff format`), the priority group **as a whole** will fail. It is not possible
+> for prek to attribute the failure to a specific hook in the group which
+> modified files. Use separate priorities for clearer failure attribution.
+
+That is the difference between `Files were modified by following hooks...Failed`
+with a dozen hooks listed as `Passed` underneath it, and a single named hook
+telling you what it rewrote.
+
+Measured on 40 files each carrying a BOM, trailing whitespace, CRLF endings and
+no final newline:
+
+| Configuration | Files still with trailing whitespace | Files still with CRLF |
+| -- | -- | -- |
+| `trailing-whitespace`, `end-of-file-fixer`, `mixed-line-ending` all at 0 | 12/40 | 3/40 |
+| …plus `fix-byte-order-marker`, also at 0 | 27/40 | 20/40 |
+| the same four, one priority each | **0/40** | **0/40** |
+
+It is not corruption — prek fails the run, and re-running fixes more each time
+until it converges. But convergence is nondeterministic, and "the hook ran and
+reported success while another hook's fix was discarded" is the failure shape
+this template treats as a bug.
+
+So: read-only checks share group 0, and each builtin file mutator gets its own
+group, 1–4. Order there is also semantic — `end-of-file-fixer` runs last so it
+sees the real final byte after line endings are normalised and the BOM is
+stripped.
+
+Group 5 holds the remaining fixers (`ruff --fix`, `markdownlint`,
+`sync-with-uv`, `uv-lock`). They share a group safely because they write
+*disjoint* file types — `.py`, `.md`, `prek.toml`, `uv.lock` — which is the
+condition upstream's warning actually turns on. `ruff-format` is the exception at
+6, because it rewrites the same `.py` files as `ruff --fix` and must run after
+it. `sync-with-uv` moved out of group 0 for the same reason: it rewrites
+`prek.toml`, which the builtin mutators in 1–4 also touch.
+
+**A new hook that writes files needs a priority no other hook writing those same
+files uses.** Since 0.4.11 these can be named via a `[priorities]` alias table
+rather than bare integers, which is worth adopting once the template's
+`minimum_prek_version` floor reaches 0.4.11.
+
 ### Why `uv-sync` keeps upstream's `--locked` {#prek-uv-sync-locked}
 
 The `uv-sync` hook ships this by default:

--- a/docs/generated-config.md
+++ b/docs/generated-config.md
@@ -273,13 +273,21 @@ group, 1–4. Order there is also semantic — `end-of-file-fixer` runs last so 
 sees the real final byte after line endings are normalised and the BOM is
 stripped.
 
-Group 5 holds the remaining fixers (`ruff --fix`, `markdownlint`,
-`sync-with-uv`, `uv-lock`). They share a group safely because they write
-*disjoint* file types — `.py`, `.md`, `prek.toml`, `uv.lock` — which is the
-condition upstream's warning actually turns on. `ruff-format` is the exception at
-6, because it rewrites the same `.py` files as `ruff --fix` and must run after
-it. `sync-with-uv` moved out of group 0 for the same reason: it rewrites
-`prek.toml`, which the builtin mutators in 1–4 also touch.
+Group 5 holds fixers that write *disjoint* file types — `ruff --fix` (`.py`),
+`markdownlint` (`.md`), `uv-lock` (`uv.lock`) — which is the condition upstream's
+warning actually turns on, so sharing a group is safe for them.
+
+Group 6 is for hooks that must follow something in 5:
+
+- `ruff-format` rewrites the same `.py` files as `ruff --fix`.
+- `sync-with-uv` **reads** `uv.lock` to update the `rev` lines in `prek.toml`,
+  and `uv-lock` writes `uv.lock`. This one is a read-after-write dependency
+  rather than two writers, which is a hazard the "do they write the same file?"
+  test does not catch — worth checking separately when placing a hook.
+
+`uv-sync` stays in group 5 despite also touching the environment, because its
+`stages` are `post-checkout`/`post-merge`/`post-rewrite`: it never runs in the
+same invocation as the `pre-commit` hooks it would otherwise contend with.
 
 **A new hook that writes files needs a priority no other hook writing those same
 files uses.** Since 0.4.11 these can be named via a `[priorities]` alias table

--- a/prek.toml
+++ b/prek.toml
@@ -52,9 +52,10 @@ hooks = [
 [[repos]]
 repo = "https://github.com/detailobsessed/sync-with-uv"
 rev = "v0.6.0-prek"
-# Priority 5, not 0: this rewrites prek.toml, which the builtin mutators in
-# groups 1-4 also touch.
-hooks = [{ id = "sync-with-uv", priority = 5 }]
+# Priority 6, not 0: it rewrites prek.toml, which the builtin mutators in groups
+# 1-4 also touch, and it READS uv.lock, which uv-lock rewrites in group 5. Both
+# hazards are ordering, not just concurrent writes.
+hooks = [{ id = "sync-with-uv", priority = 6 }]
 
 [[repos]]
 repo = "https://github.com/betterleaks/betterleaks"

--- a/prek.toml
+++ b/prek.toml
@@ -16,11 +16,16 @@ default_install_hook_types = ["commit-msg", "post-checkout", "post-merge", "post
 [update.repos."https://github.com/lycheeverse/lychee"]
 exclude_tags = ["nightly"]
 
+# Priorities schedule hooks: ascending order, same value runs concurrently.
+# Per prek's reference, two hooks in one group that mutate the same files have
+# "undefined" results, and a group that modifies files fails as a whole with no
+# attribution to the hook responsible. Read-only checks share group 0; each
+# builtin file mutator gets its own group so both problems go away.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-hook-priorities
 [[repos]]
 repo = "builtin"
 hooks = [
-  { id = "trailing-whitespace", priority = 0 },
-  { id = "end-of-file-fixer", priority = 0 },
+  # 0 — read-only checks, safe to run concurrently
   { id = "check-yaml", args = ["--allow-multiple-documents"], priority = 0 },
   { id = "check-toml", priority = 0 },
   { id = "check-json", priority = 0 },
@@ -32,27 +37,35 @@ hooks = [
   { id = "check-shebang-scripts-are-executable", priority = 0 },
   { id = "check-illegal-windows-names", priority = 0 },
   { id = "destroyed-symlinks", priority = 0 },
-  { id = "mixed-line-ending", args = ["--fix=lf"], priority = 0 },
-  { id = "fix-byte-order-marker", priority = 0 },
   { id = "forbid-new-submodules", priority = 0 },
   { id = "detect-private-key", priority = 0 },
+
+  # 1-4 — file mutators, serialised. Order is also semantic:
+  # end-of-file-fixer runs last so it sees the final byte of the file after
+  # line endings are normalised and the BOM is gone.
+  { id = "trailing-whitespace", priority = 1 },
+  { id = "mixed-line-ending", args = ["--fix=lf"], priority = 2 },
+  { id = "fix-byte-order-marker", priority = 3 },
+  { id = "end-of-file-fixer", priority = 4 },
 ]
 
 [[repos]]
 repo = "https://github.com/detailobsessed/sync-with-uv"
 rev = "v0.6.0-prek"
-hooks = [{ id = "sync-with-uv", priority = 0 }]
+# Priority 5, not 0: this rewrites prek.toml, which the builtin mutators in
+# groups 1-4 also touch.
+hooks = [{ id = "sync-with-uv", priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/betterleaks/betterleaks"
 rev = "v1.7.2"
-hooks = [{ id = "betterleaks", priority = 1 }]
+hooks = [{ id = "betterleaks", priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"
 rev = "v4.4.0"
 hooks = [
-  { id = "conventional-pre-commit", stages = ["commit-msg"], priority = 1, args = [
+  { id = "conventional-pre-commit", stages = ["commit-msg"], priority = 5, args = [
     "--strict",
     "--verbose",
     "feat",
@@ -72,27 +85,28 @@ hooks = [
 repo = "https://github.com/astral-sh/ruff-pre-commit"
 rev = "v0.16.0"
 hooks = [
-  { id = "ruff", args = ["--fix"], priority = 1 },
-  { id = "ruff-format", priority = 1 },
+  # ruff-format must follow ruff --fix, and both rewrite the same .py files.
+  { id = "ruff", args = ["--fix"], priority = 5 },
+  { id = "ruff-format", priority = 6 },
 ]
 
 [[repos]]
 repo = "https://github.com/shellcheck-py/shellcheck-py"
 rev = "v0.11.0.1"
-hooks = [{ id = "shellcheck", priority = 1 }]
+hooks = [{ id = "shellcheck", priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
 rev = "0.12.0"
 hooks = [
-  { id = "uv-lock", priority = 1 },
-  { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 1 },
+  { id = "uv-lock", priority = 5 },
+  { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 5 },
 ]
 
 [[repos]]
 repo = "https://github.com/rhysd/actionlint"
 rev = "v1.7.12"
-hooks = [{ id = "actionlint", priority = 1 }]
+hooks = [{ id = "actionlint", priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/crate-ci/typos"
@@ -103,12 +117,12 @@ rev = "v1.48.0"
 # REPLACES the upstream list rather than appending, which is what drops the
 # write flag here. Keep `--force-exclude`: it is what makes typos honour
 # _typos.toml when prek passes explicit staged filenames.
-hooks = [{ id = "typos", args = ["--force-exclude"], priority = 1 }]
+hooks = [{ id = "typos", args = ["--force-exclude"], priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
 rev = "v0.49.1"
-hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], priority = 1 }]
+hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
@@ -117,7 +131,7 @@ repo = "https://github.com/lycheeverse/lychee"
 # Note: never put a comment on the same line as `rev` — sync-with-uv anchors its
 # rev regex at end-of-line, so a trailing comment silently disables it (DOT-603).
 rev = "lychee-v0.24.2"
-hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
+hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 5, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]
 repo = "local"
@@ -129,7 +143,7 @@ entry = "uv run ty check"
 language = "system"
 types = ["python"]
 pass_filenames = false
-priority = 1
+priority = 5
 
 [[repos.hooks]]
 id = "pytest-cov"
@@ -140,4 +154,4 @@ types = ["python"]
 pass_filenames = false
 verbose = true
 stages = ["pre-push"]
-priority = 1
+priority = 5

--- a/prek.toml
+++ b/prek.toml
@@ -19,7 +19,6 @@ exclude_tags = ["nightly"]
 [[repos]]
 repo = "builtin"
 hooks = [
-  { id = "no-commit-to-branch", args = ["--branch", "main"], priority = 0 },
   { id = "trailing-whitespace", priority = 0 },
   { id = "end-of-file-fixer", priority = 0 },
   { id = "check-yaml", args = ["--allow-multiple-documents"], priority = 0 },
@@ -34,6 +33,8 @@ hooks = [
   { id = "check-illegal-windows-names", priority = 0 },
   { id = "destroyed-symlinks", priority = 0 },
   { id = "mixed-line-ending", args = ["--fix=lf"], priority = 0 },
+  { id = "fix-byte-order-marker", priority = 0 },
+  { id = "forbid-new-submodules", priority = 0 },
   { id = "detect-private-key", priority = 0 },
 ]
 

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -37,6 +37,10 @@ hooks = [
   { id = "check-illegal-windows-names", priority = 0 },
   { id = "destroyed-symlinks", priority = 0 },
   { id = "mixed-line-ending", args = ["--fix=lf"], priority = 0 },
+  # A UTF-8 BOM makes TOML parsers and `#!` lines fail in ways the error
+  # message never attributes to an invisible three-byte prefix.
+  { id = "fix-byte-order-marker", priority = 0 },
+  { id = "forbid-new-submodules", priority = 0 },
   { id = "detect-private-key", priority = 0 },
 ]
 

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -18,11 +18,16 @@ exclude_tags = ["nightly"]
 # Put per-repo notes on the line above.
 # https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-rev-lines
 
+# Priorities schedule hooks: ascending order, same value runs concurrently.
+# Per prek's reference, two hooks in one group that mutate the same files have
+# "undefined" results, and a group that modifies files fails as a whole with no
+# attribution to the hook responsible. Read-only checks share group 0; each
+# builtin file mutator gets its own group so both problems go away.
+# https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-hook-priorities
 [[repos]]
 repo = "builtin"
 hooks = [
-  { id = "trailing-whitespace", priority = 0 },
-  { id = "end-of-file-fixer", priority = 0 },
+  # 0 — read-only checks, safe to run concurrently
   { id = "check-yaml", args = ["--allow-multiple-documents"], priority = 0 },
   { id = "check-toml", priority = 0 },
   { id = "check-json", priority = 0 },
@@ -36,30 +41,38 @@ hooks = [
   { id = "check-shebang-scripts-are-executable", priority = 0 },
   { id = "check-illegal-windows-names", priority = 0 },
   { id = "destroyed-symlinks", priority = 0 },
-  { id = "mixed-line-ending", args = ["--fix=lf"], priority = 0 },
-  # A UTF-8 BOM makes TOML parsers and `#!` lines fail in ways the error
-  # message never attributes to an invisible three-byte prefix.
-  { id = "fix-byte-order-marker", priority = 0 },
   { id = "forbid-new-submodules", priority = 0 },
   { id = "detect-private-key", priority = 0 },
+
+  # 1-4 — file mutators, serialised. The order is also semantic: a UTF-8 BOM
+  # makes TOML parsers and `#!` lines fail with errors that never mention an
+  # invisible three-byte prefix, and end-of-file-fixer runs last so it sees the
+  # final byte after line endings are normalised and the BOM is stripped.
+  { id = "trailing-whitespace", priority = 1 },
+  { id = "mixed-line-ending", args = ["--fix=lf"], priority = 2 },
+  { id = "fix-byte-order-marker", priority = 3 },
+  { id = "end-of-file-fixer", priority = 4 },
 ]
 
 [[repos]]
 repo = "https://github.com/detailobsessed/sync-with-uv"
 rev = ""
-hooks = [{ id = "sync-with-uv", priority = 0 }]
+# Priority 5, not 0: this rewrites prek.toml, which the builtin mutators in
+# groups 1-4 also touch.
+hooks = [{ id = "sync-with-uv", priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/betterleaks/betterleaks"
 rev = ""
-hooks = [{ id = "betterleaks", priority = 1 }]
+hooks = [{ id = "betterleaks", priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
 rev = ""
 hooks = [
-  { id = "ruff", args = ["--fix"], priority = 1 },
-  { id = "ruff-format", priority = 1 },
+  # ruff-format must follow ruff --fix, and both rewrite the same .py files.
+  { id = "ruff", args = ["--fix"], priority = 5 },
+  { id = "ruff-format", priority = 6 },
 ]
 
 [[repos]]
@@ -71,20 +84,20 @@ rev = ""
 # before changing it.
 # https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-uv-sync-locked
 hooks = [
-  { id = "uv-lock", priority = 1 },
-  { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 1 },
+  { id = "uv-lock", priority = 5 },
+  { id = "uv-sync", stages = ["post-checkout", "post-merge", "post-rewrite"], priority = 5 },
 ]
 
 [[repos]]
 repo = "https://github.com/shellcheck-py/shellcheck-py"
 rev = ""
-hooks = [{ id = "shellcheck", priority = 1 }]
+hooks = [{ id = "shellcheck", priority = 5 }]
 {%- if repository_provider == "github.com" %}
 
 [[repos]]
 repo = "https://github.com/rhysd/actionlint"
 rev = ""
-hooks = [{ id = "actionlint", priority = 1 }]
+hooks = [{ id = "actionlint", priority = 5 }]
 {%- endif %}
 
 [[repos]]
@@ -94,19 +107,19 @@ rev = ""
 # files in place and has corrupted hex identifiers in checked-in data. Keep
 # `--force-exclude` — it is what makes typos honour _typos.toml.
 # https://detailobsessed.github.io/copier-uv-bleeding/generated-config/#prek-typos-args
-hooks = [{ id = "typos", args = ["--force-exclude"], priority = 1 }]
+hooks = [{ id = "typos", args = ["--force-exclude"], priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/igorshubovych/markdownlint-cli"
 rev = ""
-hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], priority = 1 }]
+hooks = [{ id = "markdownlint", args = ["--fix", "--ignore", "CHANGELOG.md"], priority = 5 }]
 
 [[repos]]
 repo = "https://github.com/lycheeverse/lychee"
 # The `nightly` tag is excluded in the `[update.repos]` block at the top of
 # this file, so a plain `prek update` keeps this on a versioned tag.
 rev = "lychee-v0.24.2"
-hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 1, types_or = ["markdown", "html", "rst", "yaml"] }]
+hooks = [{ id = "lychee", args = ["--config", ".lychee.toml"], priority = 5, types_or = ["markdown", "html", "rst", "yaml"] }]
 
 [[repos]]
 repo = "local"
@@ -128,7 +141,7 @@ entry = "uv run ty check"
 language = "system"
 types = ["python"]
 pass_filenames = false
-priority = 1
+priority = 5
 
 [[repos.hooks]]
 id = "pytest-testmon"
@@ -139,7 +152,7 @@ types = ["python"]
 pass_filenames = false
 verbose = true
 stages = ["pre-commit"]
-priority = 1
+priority = 5
 
 {%- if use_heavy_hooks %}
 
@@ -152,7 +165,7 @@ types = ["python"]
 pass_filenames = false
 verbose = true
 stages = ["pre-push"]
-priority = 1
+priority = 5
 {%- endif %}
 
 [[repos.hooks]]
@@ -176,7 +189,7 @@ stages = ["post-checkout"]
 repo = "https://github.com/compilerla/conventional-pre-commit"
 rev = ""
 hooks = [
-  { id = "conventional-pre-commit", stages = ["commit-msg"], priority = 1, args = [
+  { id = "conventional-pre-commit", stages = ["commit-msg"], priority = 5, args = [
     "--verbose",
     "feat",
     "fix",

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -57,9 +57,10 @@ hooks = [
 [[repos]]
 repo = "https://github.com/detailobsessed/sync-with-uv"
 rev = ""
-# Priority 5, not 0: this rewrites prek.toml, which the builtin mutators in
-# groups 1-4 also touch.
-hooks = [{ id = "sync-with-uv", priority = 5 }]
+# Priority 6, not 0: it rewrites prek.toml, which the builtin mutators in groups
+# 1-4 also touch, and it READS uv.lock, which uv-lock rewrites in group 5. Both
+# hazards are ordering, not just concurrent writes.
+hooks = [{ id = "sync-with-uv", priority = 6 }]
 
 [[repos]]
 repo = "https://github.com/betterleaks/betterleaks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ dev = [
     "pytest-cov>=7.0.0",
     "pytest-randomly>=4",
     "pytest-xdist>=3.5",
+    # Not just for running hooks: tests/test_template.py shells out to
+    # `prek util list-builtins` to check the template's builtin ids are real.
+    # Without it as a dependency that test silently skips in CI.
+    "prek>=0.4.10",
     "python-semantic-release>=10.6",
     "pyyaml>=6.0.3",
     "reuse",

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -336,6 +336,46 @@ class TestPreCommitConfig:
                 f"keep --force-exclude so _typos.toml exclusions still apply when prek passes explicit filenames; got {args!r}"
             )
 
+    @pytest.mark.skipif(shutil.which("prek") is None, reason="prek is not on PATH; it is not a dev dependency of this repo")
+    def test_builtin_hook_ids_are_real(self, copier_defaults: dict, project_factory) -> None:
+        """Every `repo = "builtin"` hook id must exist in `prek util list-builtins`.
+
+        A typo'd or retired builtin id is not a hard error at config-parse time,
+        so the hook simply never runs — the same "reports success while doing
+        nothing" shape as DOT-603 and DOT-604.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        configured = {hook["id"] for repo in data["repos"] if repo.get("repo") == "builtin" for hook in repo.get("hooks", [])}
+        assert configured, "expected a builtin repo block in prek.toml"
+
+        result = subprocess.run(["prek", "util", "list-builtins"], capture_output=True, text=True, check=True)
+        available = set(result.stdout.split())
+
+        assert configured <= available, f"not real prek builtins: {sorted(configured - available)}"
+
+    def test_no_commit_to_branch_is_not_shipped(self, copier_defaults: dict, project_factory) -> None:
+        """Generated projects must not block commits to their default branch.
+
+        `no-commit-to-branch` is a workflow opinion, not a correctness check.
+        This template has users who commit straight to main by choice; shipping
+        the hook would break that on the first commit with no way to discover
+        why beyond reading prek.toml. Kept out on purpose — the maintainers'
+        own prek.toml is where a branch policy belongs, not the template's.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        ids = [hook["id"] for repo in data["repos"] for hook in repo.get("hooks", [])]
+        assert "no-commit-to-branch" not in ids, (
+            "no-commit-to-branch imposes a branching workflow on every generated project; leave that to the user."
+        )
+
     def test_has_typos_config(self, copier_defaults: dict, project_factory) -> None:
         """Generated project ships a _typos.toml excluding generated files (DOT-604).
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -414,6 +414,15 @@ class TestPreCommitConfig:
                 "and formatting must come after fixing."
             )
 
+        # Read-after-write, not two writers: sync-with-uv reads uv.lock to
+        # update prek.toml's rev lines, and uv-lock writes uv.lock. Sharing a
+        # group lets sync-with-uv read a stale lockfile and silently sync
+        # nothing, which the same-file check above would not catch.
+        if {"uv-lock", "sync-with-uv"} <= priorities.keys():
+            assert priorities["uv-lock"] < priorities["sync-with-uv"], (
+                "sync-with-uv reads the uv.lock that uv-lock writes, so uv-lock must run in an earlier priority group."
+            )
+
     def test_no_commit_to_branch_is_not_shipped(self, copier_defaults: dict, project_factory) -> None:
         """Generated projects must not block commits to their default branch.
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -336,13 +336,15 @@ class TestPreCommitConfig:
                 f"keep --force-exclude so _typos.toml exclusions still apply when prek passes explicit filenames; got {args!r}"
             )
 
-    @pytest.mark.skipif(shutil.which("prek") is None, reason="prek is not on PATH; it is not a dev dependency of this repo")
     def test_builtin_hook_ids_are_real(self, copier_defaults: dict, project_factory) -> None:
         """Every `repo = "builtin"` hook id must exist in `prek util list-builtins`.
 
         A typo'd or retired builtin id is not a hard error at config-parse time,
         so the hook simply never runs — the same "reports success while doing
         nothing" shape as DOT-603 and DOT-604.
+
+        `prek` is a dev dependency specifically so this runs in CI rather than
+        only on machines that happen to have it installed.
         """
         project = project_factory(copier_defaults)
 
@@ -355,7 +357,62 @@ class TestPreCommitConfig:
         result = subprocess.run(["prek", "util", "list-builtins"], capture_output=True, text=True, check=True)
         available = set(result.stdout.split())
 
+        # Guard the parse itself: this asserts a subset relation, so an output
+        # format that stops being one-bare-id-per-line would make `available`
+        # junk and the assertion below vacuously true rather than failing.
+        assert "trailing-whitespace" in available, (
+            f"could not parse `prek util list-builtins`; expected bare ids, got {result.stdout[:200]!r}"
+        )
+
         assert configured <= available, f"not real prek builtins: {sorted(configured - available)}"
+
+    def test_file_mutating_hooks_do_not_share_a_priority(self, copier_defaults: dict, project_factory) -> None:
+        """Hooks writing the same files must not share a priority group.
+
+        prek's reference calls two same-group hooks mutating the same files
+        "undefined", and a group that modifies files fails as a whole with no
+        attribution to the hook responsible. Measured at 12/40 files losing
+        their trailing-whitespace fix with three such hooks sharing group 0,
+        and 0/40 once each got its own.
+        """
+        project = project_factory(copier_defaults)
+
+        with (project / "prek.toml").open("rb") as f:
+            data = tomllib.load(f)
+
+        # Every hook that writes to the files it is handed. `typos` is absent on
+        # purpose — the template drops upstream's --write-changes, so it only
+        # reports (see test_typos_hook_does_not_write_changes).
+        #
+        # The universal ones run over every text file, so they overlap with each
+        # other AND with every scoped fixer below. The scoped ones write
+        # disjoint file types (.py / .md / prek.toml / uv.lock) and may safely
+        # share a group with each other — except ruff and ruff-format, which
+        # both rewrite .py.
+        universal = {"trailing-whitespace", "end-of-file-fixer", "mixed-line-ending", "fix-byte-order-marker"}
+        scoped = {"ruff", "ruff-format", "markdownlint", "sync-with-uv", "uv-lock"}
+
+        priorities: dict[str, int] = {}
+        for repo in data["repos"]:
+            for hook in repo.get("hooks", []):
+                if hook["id"] in universal | scoped:
+                    priorities[hook["id"]] = hook.get("priority", 0)
+
+        missing = universal - priorities.keys()
+        assert not missing, f"expected these mutating hooks in prek.toml: {sorted(missing)}"
+
+        for hook_id in universal:
+            clashes = [other for other, p in priorities.items() if other != hook_id and p == priorities[hook_id]]
+            assert not clashes, (
+                f"{hook_id!r} rewrites every text file and shares priority {priorities[hook_id]} with {clashes}; "
+                "concurrent writers lose each other's edits. Give it an unused priority."
+            )
+
+        if {"ruff", "ruff-format"} <= priorities.keys():
+            assert priorities["ruff"] < priorities["ruff-format"], (
+                "ruff --fix and ruff-format both rewrite .py files, so they must not share a priority, "
+                "and formatting must come after fixing."
+            )
 
     def test_no_commit_to_branch_is_not_shipped(self, copier_defaults: dict, project_factory) -> None:
         """Generated projects must not block commits to their default branch.

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,7 @@ dev = [
     { name = "jinja2" },
     { name = "markdown-callouts" },
     { name = "poethepoet" },
+    { name = "prek" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
@@ -177,6 +178,7 @@ dev = [
     { name = "jinja2" },
     { name = "markdown-callouts" },
     { name = "poethepoet" },
+    { name = "prek", specifier = ">=0.4.10" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-randomly", specifier = ">=4" },
@@ -552,6 +554,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5c/92/93a4af9511b8c7c647874521d9e6c904266be98067c2ee1eb2e74520d208/poethepoet-0.48.0.tar.gz", hash = "sha256:a06f49d244fadfc2e2e7faa78b54e64a9694727e4ce1d50e08f23cea3ded74f1", size = 148679, upload-time = "2026-07-05T21:48:30.106Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/8d/d7c9455b15f8d2d7ce57e7b71a8ef8d02d9992ae4283c9777120620c9022/poethepoet-0.48.0-py3-none-any.whl", hash = "sha256:98da6096d060f49b8d84034770265863fb7dc92a40233b7694b9d216ac68737d", size = 185808, upload-time = "2026-07-05T21:48:28.601Z" },
+]
+
+[[package]]
+name = "prek"
+version = "0.4.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1a/73b6dae5ce7e997cb35a69bfe1d25a798e85fa3d2eabf95324563f461b30/prek-0.4.11.tar.gz", hash = "sha256:4a14cb9bbae850605ae3904fbdbb12f0e00c12455efaa2266da8fb8e5c0350d7", size = 516254, upload-time = "2026-07-24T17:05:35.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/d7/a00b2de492a80e99b1698e72c1d196ac3ed544dc7ee0ada261ac066e78e0/prek-0.4.11-py3-none-linux_armv6l.whl", hash = "sha256:3830cb7cc47e837888b8b464ecb21355a69235cfacef0fd89101e17f09345d63", size = 5770511, upload-time = "2026-07-24T17:05:12.829Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1e/f97c74defcd5d5645888cb99fcdd9b8b48cc7247cf31e64414d106d56d66/prek-0.4.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:45facadf9c2332b28e6ab2744312ae0275a93ab5a437da8bcc53a8c7260cb4b0", size = 6118049, upload-time = "2026-07-24T17:05:14.451Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/92/8367d26421ee6fe6019a63928fb0ed31179cd0d6199879c524f89ef4c95c/prek-0.4.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2f8a194b1d00d24dff8baff691c99e2668339da2da3482b4ee99c1a0f2409378", size = 5601478, upload-time = "2026-07-24T17:05:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/6f/7617c9b87afaadede4167720aae7ef12d7e51167db903bc8fbac0cadef7b/prek-0.4.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:21d93e6d76bf3d7a9bb70c6ac86ef372adaee50068c45749e6b9e1c2ac4ec939", size = 5932071, upload-time = "2026-07-24T17:05:17.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/41/6796a4011b04212333259064aa885a71d03d9581ba9bff52db3ce58d1f06/prek-0.4.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7fb07cde2d2156efa6980122b3f13dc88f20c84b933c6205675d0f1e7be2cde8", size = 5677617, upload-time = "2026-07-24T17:05:18.658Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5f/3e339901f8460b6073313619b4fd9bf4135e48430695c53640b83ace88ea/prek-0.4.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6b7f5e446d2aca739bd18b380578e9c78bb4c086299abc3e167d51c47840c56f", size = 6106370, upload-time = "2026-07-24T17:05:20.219Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4e/94e24b5c1910ec15692ecaf33d0d8ef0d02a02a8b5e40d3c976396880cba/prek-0.4.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7059d640e595d098600e2d97af961f46292b4112670edbe632de84f6828389e", size = 6884342, upload-time = "2026-07-24T17:05:21.587Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7c/fc0daa033dcafe74990c00af2da1e16922790b9c1b8da7e8eebf1123838b/prek-0.4.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85a4df33998fcac878bce3b2c624e1caeb9609f3d562c640702c1234ed815daf", size = 6331365, upload-time = "2026-07-24T17:05:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/36/49f152b8f539930e9685cff0509695ce4054abcecc22f4c16c4e1e5c23d0/prek-0.4.11-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:866991f387527c5f880ce2cc3ddea9b33cc5b986881f8c7f92524cf0969c1350", size = 5939075, upload-time = "2026-07-24T17:05:24.249Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fe/7b097af9161edae7ddedcc9f5cda4a5f31346a492ce3f92583d96c46f628/prek-0.4.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:247e5d8740e137ebdf24fa96f01a95b2d2f1892e956a1ab00c7b1474a59ebcc0", size = 5799029, upload-time = "2026-07-24T17:05:25.652Z" },
+    { url = "https://files.pythonhosted.org/packages/49/63/dc955ff99e1002d3cd375b21467c87046bc41deddfce86d898240757b151/prek-0.4.11-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:603ba9f2fd9d666dddb3ae190a25a5c55091b843cde90ed52e0a1116f50d4062", size = 5651211, upload-time = "2026-07-24T17:05:27.027Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b8/bf2139ec25eefb5afef43afac7620c5181f2c2661f220598beacb1771207/prek-0.4.11-py3-none-musllinux_1_1_i686.whl", hash = "sha256:f2682ece3c5fc7201106c4fdd84b0587ccea4b8a2ecefa3e94d3074d2841f1df", size = 5954784, upload-time = "2026-07-24T17:05:28.391Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/29/3fe5990aee1bd7c4d50a03358ad867c5e912d9510aafb83a359c7347e5fa/prek-0.4.11-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:22721d30394192931fecc80d6fc6dd47e8ddf8db8b9693805aba8ec0f50087ec", size = 6448916, upload-time = "2026-07-24T17:05:29.837Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fb/abddacf43738302242ecd237236c7c80cd7c1d27545e16e803770aee76e9/prek-0.4.11-py3-none-win32.whl", hash = "sha256:8b093e7624522146049e994d5cf283d01d71632b638620b79ae0f96afeaa2624", size = 5483539, upload-time = "2026-07-24T17:05:31.228Z" },
+    { url = "https://files.pythonhosted.org/packages/00/1e/c293f7a15cb93963c4be36a02e144b93f43906bc02644a3f04e5708e7453/prek-0.4.11-py3-none-win_amd64.whl", hash = "sha256:5a3d7c80b970b456e5f1bcec8382008ee1ae6a3f324a6b9bb4ff7e666ab0f3c4", size = 5861119, upload-time = "2026-07-24T17:05:32.479Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0c/05fe6eb9d6a54d0e02dfa8cc5ad6f86869bf953419ec15909a32466a28ee/prek-0.4.11-py3-none-win_arm64.whl", hash = "sha256:e7b0df37ce05e45a14a9da39ab104691474d72f139bf4f6c860f754763a322cb", size = 5626386, upload-time = "2026-07-24T17:05:33.813Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Started as a prek builtin audit; grew a correctness fix when the audit surfaced a scheduling bug.

1. **Drops `no-commit-to-branch`** from this repo's own `prek.toml`, plus the now-dead `SKIP:` entry in `ci.yml` that existed only to let CI past it. It was never in `project/prek.toml.jinja`, so generated projects are unaffected.
2. **Adds two builtins** to both configs — `fix-byte-order-marker` and `forbid-new-submodules`.
3. **Stops file-rewriting hooks from sharing a priority group**, in both configs.
4. **Adds `prek` as a dev dependency** so the new builtin-id test runs in CI rather than skipping.

## Why

### Builtin audit

`prek util list-builtins` reports 26; the template used 15. Two were worth adding:

| Hook | Why |
| -- | -- |
| `fix-byte-order-marker` | A UTF-8 BOM makes TOML parsers and `#!` lines fail with errors that never mention an invisible three-byte prefix. Same class of Windows-editor hygiene as the `mixed-line-ending` hook already present. Verified stripping `efbbbf` from a `.py` file. |
| `forbid-new-submodules` | A git submodule in a uv-managed Python project is close to always accidental. Zero config. |

Rejected deliberately: `requirements-txt-fixer` (no such file in a uv project), `check-json5` / `check-xml` (no such files), `pretty-format-json` (reformats rather than validates, would fight generated files), `deny-pattern` / `require-pattern` / `file-contents-sorter` (need per-project config), and `check-vcs-permalinks`, which was measured **passing** a plain branch URL and is far narrower than its name suggests.

### The priority bug the audit surfaced

Adding a fourth file-mutating hook to priority group 0 made an existing bug measurably worse. prek's reference is explicit:

> **Parallel hooks modifying files** — If two hooks run in the same priority group and both mutate the same files (or depend on shared state), results are **undefined**. Use separate priorities to avoid overlap.

> If a hook modifies files without emitting a non-zero exit code (e.g. `ruff format`), the priority group **as a whole** will fail. It is not possible for prek to attribute the failure to a specific hook in the group which modified files.

Both applied. `trailing-whitespace`, `end-of-file-fixer` and `mixed-line-ending` all sat in group 0, and `sync-with-uv` sat there too while rewriting `prek.toml`.

Measured on 40 files each carrying a BOM, trailing whitespace, CRLF endings and no final newline:

| Configuration | Kept trailing whitespace | Kept CRLF |
| -- | -- | -- |
| three mutators in group 0 (before this PR) | 12/40 | 3/40 |
| plus `fix-byte-order-marker`, also group 0 | 27/40 | 20/40 |
| one priority each | **0/40** | **0/40** |

Not corruption — prek fails the run and re-running converges — but convergence is nondeterministic, and "reports success while another hook's fix was discarded" is the failure shape this template treats as a bug. The attribution problem is the other half: `Files were modified by following hooks...Failed` with a dozen hooks listed `Passed` underneath tells you nothing about which one wrote.

### Layout

- **0** — read-only checks, safe concurrently
- **1–4** — builtin file mutators, one each. Order is semantic: `end-of-file-fixer` last, so it sees the real final byte after line endings are normalised and the BOM is stripped
- **5** — fixers writing disjoint file types: `ruff --fix` (`.py`), `markdownlint` (`.md`), `uv-lock` (`uv.lock`)
- **6** — hooks that must follow something in 5: `ruff-format` (same `.py` files as `ruff --fix`), `sync-with-uv` (**reads** the `uv.lock` that `uv-lock` writes)

`uv-sync` stays in group 5: its stages are `post-checkout`/`post-merge`/`post-rewrite`, so it never runs in the same invocation as the `pre-commit` hooks it would otherwise contend with.

Priority **aliases** (`[priorities]` table) would read better than bare integers, but they need prek 0.4.11 and the template floors at 0.4.10. Left as a follow-up and noted in the docs.

## Test plan

Three new tests in `tests/test_template.py`:

- `test_builtin_hook_ids_are_real` — every `repo = "builtin"` id must appear in `prek util list-builtins`. A typo'd id is not a config-parse error, so the hook would just never run. Includes a guard so a changed output format fails loudly instead of making the subset assertion vacuously true.
- `test_file_mutating_hooks_do_not_share_a_priority` — universal mutators get unique priorities; `ruff` before `ruff-format`; `uv-lock` before `sync-with-uv`.
- `test_no_commit_to_branch_is_not_shipped` — pins the deliberate choice not to impose a branching workflow on generated projects.

Manual verification, all in throwaway repos:

- `prek util list-builtins` → 26 ids, confirming the audit set
- BOM strip confirmed byte-level (`efbbbf` prefix removed)
- The 40-file matrix above, per configuration
- The final scheme converges in a single pass: 0/40 on all four defects
- `prek validate-config` passes on both configs

CI green. `docs/generated-config.md` gains a `#prek-hook-priorities` section; the stale priority note in `CLAUDE.md` is corrected.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add BOM and submodule builtins to prek config and serialize file-mutating hooks by priority
> - Removes `no-commit-to-branch` from [prek.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/343/files#diff-72359463e1c50ddcb8dfabe900898a8f1d92416bbe6754f2e497f62d96232021) and the generated [project/prek.toml.jinja](https://github.com/detailobsessed/copier-uv-bleeding/pull/343/files#diff-3bb60cac251bd25ef247f1ff0e7aaf608d18c1c489585fc8aef396b888bb554c) template; adds `forbid-new-submodules` as a read-only check at priority 0.
> - Moves file-mutating builtin hooks (`trailing-whitespace`, `mixed-line-ending`, `fix-byte-order-marker`, `end-of-file-fixer`) to serialized priorities 1–4 so they never run concurrently with each other; read-only checks stay at priority 0 and fixers (ruff, uv-lock, etc.) move to 5, with dependents like `ruff-format` and `sync-with-uv` at 6.
> - Adds tests enforcing that file-mutating hooks have unique priorities, that `no-commit-to-branch` is not present in generated configs, and that all configured builtin hook IDs exist in `prek util list-builtins` output.
> - Adds `prek>=0.4.10` to the `dev` extras in [pyproject.toml](https://github.com/detailobsessed/copier-uv-bleeding/pull/343/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) so the new builtin-validation tests run in CI.
> - Behavioral Change: generated project configs and this repo's own hooks now run in a deterministic priority order; any project relying on the previous concurrent execution of file-mutating builtins will see them run serially.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85a3e12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->