### PR TITLE
ci: bump pinned actions and SHA-pin generated workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
       id: filter
       with:
         filters: |
@@ -52,9 +52,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Check links
-      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+      uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
       with:
         fail: true
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,15 +63,15 @@ jobs:
   prek:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         python-version: "3.14"
         enable-cache: true
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Refresh lockfile
       run: uv lock
-    - uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
+    - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
       env:
         SKIP: pytest-cov,lychee,uv-lock
       with:
@@ -84,7 +84,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -96,7 +96,7 @@ jobs:
         git config --global user.name "I Choose to Accept"
 
     - name: Setup uv and Python
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         python-version: "3.14"
         enable-cache: true
@@ -120,7 +120,7 @@ jobs:
       run: uv run pytest tests/test_template.py tests/test_template_lint.py -v --cov=tests --cov-report=term-missing
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: main
         fetch-depth: 0
         fetch-tags: true
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         python-version: "3.14"
         enable-cache: true

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -38,8 +38,8 @@ jobs:
     outputs:
       src: {% raw %}${{ steps.filter.outputs.src }}{% endraw %}
     steps:
-    - uses: actions/checkout@v6
-    - uses: dorny/paths-filter@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
       id: filter
       with:
         filters: |
@@ -57,15 +57,15 @@ jobs:
     runs-on: ubuntu-latest
 {%- endif %}
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         python-version: "3.14"
         enable-cache: true
         github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
     - name: Refresh lockfile
       run: uv lock
-    - uses: j178/prek-action@v1
+    - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
       env:
         SKIP: pytest-testmon,uv-lock
       with:
@@ -82,13 +82,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         fetch-tags: true
 
     - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         python-version: "3.14"
         enable-cache: true
@@ -142,13 +142,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
         fetch-tags: true
 
     - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
 {%- if publish_to_pypi %}
         python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
@@ -180,7 +180,7 @@ jobs:
       if: {% raw %}${{ matrix.os == 'ubuntu-latest' && matrix.resolution == 'highest' }}{% endraw %}
 {%- endif %}
 {%- endif %}
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: {% raw %}${{ secrets.CODECOV_TOKEN }}{% endraw %}
         fail_ci_if_error: false

--- a/project/.github/workflows/release.yml.jinja
+++ b/project/.github/workflows/release.yml.jinja
@@ -26,14 +26,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: main
         fetch-depth: 0
         fetch-tags: true
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         python-version: "3.14"
         enable-cache: true
@@ -79,12 +79,12 @@ jobs:
       id-token: write
     steps:
     - name: Checkout release tag
-      uses: actions/checkout@v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: {% raw %}${{ needs.release.outputs.tag }}{% endraw %}
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         python-version: "3.14"
         github-token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}


### PR DESCRIPTION
## Summary

Action version bumps in two places: this repo's own workflows (via `actions-up`), and
the generated project's workflow templates, which had drifted up to two majors behind
because `actions-up` does not scan `.jinja` files.

| | This repo was | Template was | Now |
| --- | --- | --- | --- |
| `astral-sh/setup-uv` | v8.0.0 | `@v7` | v9.0.0 |
| `j178/prek-action` | v2.0.1 | `@v1` | v3.0.0 |
| `codecov/codecov-action` | v6.0.0 | `@v5` | v7.0.0 |
| `actions/checkout` | v6.0.2 | `@v6` | v7.0.1 |
| `dorny/paths-filter` | v4.0.1 | `@v3` | v4.0.2 |
| `re-actors/alls-green` | v1.2.2 | v1.2.2 | unchanged, already latest |

## Why

**The move from floating major tags to SHAs in the template is forced, not stylistic.**
`setup-uv` stopped publishing major/minor tags at v8 and `prek-action` at v3, both
citing the tj-actions supply-chain attack — a retargetable `@v8` is the vector.
Confirmed against the remotes rather than taken from release notes:

```
setup-uv:     v7 v7.0 v7.0.0 v7.1 ... v7.6.0   v8.0.0   v9.0.0
prek-action:  v1 v2 v2.0 v2.0.0 ... v2.0.6     v3.0.0
```

There is no `@v8`, `@v9` or `@v3` to move to, so the template could not have stayed on
floating majors. Pinning the rest the same way keeps one convention per file and
matches `re-actors/alls-green`, which was already SHA-pinned there. Every SHA was
verified to resolve to its commented tag via `git ls-remote` before being written.

Generated workflows are not in `_skip_if_exists`, so these pins reach existing projects
on the next `copier update`.

**No breaking change reaches either this repo or a generated project:**

- **checkout v7** blocks checking out a fork PR under `pull_request_target` and
  `workflow_run`. Both `release.yml` files are `workflow_run`, but gated to
  `branches: [main]` with an explicit `ref: main`, not the triggering head.
- **setup-uv v8** removed the deprecated `manifest-file` format (unused here) and the
  floating tags; **v9** flips `prune-cache` to `false`, which only grows the cache.
- **prek-action v2** was a TypeScript rewrite; the inputs used here (`extra-args`, and
  `SKIP` via `env`) are unchanged through v3.
- **codecov v6** and **paths-filter v4** moved to the node24 runtime, which current
  GitHub runners provide. The codecov inputs used here are unchanged.

## Test plan

- `pytest tests/test_template_lint.py` — 39 passed
- Rendered a project and ran `actionlint` over both generated workflows — exit 0
- Verified each SHA against `git ls-remote` before writing it; a wrong `# vX.Y.Z`
  comment would silently mislead every future `actions-up` run

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pins third-party actions in the generated CI and release workflow templates to immutable commit SHAs. A representative project generated with CI, semantic-release, and PyPI publishing enabled produced valid YAML for both workflows, with all 10 rendered action references pinned to 40-character SHAs. The template lint suite passed with 39 tests.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge; no blocking failure remains.

Generated CI and release workflows parsed successfully, retained the expected action references, and passed the repository's template-lint coverage.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated a Copier project from the parent and PR versions with CI, semantic-release, and PyPI publishing enabled.
- Validated the generated workflows parsed as YAML and observed the change in action references: the parent had nine version-tag references and the PR had ten SHA-based references.
- Ran tests with pytest against tests/test\_template\_lint.py on both versions and confirmed all 39 tests passed in each run.
- Performed repository consistency checks, including a diff check and whitespace verification, and confirmed no repository files were modified.

<a href="https://app.greptile.com/trex/runs/17414748/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["ci(template): pin generated workflow act..."](https://github.com/detailobsessed/copier-uv-bleeding/commit/fdb0a181eaf2f50a52d3b17be9d5b9512a7a7a43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50345456)</sub>

<!-- /greptile_comment -->