### PR TITLE
test: tolerate copier's temp-clone cleanup race on a dirty tree

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,33 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).parent.parent
+
+# The one copier failure the suite tolerates (DOT-606), matched as a whole rather than as
+# loose substrings. The `OSError` line must itself name a path under copier's own temp
+# clone: a render error's traceback also mentions that directory — every template frame
+# lives inside it — so `"copier._vcs.clone" in stderr` is nearly vacuous on its own.
+_CLONE_CLEANUP_RE = re.compile(
+    r"^OSError: \[Errno \d+\] Directory not empty: .*copier\._vcs\.clone\.",
+    re.MULTILINE,
+)
+
+# ...and it must have been raised *by* the cleanup, not merely alongside it.
+_CLEANUP_FRAME = ", in _cleanup"
+
+# A chained traceback means something failed first and the cleanup crash rode along on the
+# unwind. That is the dangerous shape: a partial render whose exception is followed by the
+# cleanup `OSError`, which would otherwise satisfy every check above.
+_CHAINED_EXCEPTION_MARKERS = (
+    "During handling of the above exception",
+    "The above exception was the direct cause",
+)
 
 
 @pytest.fixture
@@ -89,14 +110,30 @@ def _is_temp_clone_cleanup_failure(stderr: str, dst: Path) -> bool:
     first, so it reads as flakiness rather than as one deterministic bug. Re-running the
     "failed" test alone usually passes, which sends triage down the wrong path entirely.
 
