### PR TITLE
fix(template): stop chmodding scripts the template does not own

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -260,9 +260,23 @@ configure_repo_settings:
 
 
 # TASKS --------------------------------
+#
+# There is deliberately no `chmod +x` task here. It used to be
+# `chmod +x scripts/*.sh scripts/*.py`, which flipped the mode of *every* file
+# a downstream project keeps in `scripts/` — including its own shebang-less
+# ones, which then failed ruff's `EXE002` ("executable but no shebang") with no
+# `.rej` and no warning. The obvious recovery (`chmod 644 scripts/*.py`) then
+# trips `EXE001` on the legitimately-executable ones (DOT-628).
+#
+# It was never needed. Copier's own `_render_file` chmods each rendered file to
+# the template's mode, preferring the template's *git-index* exec bit over
+# `stat().st_mode` so it survives filesystems that don't carry the bit
+# (Windows), then syncs the destination's git index to match. That runs on
+# `copy` and `update` alike, and only for files copier actually renders — so
+# `scripts/check-template-update.sh` (committed 100755) arrives executable,
+# and files the template does not own are never touched. Verified against
+# copier 9.17.1.
 _tasks:
-  # Always run
-  - "chmod +x scripts/*.sh scripts/*.py 2>/dev/null || true"
   # Run `uv sync` in copier's temp render dirs (`old_copy`/`new_copy`) AND on
   # initial `copy`, but NOT in the real destination during update. Why this
   # inverted guard (`[ ! -d .git ]`) instead of the more obvious "only sync in

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import re
 import shutil
+import stat
 import subprocess
 import tomllib
 from typing import TYPE_CHECKING, ClassVar
@@ -1428,6 +1429,50 @@ class TestTemplateUpdateCheck:
             "copier.yml _tasks has `[ -d .git ]; then uv sync --upgrade` — the naive guard "
             "that lets copier delete the user's uv.lock and .venv on update. Use "
             "`[ ! -d .git ]` instead (see DOT-587 / DOT-588)."
