### PR TITLE
fix(template): repoint sync-with-uv at the upstream project

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -52,8 +52,8 @@ hooks = [
 ]
 
 [[repos]]
-repo = "https://github.com/detailobsessed/sync-with-uv"
-rev = "v0.6.0-prek"
+repo = "https://github.com/tsvikas/sync-with-uv"
+rev = "v0.6.0"
 # Priority 6, not 0: it rewrites prek.toml, which the builtin mutators in groups
 # 1-4 also touch, and it READS uv.lock, which uv-lock rewrites in group 5. Both
 # hazards are ordering, not just concurrent writes.

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -55,7 +55,7 @@ hooks = [
 ]
 
 [[repos]]
-repo = "https://github.com/detailobsessed/sync-with-uv"
+repo = "https://github.com/tsvikas/sync-with-uv"
 rev = ""
 # Priority 6, not 0: it rewrites prek.toml, which the builtin mutators in groups
 # 1-4 also touch, and it READS uv.lock, which uv-lock rewrites in group 5. Both


### PR DESCRIPTION
## Summary

Repoints the `sync-with-uv` prek hook from the `detailobsessed/sync-with-uv` fork to the upstream project at `tsvikas/sync-with-uv`, in both this repo's `prek.toml` and the generated `project/prek.toml.jinja`.