-    Deliberately narrow. This tolerates only an `rmtree` of a path copier itself names
-    `copier._vcs.clone.*`, and only when the destination actually received a rendered
-    project. A render that genuinely failed leaves no `pyproject.toml`, and any other
-    non-zero exit still fails the test with copier's own stderr.
+    Deliberately narrow, because this is the one place a real copier failure could be
+    swallowed. All four must hold:
+
+    1. The final exception is an `OSError` naming a path under copier's own temp clone.
+    2. It was raised from a `_cleanup` frame — the cleanup is what failed, not something
+       that merely happened to mention the same directory.
+    3. Nothing failed before it. A chained traceback is exactly how a partial render would
+       present: its own exception, then the cleanup `OSError` raised while unwinding.
+    4. The destination actually received a render.
+
+    Independent substring checks are not enough for (1) and (2): every template frame in a
+    Jinja render error lives *inside* the temp clone, so a genuine render failure can put
+    `copier._vcs.clone` and `rmtree` in stderr on unrelated lines while `pyproject.toml` —
+    written early — already exists in the destination. Any other non-zero exit still fails
+    the test with copier's own stderr.
+
+    If copier renames `_cleanup`, this stops matching and DOT-606's dirty-tree failures
+    come back visibly. That is the intended direction to fail in.
     """
-    if "copier._vcs.clone" not in stderr:
+    if not _CLONE_CLEANUP_RE.search(stderr):
         return False
-    if not any(marker in stderr for marker in ("Directory not empty", "rmtree", "Errno 66")):
+    if _CLEANUP_FRAME not in stderr:
+        return False
+    if any(marker in stderr for marker in _CHAINED_EXCEPTION_MARKERS):
         return False
     return (dst / "pyproject.toml").is_file()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,10 +70,35 @@ def generate_project(
             cmd.extend(["-d", f"{key}={value}"])
 
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    if result.returncode != 0:
+    if result.returncode != 0 and not _is_temp_clone_cleanup_failure(result.stderr, tmp_path):
         pytest.fail(f"Copier failed: {result.stderr}")
 
     return tmp_path
+
+
+def _is_temp_clone_cleanup_failure(stderr: str, dst: Path) -> bool:
+    """True if copier rendered successfully but crashed clearing its own temp clone (DOT-606).
+
+    On a dirty working tree copier takes its dirty-file overlay path, which does extra git
+    work inside the temp clone it made of this repo. Something still holds a handle under
+    that clone's `.git` when `_cleanup` calls `rmtree(..., ignore_errors=False)`, so copier
+    exits non-zero *after* every file has been written. Observed on macOS with copier 9.17.x.
+
+    The effect is a test suite that is green in CI (which always checks out clean) and red
+    for anyone mid-change — with the failure landing on whichever test happens to render
+    first, so it reads as flakiness rather than as one deterministic bug. Re-running the
+    "failed" test alone usually passes, which sends triage down the wrong path entirely.
+
+    Deliberately narrow. This tolerates only an `rmtree` of a path copier itself names
+    `copier._vcs.clone.*`, and only when the destination actually received a rendered
+    project. A render that genuinely failed leaves no `pyproject.toml`, and any other
+    non-zero exit still fails the test with copier's own stderr.
+    """
+    if "copier._vcs.clone" not in stderr:
+        return False
+    if not any(marker in stderr for marker in ("Directory not empty", "rmtree", "Errno 66")):
+        return False
+    return (dst / "pyproject.toml").is_file()
 
 
 def _cache_key(answers: dict, project_type: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,12 @@ _CHAINED_EXCEPTION_MARKERS = (
     "The above exception was the direct cause",
 )
 
+# The race is intermittent — the same dirty tree renders fine on the next attempt — so a
+# re-render is the actual fix and stderr matching only decides whether to spend one. Three
+# is chosen against a measured hit rate around one render in ten; a run that loses the race
+# three times running fails, which is the safe direction.
+_MAX_RENDER_ATTEMPTS = 3
+
 
 @pytest.fixture
 def copier_defaults() -> dict:
@@ -90,15 +96,21 @@ def generate_project(
         else:
             cmd.extend(["-d", f"{key}={value}"])
 
-    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    if result.returncode != 0 and not _is_temp_clone_cleanup_failure(result.stderr, tmp_path):
-        pytest.fail(f"Copier failed: {result.stderr}")
+    for attempt in range(1, _MAX_RENDER_ATTEMPTS + 1):
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode == 0:
+            return tmp_path
+        # A non-zero exit is never accepted as success. The cleanup race only buys another
+        # attempt; if copier keeps failing, the last stderr is what the test reports.
+        if attempt < _MAX_RENDER_ATTEMPTS and _is_retryable_cleanup_race(result.stderr, tmp_path):
+            continue
+        pytest.fail(f"Copier failed (attempt {attempt}/{_MAX_RENDER_ATTEMPTS}): {result.stderr}")
 
     return tmp_path
 
 
-def _is_temp_clone_cleanup_failure(stderr: str, dst: Path) -> bool:
-    """True if copier rendered successfully but crashed clearing its own temp clone (DOT-606).
+def _is_retryable_cleanup_race(stderr: str, dst: Path) -> bool:
+    """True if copier's exit looks like the temp-clone cleanup race, so re-rendering is worth a shot (DOT-606).
 
     On a dirty working tree copier takes its dirty-file overlay path, which does extra git
     work inside the temp clone it made of this repo. Something still holds a handle under
@@ -110,24 +122,28 @@ def _is_temp_clone_cleanup_failure(stderr: str, dst: Path) -> bool:
     first, so it reads as flakiness rather than as one deterministic bug. Re-running the
     "failed" test alone usually passes, which sends triage down the wrong path entirely.
 
-    Deliberately narrow, because this is the one place a real copier failure could be
-    swallowed. All four must hold:
+    This decides whether to *retry*, never whether to accept a failure. That distinction is
+    what bounds the damage of a wrong answer: a false positive costs one extra render and
+    then fails with copier's real stderr anyway, and a false negative fails immediately —
+    which is what would have happened without any of this. Nothing is ever suppressed, so
+    no amount of cleverness in classifying stderr is load-bearing for correctness.
+
+    Still matched tightly, to keep pointless retries rare. All four must hold:
 
     1. The final exception is an `OSError` naming a path under copier's own temp clone.
     2. It was raised from a `_cleanup` frame — the cleanup is what failed, not something
        that merely happened to mention the same directory.
-    3. Nothing failed before it. A chained traceback is exactly how a partial render would
-       present: its own exception, then the cleanup `OSError` raised while unwinding.
+    3. Nothing failed before it. A chained traceback is how a partial render presents: its
+       own exception, then the cleanup `OSError` raised while unwinding.
     4. The destination actually received a render.
 
     Independent substring checks are not enough for (1) and (2): every template frame in a
     Jinja render error lives *inside* the temp clone, so a genuine render failure can put
     `copier._vcs.clone` and `rmtree` in stderr on unrelated lines while `pyproject.toml` —
-    written early — already exists in the destination. Any other non-zero exit still fails
-    the test with copier's own stderr.
+    written early — already exists in the destination.
 
-    If copier renames `_cleanup`, this stops matching and DOT-606's dirty-tree failures
-    come back visibly. That is the intended direction to fail in.
+    If copier renames `_cleanup`, this stops matching and the race stops being retried.
+    That is the intended direction to fail in.
     """
     if not _CLONE_CLEANUP_RE.search(stderr):
         return False

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 import yaml
-from conftest import REPO_ROOT, _is_temp_clone_cleanup_failure, generate_project
+from conftest import REPO_ROOT, _is_retryable_cleanup_race, generate_project
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -2655,14 +2655,16 @@ class TestIntegration:
 
 
 class TestTempCloneCleanupTolerance:
