### PR TITLE
docs: scope Linear reporting to this project and pin Closes-line discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A **Copier template** that generates production-ready Python 3.14+ projects. The `project/` directory contains Jinja templates rendered by `copier copy`. Changes here don't run directly -- they produce scaffolded projects, so every change must be valid across all combinations of user answers.
 
+## Issue Tracking
+
+Linear issues for this repo live in the **`copier-uv-bleeding` project** on the `Detail Obsessed` (DOT) team. When working in this repo, only report on issues in that Linear project -- the DOT team also holds unrelated work (a macOS app, career/website tasks) that is noise here. `list_issues` takes `project: "copier-uv-bleeding"`.
+
+Linear only auto-closes on a bare `Closes DOT-NNN` line -- `Refs DOT-NNN` attaches the PR without closing. **When adding a commit to an already-open PR, re-check the PR body's `Closes`/`Refs` lines**: a fix appended to a stack after the body was written closes nothing (DOT-629 shipped in #345 and stayed in Backlog for exactly this reason).
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Two repo-local rules in `CLAUDE.md`:

1. Linear queries from this repo filter to the **`copier-uv-bleeding` project**, not the whole DOT team.
2. Re-check a PR body's `Closes`/`Refs` lines whenever a commit is **appended to an already-open PR**.

## Why

**Rule 1** is noise reduction. The DOT team also tracks a macOS app and career/website work. An unfiltered `list_issues` returns sixty rows to surface the eight that concern this template.

**Rule 2** is the DOT-629 post-mortem. Linear's GitHub integration closes on a bare `Closes DOT-NNN` and deliberately does *not* close on `Refs`. #345 carried exactly one tracker line — `Refs DOT-620` — written when the PR held three commits. The testmon fix landed as a fourth commit afterwards and named DOT-629 nowhere: not in its own message, not in the body. It shipped in 0.41.13 and the issue stayed in Backlog until someone audited by hand.

The failure mode is specific to stacked PRs, where the body is written once and the commits keep arriving.

## Test plan

Documentation only — no code paths touched. `prek` hooks (markdownlint, typos, lychee) pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds repository-local Linear guidance for contributors working on this Copier template. The new instructions scope issue searches to the `copier-uv-bleeding` project, distinguish closing references from non-closing references, and remind authors to update issue references when appending work to an open PR.

The updated guidance was checked against the previous and current versions of `CLAUDE.md`: the new version contains the required project filter and clearly defines the separate `Closes DOT-NNN` and `Refs DOT-NNN` behaviors. No defects were found.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the review-authored checker against the parent CLAUDE.md and the updated CLAUDE.md; the parent failed due to missing Linear guidance, while the updated version passed after identifying the copier-uv-bleeding project filter and distinct Closes DOT-NNN and Refs DOT-NNN conventions.
- Reviewed the executable script named linear-guidance-check.py to confirm it extracts the Issue Tracking contract and asserts the required project filter and Closes/Refs semantics.
- Compared the before and after logs to verify the pre-capture failure turned into a passing post-capture state.
- Mapped the supporting artifacts to verify the above conclusions, including the checker results and the linear guidance script and logs.

<a href="https://app.greptile.com/trex/runs/17455248/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: scope Linear reporting to this pro..."](https://github.com/detailobsessed/copier-uv-bleeding/commit/f135bc68381a70376f90d9004b31d8bd1aa21cbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50479627)</sub>

<!-- /greptile_comment -->