- `prek.toml` — `repo` → `https://github.com/tsvikas/sync-with-uv`, `rev` → `v0.6.0` (was the fork's bespoke `v0.6.0-prek` tag)
- `project/prek.toml.jinja` — same `repo` change; `rev` stays `""` for `prek update` to fill

## Why

The fork has been deleted, so every `prek update` / `prek run` that had to clone it failed with `git fetch` exit 128. That took out `tests/test_template.py::TestIntegration::test_first_commit_succeeds_with_prek_hooks`, the pre-push `pytest-cov` hook, and main's CI. Generated projects were broken the same way — a fresh scaffold could not complete its first commit.

The fork existed because upstream did not yet read `prek.toml`. It does now: `prek.toml` support landed in upstream v0.6.0, so the fork has no remaining purpose. Upstream v0.6.0 is a drop-in match — same hook id (`sync-with-uv`), same hook name, and a `files` pattern that already covers `prek.toml`.

## Test plan

- `pytest tests/test_template.py::TestIntegration::test_first_commit_succeeds_with_prek_hooks` — passes (12.6s); this is the test that was failing on the dead repo
- The pre-push `pytest-cov` hook passed on the push for this branch, which is the gate that blocked the previous `stack merge`
- CI on this PR re-runs the full suite against the new reference

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change repoints the `sync-with-uv` Prek hook to its maintained upstream in the repository configuration and generated-project template. The rendered-project flow successfully installed and updated Prek hooks, and the replacement `sync-with-uv` hook passed. However, a freshly generated project cannot complete its initial commit on the tested Linux environment because the unchanged Lychee hook binary requires unavailable GLIBC versions.

<h3>Confidence Score: 4/5</h3>

Do not merge while generated projects can fail their first commit on supported Linux environments.

The replacement sync-with-uv hook completed successfully in a rendered project's update and commit-hook flow, but the same flow reproduced a blocking Lychee runtime incompatibility.

**Files Needing Attention:** project/prek.toml.jinja needs attention at the Lychee revision pin on line 122; prek.toml and the sync-with-uv template entry completed successfully.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding by running the focused first-commit test and recording the outcome.
- T-Rex produced a proof for another posted P1 finding.
- T-Rex performed general contract validation, capturing the exact runtime record and summarizing the Lychee configuration and PR-diff status.

<a href="https://app.greptile.com/trex/runs/17537372/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `project/prek.toml.jinja`, line 122 ([link](https://github.com/detailobsessed/copier-uv-bleeding/blob/2f64304896aaf3d82795717aa2f39297488ffb32/project/prek.toml.jinja#L122)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Lychee hook cannot load on the supported Linux baseline**

   A freshly rendered project's `prek update` retains `lychee-v0.24.2`, whose Linux executable requires `GLIBC_2.38` and `GLIBC_2.39`. On the tested environment, both initial-commit attempts fail before Lychee can run. Pin a Lychee release compatible with the supported glibc baseline, or run this hook in an environment with GLIBC 2.39 or later.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Focused first-commit test output](https://app.greptile.com/trex/artifacts/46f69ab6-1434-4bc6-ad0e-b099c5748bd0)**

   - Exact captured output from the requested pytest command shows sync-with-uv passed while Lychee 0.24.2 failed to load because GLIBC 2.38 and 2.39 are unavailable, so the initial commit remains blocked.

   **[Lychee configuration and PR diff](https://app.greptile.com/trex/artifacts/ed21576d-58ca-464d-b1dd-bd483540a5db)**

   - Captured numbered template configuration and HEAD diff show the unchanged Lychee 0.24.2 pin and that the PR only repoints sync-with-uv, so the Lychee failure is pre-existing.

   <a href="https://app.greptile.com/trex/runs/17537372/artifacts?artifact=46f69ab6-1434-4bc6-ad0e-b099c5748bd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: project/prek.toml.jinja
   Line: 122

   Comment:
   **Lychee hook cannot load on the supported Linux baseline**

   A freshly rendered project's `prek update` retains `lychee-v0.24.2`, whose Linux executable requires `GLIBC_2.38` and `GLIBC_2.39`. On the tested environment, both initial-commit attempts fail before Lychee can run. Pin a Lychee release compatible with the supported glibc baseline, or run this hook in an environment with GLIBC 2.39 or later.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20project%2Fprek.toml.jinja%0ALine%3A%20122%0A%0AComment%3A%0A**Lychee%20hook%20cannot%20load%20on%20the%20supported%20Linux%20baseline**%0A%0AA%20freshly%20rendered%20project's%20%60prek%20update%60%20retains%20%60lychee-v0.24.2%60%2C%20whose%20Linux%20executable%20requires%20%60GLIBC_2.38%60%20and%20%60GLIBC_2.39%60.%20On%20the%20tested%20environment%2C%20both%20initial-commit%20attempts%20fail%20before%20Lychee%20can%20run.%20Pin%20a%20Lychee%20release%20compatible%20with%20the%20supported%20glibc%20baseline%2C%20or%20run%20this%20hook%20in%20an%20environment%20with%20GLIBC%202.39%20or%20later.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=detailobsessed%2Fcopier-uv-bleeding&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Initial commit fails when the template's Lychee 0.24.2 binary needs newer GLIBC**

   - **Bug**
     - A freshly rendered project's `prek update` leaves Lychee at `lychee-v0.24.2`; its executable then fails at commit time because this Linux runner lacks GLIBC_2.38 and GLIBC_2.39. Both permitted commit attempts fail, despite the updated sync-with-uv hook passing.
   - **Cause**
     - `project/prek.toml.jinja:122` pins the Lychee hook to `lychee-v0.24.2`, whose installed binary is incompatible with the runner's glibc. The `[update.repos]` exclusion at lines 12-13 only rejects `nightly`, not this incompatible stable release.
   - **Fix**
     - Use a Lychee hook release with binaries compatible with the supported Linux glibc baseline, or execute the hook in a GLIBC 2.39+ environment; validate with the same rendered-project first-commit test.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aproject%2Fprek.toml.jinja%3A122%0A**Lychee%20hook%20cannot%20load%20on%20the%20supported%20Linux%20baseline**%0A%0AA%20freshly%20rendered%20project's%20%60prek%20update%60%20retains%20%60lychee-v0.24.2%60%2C%20whose%20Linux%20executable%20requires%20%60GLIBC_2.38%60%20and%20%60GLIBC_2.39%60.%20On%20the%20tested%20environment%2C%20both%20initial-commit%20attempts%20fail%20before%20Lychee%20can%20run.%20Pin%20a%20Lychee%20release%20compatible%20with%20the%20supported%20glibc%20baseline%2C%20or%20run%20this%20hook%20in%20an%20environment%20with%20GLIBC%202.39%20or%20later.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=detailobsessed%2Fcopier-uv-bleeding&pr=349&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
project/prek.toml.jinja:122
**Lychee hook cannot load on the supported Linux baseline**

A freshly rendered project's `prek update` retains `lychee-v0.24.2`, whose Linux executable requires `GLIBC_2.38` and `GLIBC_2.39`. On the tested environment, both initial-commit attempts fail before Lychee can run. Pin a Lychee release compatible with the supported glibc baseline, or run this hook in an environment with GLIBC 2.39 or later.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(template): repoint sync-with-uv at t..."](https://github.com/detailobsessed/copier-uv-bleeding/commit/2f64304896aaf3d82795717aa2f39297488ffb32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50643152)</sub>

<!-- /greptile_comment -->