-    """Pin the boundary of `conftest._is_temp_clone_cleanup_failure` (DOT-606).
+    """Pin the boundary of `conftest._is_retryable_cleanup_race` (DOT-606).
 
-    That helper is the one place in the suite where a non-zero copier exit is suppressed,
-    and both directions of drift are silent. Widen it and a genuine render failure passes
-    as a green test; narrow it and the dirty-tree failures it exists to absorb come back.
-    Neither shows up in the integration tests, which only ever see whichever exit copier
-    happens to produce on the machine running them — on a clean tree, that is exit 0 and
-    this helper is never consulted at all.
+    The helper decides whether a failed render is worth re-running, so a wrong answer costs
+    a wasted render or an early failure — never a swallowed one. It is still worth pinning:
+    widen it and the suite burns three renders on every genuinely broken template; narrow it
+    and DOT-606's dirty-tree failures stop being retried and come back.
+
+    The integration tests cannot cover this. They only see whichever exit copier produces on
+    the machine running them, and on a clean tree that is exit 0 with the helper never
+    consulted at all.
     """
 
     # Trimmed from a real failure: dirty tree, `copier copy -r HEAD`, copier 9.17.1 on
@@ -2707,7 +2709,7 @@ jinja2.exceptions.TemplateSyntaxError: unexpected '}'
 
     def test_accepts_a_cleanup_only_failure(self, tmp_path: Path) -> None:
         """The one shape this exists for: render finished, `_cleanup` could not rmtree."""
-        assert _is_temp_clone_cleanup_failure(self.CLEANUP_ONLY, self._with_render(tmp_path))
+        assert _is_retryable_cleanup_race(self.CLEANUP_ONLY, self._with_render(tmp_path))
 
     def test_rejects_partial_render_with_chained_cleanup_failure(self, tmp_path: Path) -> None:
         """The dangerous case: a real render error whose unwind also trips the cleanup.
@@ -2716,22 +2718,22 @@ jinja2.exceptions.TemplateSyntaxError: unexpected '}'
         `pyproject.toml` written before the failure. Suppressing this would run the whole
         suite against a half-rendered project.
         """
-        assert not _is_temp_clone_cleanup_failure(self.PARTIAL_RENDER_THEN_CLEANUP, self._with_render(tmp_path))
+        assert not _is_retryable_cleanup_race(self.PARTIAL_RENDER_THEN_CLEANUP, self._with_render(tmp_path))
 
     def test_rejects_render_error_that_merely_mentions_the_clone(self, tmp_path: Path) -> None:
         """`copier._vcs.clone` and `rmtree` in stderr prove nothing on their own."""
-        assert not _is_temp_clone_cleanup_failure(self.RENDER_ERROR_ONLY, self._with_render(tmp_path))
+        assert not _is_retryable_cleanup_race(self.RENDER_ERROR_ONLY, self._with_render(tmp_path))
 
     def test_rejects_cleanup_failure_outside_copiers_temp_clone(self, tmp_path: Path) -> None:
         """Same exception, a directory copier did not create — not ours to excuse."""
         stderr = self.CLEANUP_ONLY.replace("copier._vcs.clone.ulvgwzp7", "some-other-dir")
-        assert not _is_temp_clone_cleanup_failure(stderr, self._with_render(tmp_path))
+        assert not _is_retryable_cleanup_race(stderr, self._with_render(tmp_path))
 
     def test_rejects_when_the_failure_was_not_raised_by_cleanup(self, tmp_path: Path) -> None:
         """Bind the OSError to the `_cleanup` frame, not just to the clone path."""
         stderr = self.CLEANUP_ONLY.replace(", in _cleanup", ", in _render_file")
-        assert not _is_temp_clone_cleanup_failure(stderr, self._with_render(tmp_path))
+        assert not _is_retryable_cleanup_race(stderr, self._with_render(tmp_path))
 
     def test_rejects_when_nothing_was_rendered(self, tmp_path: Path) -> None:
         """The load-bearing gate: cleanup noise never excuses an empty destination."""
-        assert not _is_temp_clone_cleanup_failure(self.CLEANUP_ONLY, tmp_path)
+        assert not _is_retryable_cleanup_race(self.CLEANUP_ONLY, tmp_path)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2665,7 +2665,39 @@ class TestTempCloneCleanupTolerance:
     this helper is never consulted at all.
     """
 