+        )
+
+    def test_tasks_do_not_chmod_downstream_scripts(self) -> None:
+        """`_tasks` must not blanket-chmod `scripts/` (DOT-628).
+
+        The template owns exactly one file under `scripts/`. A downstream project keeps its
+        own one-off scripts in the same directory, and the template has no business changing
+        their modes. `chmod +x scripts/*.sh scripts/*.py` did exactly that: every shebang-less
+        `.py` a project kept there went 644 -> 755 on update, and ruff's `EXE002` turned a
+        lint-clean repo red with no `.rej` file to explain it.
+
+        Nothing replaces the task, because nothing needs to: copier chmods each rendered file
+        to the template's git-index mode itself (`_render_file`), on copy and update alike.
+        See `test_shipped_script_is_rendered_executable` for the other half of this pair.
+        """
+        copier_yml = pathlib.Path(__file__).resolve().parent.parent / "copier.yml"
+        task_lines = [line for line in copier_yml.read_text().splitlines() if line.lstrip().startswith("- ") and "chmod" in line]
+
+        assert not task_lines, (
+            "copier.yml _tasks contains a chmod task:\n"
+            + "\n".join(task_lines)
+            + "\n\nThe template must not change modes of files it does not own — a glob over "
+            "`scripts/` catches the downstream project's own scripts and breaks ruff EXE002 "
+            "(DOT-628). Copier already propagates the template's exec bits; if a newly "
+            "shipped script needs +x, commit it 100755 instead."
+        )
+
+    def test_shipped_script_is_rendered_executable(self, copier_defaults: dict, project_factory) -> None:
+        """The one script the template ships must arrive executable, with no chmod task.
+
+        This is the load-bearing half of DOT-628's fix: dropping the chmod task is only safe
+        because copier propagates the template's own mode. If `check-template-update.sh` were
+        ever committed 100644, the generated project's `check-shebang-scripts-are-executable`
+        hook would fail on the very first commit — so pin the rendered mode, not the source's.
+        """
+        project = project_factory(copier_defaults)
+
+        script = project / "scripts" / "check-template-update.sh"
+        assert script.stat().st_mode & 0o111, (
+            f"{script.name} rendered non-executable ({stat.filemode(script.stat().st_mode)}). "
+            "It has a shebang, so the generated project's `check-shebang-scripts-are-executable` "
+            "hook will block every commit. Commit `project/scripts/check-template-update.sh` "
+            "with mode 100755 (`git update-index --chmod=+x`) — do not add a chmod task, which "
+            "would re-introduce DOT-628."
         )
 
     def test_update_banner_does_not_claim_deps_synced(self) -> None:

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1445,11 +1445,19 @@ class TestTemplateUpdateCheck:
         See `test_shipped_script_is_rendered_executable` for the other half of this pair.
         """
         copier_yml = pathlib.Path(__file__).resolve().parent.parent / "copier.yml"
-        task_lines = [line for line in copier_yml.read_text().splitlines() if line.lstrip().startswith("- ") and "chmod" in line]
+        tasks = yaml.safe_load(copier_yml.read_text())["_tasks"]
 
-        assert not task_lines, (
+        # Parse the YAML rather than grepping lines. A copier task is either a bare command
+        # string or a mapping with `command` (plus `when`), and either form can put the
+        # command on a folded continuation line — `- command: >-` with the body indented
+        # underneath. A line-oriented filter sees no `chmod` on the `- ` line and passes
+        # while copier happily runs the task.
+        commands = [task if isinstance(task, str) else task.get("command", "") for task in tasks]
+        offenders = [command for command in commands if "chmod" in command]
+
+        assert not offenders, (
             "copier.yml _tasks contains a chmod task:\n"
-            + "\n".join(task_lines)
+            + "\n".join(offenders)
             + "\n\nThe template must not change modes of files it does not own — a glob over "
             "`scripts/` catches the downstream project's own scripts and breaks ruff EXE002 "
             "(DOT-628). Copier already propagates the template's exec bits; if a newly "


### PR DESCRIPTION
## Summary

Deletes the `chmod +x scripts/*.sh scripts/*.py` task from `copier.yml`'s `_tasks`. Adds two tests pinning both halves of why that is safe.

## Why

The task chmodded **every** file a downstream project keeps in `scripts/`, not just the one the template ships. Nine shebang-less files went `644 -> 755` on a routine 0.41.10 → 0.41.12 update, and ruff's `EXE002` ("file is executable but no shebang is present") took that repo from lint-clean to nine errors — with no `.rej` and no warning.

The obvious recovery is a trap of its own: `chmod 644 scripts/*.py` clears `EXE002` and raises `EXE001` on the scripts that legitimately have shebangs. The real recovery is `git checkout -- scripts/`, which nothing points you at.

**Deleted rather than narrowed, because the task was never needed.** Copier's `_render_file` already chmods each rendered file to the template's mode — preferring the template's *git-index* exec bit over `stat().st_mode`, so a bit committed by the template author survives filesystems that do not carry one (Windows) — then syncs the destination repo's index to match. It runs on `copy` and `update` alike, and only for files copier actually renders, so a downstream `scripts/probe.py` is never a candidate.

Confirmed two ways: in copier 9.17.1's source (`_main.py:862-907`), and empirically — rendering with `--skip-tasks`, which never ran the chmod, already produces `check-template-update.sh` at `755`.

That makes the template's *committed file mode* load-bearing, which is why there are two tests rather than one. Without `test_shipped_script_is_rendered_executable`, committing that file `644` would silently break `check-shebang-scripts-are-executable` on the first commit of every generated project.

## Test plan

- `test_tasks_do_not_chmod_downstream_scripts` — asserts no `chmod` task in `copier.yml`.
- `test_shipped_script_is_rendered_executable` — asserts the rendered `scripts/check-template-update.sh` has the exec bit, pinning the copier behaviour now doing the work.
- Fast suite: `202 passed`.

**Known gap:** no test exercises `_tasks` end-to-end — every copier invocation in the suite passes `--skip-tasks`, since running tasks means `uv sync --upgrade` (network, minutes). The first assertion is therefore structural on `copier.yml` text; the behavioural claim is covered by the second test plus the source reading above.

Closes DOT-628

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change removes the blanket `chmod` task and strengthens the regression check by parsing Copier task definitions as YAML.

The previously observed script-mode regression was exercised and disproved for this revision: a real Copier update leaves a downstream-owned shebang-less Python script at mode `0644`, while the template-owned `scripts/check-template-update.sh` remains executable at mode `0755`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking failure remains.

A real Copier copy/update flow confirmed that downstream-owned scripts keep their mode and the template-owned shell script remains executable.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a generated Bash harness with Copier 9.17.1 to create an old-template project, added downstream\_owned.py at mode 0644, and ran Copier updates with tasks enabled.
- The baseline update to 0.41.14 changed the downstream-owned file to mode 0755, reproducing the former blanket-chmod behavior.
- Updating from 0.41.14 to the revision left downstream\_owned.py at 0644 with no Git mode diff, and left scripts/check-template-update.sh at 0755.
- These results show that the removed task no longer changes downstream-owned script permissions while the template-owned script remains executable.
- Downstream-owned scripts remained at 0644 and the template-owned script stayed executable after the change, reproducing the baseline conditions described in the validation proof.

<a href="https://app.greptile.com/trex/runs/17581382/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["test: parse copier.yml as YAML in the ch..."](https://github.com/detailobsessed/copier-uv-bleeding/commit/15c02ed3fed4d46b6fee51c513663d52ffeff378) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50480157)</sub>

<!-- /greptile_comment -->