-    CLONE_CLEANUP_STDERR = "OSError: [Errno 66] Directory not empty: '/tmp/copier._vcs.clone.ab12cd34/.git'"
+    # Trimmed from a real failure: dirty tree, `copier copy -r HEAD`, copier 9.17.1 on
+    # macOS. Frame paths shortened, structure and the final line kept verbatim.
+    CLEANUP_ONLY = """Traceback (most recent call last):
+  File "/venv/copier/_template.py", line 240, in _cleanup
+    rmtree(temp_clone, ignore_errors=False, onexc=handle_remove_readonly)
+  File "/python/shutil.py", line 753, in _rmtree_safe_fd_step
+    os.rmdir(name, dir_fd=dirfd)
+OSError: [Errno 66] Directory not empty: PosixPath('/tmp/copier._vcs.clone.ulvgwzp7')
+"""
+
+    # A render that died partway, with the cleanup crash chained onto the unwind. Every
+    # loose substring the old matcher looked for is present, and `pyproject.toml` was
+    # written before the failure — so only the chaining marker separates this from benign.
+    PARTIAL_RENDER_THEN_CLEANUP = """Traceback (most recent call last):
+  File "/venv/copier/_main.py", line 850, in _render_file
+    raise UndefinedError(msg)
+jinja2.exceptions.UndefinedError: 'project_name' is undefined
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/venv/copier/_template.py", line 240, in _cleanup
+    rmtree(temp_clone, ignore_errors=False, onexc=handle_remove_readonly)
+OSError: [Errno 66] Directory not empty: PosixPath('/tmp/copier._vcs.clone.ulvgwzp7')
+"""
+
+    # A pure render failure. Mentions the clone directory (every template frame lives
+    # inside it) and the word `rmtree`, but nothing here is a cleanup failure.
+    RENDER_ERROR_ONLY = """Traceback (most recent call last):
+  File "/tmp/copier._vcs.clone.ulvgwzp7/project/scripts/rmtree_helper.py", line 3
+    {{ project_name }
+jinja2.exceptions.TemplateSyntaxError: unexpected '}'
+"""
 
     @staticmethod
     def _with_render(tmp_path: Path) -> Path:
@@ -2673,22 +2705,33 @@ class TestTempCloneCleanupTolerance:
         (tmp_path / "pyproject.toml").write_text('[project]\nname = "rendered"\n')
         return tmp_path
 
-    @pytest.mark.parametrize("marker", ["Directory not empty", "rmtree", "Errno 66"])
-    def test_accepts_each_cleanup_marker(self, tmp_path: Path, marker: str) -> None:
-        """Each accepted signature is tested alone — no case leans on another's marker."""
-        stderr = f"copier._vcs.clone.ab12cd34 cleanup failed: {marker}"
-        assert _is_temp_clone_cleanup_failure(stderr, self._with_render(tmp_path))
+    def test_accepts_a_cleanup_only_failure(self, tmp_path: Path) -> None:
+        """The one shape this exists for: render finished, `_cleanup` could not rmtree."""
+        assert _is_temp_clone_cleanup_failure(self.CLEANUP_ONLY, self._with_render(tmp_path))
 
-    def test_rejects_failure_outside_copiers_temp_clone(self, tmp_path: Path) -> None:
-        """Same OSError, a path copier did not create — could be the template's own tree."""
-        stderr = "OSError: [Errno 66] Directory not empty: '/some/other/path/.git'"
+    def test_rejects_partial_render_with_chained_cleanup_failure(self, tmp_path: Path) -> None:
+        """The dangerous case: a real render error whose unwind also trips the cleanup.
+
+        Every individual token the matcher keys on is present, and the destination holds a
+        `pyproject.toml` written before the failure. Suppressing this would run the whole
+        suite against a half-rendered project.
+        """
+        assert not _is_temp_clone_cleanup_failure(self.PARTIAL_RENDER_THEN_CLEANUP, self._with_render(tmp_path))
+
+    def test_rejects_render_error_that_merely_mentions_the_clone(self, tmp_path: Path) -> None:
+        """`copier._vcs.clone` and `rmtree` in stderr prove nothing on their own."""
+        assert not _is_temp_clone_cleanup_failure(self.RENDER_ERROR_ONLY, self._with_render(tmp_path))
+
+    def test_rejects_cleanup_failure_outside_copiers_temp_clone(self, tmp_path: Path) -> None:
+        """Same exception, a directory copier did not create — not ours to excuse."""
+        stderr = self.CLEANUP_ONLY.replace("copier._vcs.clone.ulvgwzp7", "some-other-dir")
         assert not _is_temp_clone_cleanup_failure(stderr, self._with_render(tmp_path))
 
-    def test_rejects_clone_path_without_a_cleanup_marker(self, tmp_path: Path) -> None:
-        """A real failure *inside* the clone (bad ref, missing commit) must still fail."""
-        stderr = "copier._vcs.clone.ab12cd34: fatal: invalid reference: HEAD"
+    def test_rejects_when_the_failure_was_not_raised_by_cleanup(self, tmp_path: Path) -> None:
+        """Bind the OSError to the `_cleanup` frame, not just to the clone path."""
+        stderr = self.CLEANUP_ONLY.replace(", in _cleanup", ", in _render_file")
         assert not _is_temp_clone_cleanup_failure(stderr, self._with_render(tmp_path))
 
     def test_rejects_when_nothing_was_rendered(self, tmp_path: Path) -> None:
         """The load-bearing gate: cleanup noise never excuses an empty destination."""
-        assert not _is_temp_clone_cleanup_failure(self.CLONE_CLEANUP_STDERR, tmp_path)
+        assert not _is_temp_clone_cleanup_failure(self.CLEANUP_ONLY, tmp_path)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 import yaml
-from conftest import REPO_ROOT, generate_project
+from conftest import REPO_ROOT, _is_temp_clone_cleanup_failure, generate_project
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -2652,3 +2652,43 @@ class TestIntegration:
             f"Underscored repo slug `die_zeit` leaked into CHANGELOG.md — semantic-release "
             f"appears to be using python_package_import_name instead of the repo slug:\n{changelog}"
         )
+
+
+class TestTempCloneCleanupTolerance:
+    """Pin the boundary of `conftest._is_temp_clone_cleanup_failure` (DOT-606).
+
+    That helper is the one place in the suite where a non-zero copier exit is suppressed,
+    and both directions of drift are silent. Widen it and a genuine render failure passes
+    as a green test; narrow it and the dirty-tree failures it exists to absorb come back.
+    Neither shows up in the integration tests, which only ever see whichever exit copier
+    happens to produce on the machine running them — on a clean tree, that is exit 0 and
+    this helper is never consulted at all.
+    """
+
+    CLONE_CLEANUP_STDERR = "OSError: [Errno 66] Directory not empty: '/tmp/copier._vcs.clone.ab12cd34/.git'"
+
+    @staticmethod
+    def _with_render(tmp_path: Path) -> Path:
+        """A destination that received a project: the render-succeeded half of the gate."""
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "rendered"\n')
+        return tmp_path
+
+    @pytest.mark.parametrize("marker", ["Directory not empty", "rmtree", "Errno 66"])
+    def test_accepts_each_cleanup_marker(self, tmp_path: Path, marker: str) -> None:
+        """Each accepted signature is tested alone — no case leans on another's marker."""
+        stderr = f"copier._vcs.clone.ab12cd34 cleanup failed: {marker}"
+        assert _is_temp_clone_cleanup_failure(stderr, self._with_render(tmp_path))
+
+    def test_rejects_failure_outside_copiers_temp_clone(self, tmp_path: Path) -> None:
+        """Same OSError, a path copier did not create — could be the template's own tree."""
+        stderr = "OSError: [Errno 66] Directory not empty: '/some/other/path/.git'"
+        assert not _is_temp_clone_cleanup_failure(stderr, self._with_render(tmp_path))
+
+    def test_rejects_clone_path_without_a_cleanup_marker(self, tmp_path: Path) -> None:
+        """A real failure *inside* the clone (bad ref, missing commit) must still fail."""
+        stderr = "copier._vcs.clone.ab12cd34: fatal: invalid reference: HEAD"
+        assert not _is_temp_clone_cleanup_failure(stderr, self._with_render(tmp_path))
+
+    def test_rejects_when_nothing_was_rendered(self, tmp_path: Path) -> None:
+        """The load-bearing gate: cleanup noise never excuses an empty destination."""
+        assert not _is_temp_clone_cleanup_failure(self.CLONE_CLEANUP_STDERR, tmp_path)


### PR DESCRIPTION
## Summary

`generate_project` in `tests/conftest.py` now tolerates one specific copier exit: a successful render whose temp-clone cleanup crashed.

## Why

`poe test` failed whenever the working tree was dirty and passed when it was clean. One unrelated newline reproduced it. CI never saw it — CI always checks out clean — so the suite was green exactly when nobody needed it and red exactly when somebody was mid-change.

On a dirty tree copier takes its dirty-file overlay path, which does extra git work inside the temp clone it makes of this repo. Something still holds a handle under that clone's `.git` when `_cleanup` calls `rmtree(ignore_errors=False)`, so copier exits non-zero *after* every file has already been written. The render succeeds; only the cleanup fails.

It reads as flakiness and is not. The failure lands on whichever test happens to render first, so the count and identity of "failing" tests vary per run, and re-running one in isolation usually passes — which sends triage toward "just a flake" and then toward "it started when I changed X". Both are wrong.

**Narrow on purpose,** in three ways: stderr must name a path copier itself calls `copier._vcs.clone.*`, it must carry an `rmtree`/`Errno 66` signature, and the destination must actually contain a rendered `pyproject.toml`. A render that genuinely failed writes no `pyproject.toml`, and every other non-zero exit still fails the test with copier's own stderr. A broader "ignore non-zero exits" would be a real liability in a suite whose entire job is asserting on rendered output.

## Test plan

- Fast suite **on a dirty tree**: `202 passed`. The same tree previously gave `2 failed, 13 passed` in `TestTemplateUpdateCheck` alone, with the failures on tests unrelated to the edit.
- Fast suite on a clean tree: unchanged, the tolerance path is never entered.

Closes DOT-606

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The fixture now retries a narrowly classified temporary-clone cleanup failure instead of accepting any nonzero Copier result. Focused tests cover the accepted cleanup traceback and its rejection gates.
- Adds a maximum of three render attempts for the intermittent dirty-tree cleanup race.
- Requires a cleanup-frame traceback, Copier temporary-clone path, no chained exception, and rendered `pyproject.toml` before retrying.
- Adds regression coverage based on representative cleanup and render-error tracebacks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current implementation only returns after a successful Copier exit, and the previously reported coverage and partial-render suppression issues are fixed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/conftest.py | Replaces failure suppression with bounded retry behavior while preserving failure for every unsuccessful final attempt. |
| tests/test_template.py | Adds focused coverage for the retry classifier’s accepted traceback and rejection boundaries. |

<sub>Reviews (6): Last reviewed commit: ["fix(test): retry the cleanup race instea..."](https://github.com/detailobsessed/copier-uv-bleeding/commit/138e14aa0f8f2947837dc8e750385dd3211fae03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50480718)</sub>

<!-- /greptile_comment -->